### PR TITLE
Rewrite README and move config to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# ============================================================================
+# ServerMonitor environment configuration
+#
+# Copy this file to `.env` (or `.env.local`) and fill in values for your own
+# setup. `.env*` files are already gitignored, so real IPs/hostnames never
+# need to be committed to the repo.
+#
+# NEXT_PUBLIC_* variables are inlined into the client bundle at build time
+# (required because the cluster dashboard runs in the browser). Variables
+# without that prefix are only read on the server.
+# ============================================================================
+
+# --- Cluster dashboard (src/app/cluster) -----------------------------------
+# JSON array of servers shown on the /cluster page.
+# "type" must be "intel" or "rpi" (controls which sensors are read/displayed).
+NEXT_PUBLIC_CLUSTER_SERVERS=[{"name":"RuthServer","ip":"192.168.0.100","type":"intel"},{"name":"RuthPiMaster","ip":"192.168.0.200","type":"rpi"},{"name":"RuthPiNode1","ip":"192.168.0.201","type":"rpi"},{"name":"RuthPiNode2","ip":"192.168.0.202","type":"rpi"}]
+
+# Port each cluster node's /api/system endpoint listens on.
+NEXT_PUBLIC_CLUSTER_PORT=3000
+
+# --- API CORS allow-list (src/app/api/system/route.ts) ---------------------
+# Comma-separated list of origins allowed to call /api/system.
+ALLOWED_ORIGINS=http://localhost:3000,http://192.168.0.100:3000,http://192.168.0.200:3000,http://192.168.0.201:3000,http://192.168.0.202:3000,https://ruthcloud.xyz,https://cluster0.ruthcloud.xyz,https://cluster1.ruthcloud.xyz,https://cluster2.ruthcloud.xyz
+
+# --- Site metadata (layout.tsx, robots.ts, sitemap.ts) ---------------------
+NEXT_PUBLIC_SITE_URL=https://ruthcloud.xyz
+NEXT_PUBLIC_SITE_NAME=RuthServer Cloud
+NEXT_PUBLIC_SITE_SHORT_NAME=RuthServer
+NEXT_PUBLIC_SITE_DESCRIPTION=RuthServer for multiple cloud platforms
+NEXT_PUBLIC_AUTHOR_NAME=Ruthgyeul
+
+# --- Kiosk launch script (scripts/run.sh) ----------------------------------
+# Linux user whose Firefox session is killed/relaunched in kiosk mode, and
+# the URL that gets opened.
+KIOSK_USER=ruthgyeul
+KIOSK_URL=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ NEXT_PUBLIC_CLUSTER_SERVERS=[{"name":"RuthServer","ip":"192.168.0.100","type":"i
 # Port each cluster node's /api/system endpoint listens on.
 NEXT_PUBLIC_CLUSTER_PORT=3000
 
+# Scheme used to reach cluster nodes from the browser ("http" or "https").
+# Set to "https" if nodes terminate TLS, to avoid mixed-content blocking when
+# the dashboard itself is served over HTTPS.
+NEXT_PUBLIC_CLUSTER_PROTOCOL=http
+
 # --- API CORS allow-list (src/app/api/system/route.ts) ---------------------
 # Comma-separated list of origins allowed to call /api/system.
 ALLOWED_ORIGINS=http://localhost:3000,http://192.168.0.100:3000,http://192.168.0.200:3000,http://192.168.0.201:3000,http://192.168.0.202:3000,https://ruthcloud.xyz,https://cluster0.ruthcloud.xyz,https://cluster1.ruthcloud.xyz,https://cluster2.ruthcloud.xyz

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,36 +1,115 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ServerMonitor
 
-## Getting Started
+A self-hosted, real-time server monitoring dashboard built with Next.js. It
+reads live system metrics (CPU, memory, disk, network, temperature, fan
+speed, uptime, top processes) from the host it runs on and exposes them
+through a small dashboard UI and a JSON API, with an optional cluster view
+that aggregates several nodes on one screen.
 
-First, run the development server:
+![ServerMonitor screenshot](public/screenshots/home.png)
+
+## Features
+
+- **Live dashboard** (`/`) — CPU/memory/disk usage, network throughput and
+  error rates, temperature, fan speed, uptime, and a top-processes list,
+  polling `/api/system` every second.
+- **Cluster view** (`/cluster`) — a compact grid that polls multiple
+  ServerMonitor instances (e.g. an x86 server plus several Raspberry Pi
+  nodes) and shows their status side by side.
+- **JSON API** (`/api/system`) — returns the current metrics for the host,
+  with a configurable CORS allow-list for cross-node requests.
+- **Kiosk launch script** — boots the dashboard full-screen in Firefox for
+  a dedicated status display.
+
+## Tech stack
+
+- [Next.js](https://nextjs.org) (App Router) + React + TypeScript
+- Tailwind CSS
+- Recharts for network history charts
+- A shell script (`scripts/monitor.sh`) that shells out to standard Linux
+  tools (`top`, `free`, `df`, `sensors`, `ip`, `ps`, …) to collect metrics
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18+
+- A Linux host (metrics collection relies on `/proc`, `sensors`, `ip`, etc.)
+- `lm-sensors` installed and configured if you want temperature/fan readings
+
+### Install
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### Configure environment variables
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+All environment-specific values (cluster node IPs, allowed CORS origins,
+site metadata, kiosk settings) live in a single `.env` file instead of being
+hardcoded, so the app can be reused across servers/domains without editing
+source code.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+cp .env.example .env
+```
 
-## Learn More
+Then edit `.env` to match your own setup. See
+[Environment variables](#environment-variables) below for what each value
+does.
 
-To learn more about Next.js, take a look at the following resources:
+### Run
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+# development
+npm run dev
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+# production
+npm run build
+npm run start
+```
 
-## Deploy on Vercel
+Open [http://localhost:3000](http://localhost:3000) for the single-server
+dashboard, or `/cluster` for the multi-node view.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Environment variables
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+`.env.example` documents every supported variable. `NEXT_PUBLIC_*` values are
+inlined into the client bundle at build time (needed because the cluster
+dashboard fetches other nodes directly from the browser); the rest are only
+read on the server.
+
+| Variable | Used in | Description |
+| --- | --- | --- |
+| `NEXT_PUBLIC_CLUSTER_SERVERS` | `src/config/clusterConfig.ts` | JSON array of `{ "name", "ip", "type" }` objects rendered on `/cluster`. `type` is `"intel"` or `"rpi"` and controls which sensors are read. |
+| `NEXT_PUBLIC_CLUSTER_PORT` | `src/config/clusterConfig.ts` | Port each cluster node's `/api/system` listens on (default `3000`). |
+| `ALLOWED_ORIGINS` | `src/app/api/system/route.ts` | Comma-separated list of origins allowed to call `/api/system` (CORS allow-list). |
+| `NEXT_PUBLIC_SITE_URL` | `src/config/siteConfig.ts` | Canonical site URL used for metadata, Open Graph tags, `robots.txt` and `sitemap.xml`. |
+| `NEXT_PUBLIC_SITE_NAME` | `src/config/siteConfig.ts` | Full site/app name shown in page titles and metadata. |
+| `NEXT_PUBLIC_SITE_SHORT_NAME` | `src/config/siteConfig.ts` | Short name used in the title template and mobile web app title. |
+| `NEXT_PUBLIC_SITE_DESCRIPTION` | `src/config/siteConfig.ts` | Site description used in metadata and social previews. |
+| `NEXT_PUBLIC_AUTHOR_NAME` | `src/config/siteConfig.ts` | Author/creator/publisher metadata. |
+| `KIOSK_USER` | `scripts/run.sh` | Linux user whose Firefox session is killed/relaunched in kiosk mode. |
+| `KIOSK_URL` | `scripts/run.sh` | URL opened in kiosk mode. |
+
+Adding, removing, or repointing a cluster node is now a one-line edit in
+`.env` — no code changes or redeploy of the dashboard logic required.
+
+## Scripts
+
+- `scripts/monitor.sh` — collects system metrics and prints them as JSON;
+  invoked by the API route on the host it runs on.
+- `scripts/run.sh` — launches the dashboard full-screen in Firefox kiosk
+  mode, reading `KIOSK_USER`/`KIOSK_URL` from `.env` if present.
+
+## Deploying a cluster
+
+Each node in `NEXT_PUBLIC_CLUSTER_SERVERS` should run its own instance of
+this app (so its `/api/system` endpoint is reachable at
+`http://<ip>:<NEXT_PUBLIC_CLUSTER_PORT>`), and each node's `ALLOWED_ORIGINS`
+should include the origin of whichever instance is displaying `/cluster`.
+
+## Learn more
+
+- [Next.js Documentation](https://nextjs.org/docs)
+- [Learn Next.js](https://nextjs.org/learn)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ read on the server.
 | --- | --- | --- |
 | `NEXT_PUBLIC_CLUSTER_SERVERS` | `src/config/clusterConfig.ts` | JSON array of `{ "name", "ip", "type" }` objects rendered on `/cluster`. `type` is `"intel"` or `"rpi"` and controls which sensors are read. |
 | `NEXT_PUBLIC_CLUSTER_PORT` | `src/config/clusterConfig.ts` | Port each cluster node's `/api/system` listens on (default `3000`). |
+| `NEXT_PUBLIC_CLUSTER_PROTOCOL` | `src/config/clusterConfig.ts` | Scheme (`http`/`https`) used to reach cluster nodes from the browser (default `http`). |
 | `ALLOWED_ORIGINS` | `src/app/api/system/route.ts` | Comma-separated list of origins allowed to call `/api/system` (CORS allow-list). |
 | `NEXT_PUBLIC_SITE_URL` | `src/config/siteConfig.ts` | Canonical site URL used for metadata, Open Graph tags, `robots.txt` and `sitemap.xml`. |
 | `NEXT_PUBLIC_SITE_NAME` | `src/config/siteConfig.ts` | Full site/app name shown in page titles and metadata. |

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
+# Load KIOSK_USER / KIOSK_URL from .env if present
+ENV_FILE="$(cd "$(dirname "$0")/.." && pwd)/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    source "$ENV_FILE"
+    set +a
+fi
+
+KIOSK_USER="${KIOSK_USER:-$(whoami)}"
+KIOSK_URL="${KIOSK_URL:-http://localhost:3000}"
+
 # DISPLAY Setup
 export DISPLAY=:0
 
-# Kill any existing Firefox processes for the user 'ruthgyeul'
-pkill -u ruthgyeul firefox
+# Kill any existing Firefox processes for the kiosk user
+pkill -u "$KIOSK_USER" firefox
 
 # Activate the firefox kiosk mode
-firefox --kiosk http://localhost:3000
+firefox --kiosk "$KIOSK_URL"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-# Load KIOSK_USER / KIOSK_URL from .env if present
+# Read a single KEY=value out of .env without sourcing (executing) the file,
+# since dotenv values aren't guaranteed to be safe shell syntax.
 ENV_FILE="$(cd "$(dirname "$0")/.." && pwd)/.env"
-if [ -f "$ENV_FILE" ]; then
-    set -a
-    source "$ENV_FILE"
-    set +a
-fi
 
+read_env_value() {
+    local key="$1"
+    [ -f "$ENV_FILE" ] || return 0
+    grep -E "^${key}=" "$ENV_FILE" | tail -n 1 | cut -d '=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]\$//"
+}
+
+KIOSK_USER="${KIOSK_USER:-$(read_env_value KIOSK_USER)}"
 KIOSK_USER="${KIOSK_USER:-$(whoami)}"
+KIOSK_URL="${KIOSK_URL:-$(read_env_value KIOSK_URL)}"
 KIOSK_URL="${KIOSK_URL:-http://localhost:3000}"
 
 # DISPLAY Setup

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -23,18 +23,11 @@ const defaultServerData: ServerData = {
     processes: []
 };
 
-// 허용된 origin 목록
-const allowedOrigins = [
-    'http://localhost:3000',
-    'http://192.168.0.100:3000',
-    'http://192.168.0.200:3000',
-    'http://192.168.0.201:3000',
-    'http://192.168.0.202:3000',
-    'https://ruthcloud.xyz',
-    'https://cluster0.ruthcloud.xyz',
-    'https://cluster1.ruthcloud.xyz',
-    'https://cluster2.ruthcloud.xyz'
-];
+// 허용된 origin 목록 (.env의 ALLOWED_ORIGINS로 설정, 콤마로 구분)
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
 
 function getCorsHeaders(origin: string | undefined) {
     const headers: Record<string, string> = {

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -26,7 +26,7 @@ const defaultServerData: ServerData = {
 // 허용된 origin 목록 (.env의 ALLOWED_ORIGINS로 설정, 콤마로 구분)
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
     .split(',')
-    .map((origin) => origin.trim())
+    .map((origin) => origin.trim().replace(/\/+$/, ''))
     .filter(Boolean);
 
 function getCorsHeaders(origin: string | undefined) {

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -6,7 +6,7 @@ import { Cpu, HardDrive, MemoryStick, Network, Thermometer, Fan, Clock, Activity
 import { Header } from '@/components/common/Header';
 import Loading from '@/app/loading';
 import { NetworkChart } from '@/components/charts/NetworkChart';
-import { getClusterServers, CLUSTER_PORT, ClusterServer } from '@/config/clusterConfig';
+import { getClusterServers, CLUSTER_PORT, CLUSTER_PROTOCOL, ClusterServer } from '@/config/clusterConfig';
 
 type Server = ClusterServer;
 
@@ -144,7 +144,7 @@ const ClusterPage = () => {
 
         for (const server of servers) {
             try {
-                const url = `http://${server.ip}:${CLUSTER_PORT}/api/system`;
+                const url = `${CLUSTER_PROTOCOL}://${server.ip}:${CLUSTER_PORT}/api/system`;
                 const controller = new AbortController();
                 const timeoutId = setTimeout(() => controller.abort(), 5000);
 

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -6,12 +6,9 @@ import { Cpu, HardDrive, MemoryStick, Network, Thermometer, Fan, Clock, Activity
 import { Header } from '@/components/common/Header';
 import Loading from '@/app/loading';
 import { NetworkChart } from '@/components/charts/NetworkChart';
+import { getClusterServers, CLUSTER_PORT, ClusterServer } from '@/config/clusterConfig';
 
-interface Server {
-    name: string;
-    ip: string;
-    type: 'intel' | 'rpi';
-}
+type Server = ClusterServer;
 
 interface Uptime {
     days: number;
@@ -100,13 +97,8 @@ const ClusterPage = () => {
     const [lastUpdate, setLastUpdate] = useState(new Date());
     const [networkHistory, setNetworkHistory] = useState<{ [key: string]: NetworkHistoryEntry[] }>({});
 
-    // 메모이제이션된 서버 목록
-    const servers = useMemo(() => [
-        { name: 'RuthServer', ip: '192.168.0.100', type: 'intel' as const },
-        { name: 'RuthPiMaster', ip: '192.168.0.200', type: 'rpi' as const },
-        { name: 'RuthPiNode1', ip: '192.168.0.201', type: 'rpi' as const },
-        { name: 'RuthPiNode2', ip: '192.168.0.202', type: 'rpi' as const }
-    ], []);
+    // 메모이제이션된 서버 목록 (.env의 NEXT_PUBLIC_CLUSTER_SERVERS로 설정)
+    const servers = useMemo(() => getClusterServers(), []);
 
     // 메모리 관리를 위한 cleanup 함수
     const cleanupNetworkHistory = useCallback(() => {
@@ -152,7 +144,7 @@ const ClusterPage = () => {
 
         for (const server of servers) {
             try {
-                const url = `http://${server.ip}:3000/api/system`;
+                const url = `http://${server.ip}:${CLUSTER_PORT}/api/system`;
                 const controller = new AbortController();
                 const timeoutId = setTimeout(() => controller.abort(), 5000);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 
 import Loading from '@/app/loading';
 import Error from '@/app/error';
+import { SITE_URL, SITE_NAME, SITE_SHORT_NAME, SITE_DESCRIPTION, AUTHOR_NAME } from '@/config/siteConfig';
 import "@/styles/globals.css";
 
 const geistSans = Geist({
@@ -19,18 +20,18 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-    metadataBase: new URL('https://ruthcloud.xyz'),
+    metadataBase: new URL(SITE_URL),
     title: {
-        template: '%s | RuthServer',
-        default: 'RuthServer Cloud'
+        template: `%s | ${SITE_SHORT_NAME}`,
+        default: SITE_NAME
     },
-    description: "RuthServer for multiple cloud platforms",
+    description: SITE_DESCRIPTION,
     manifest: "/manifest.json",
-    applicationName: "RuthServer Cloud",
+    applicationName: SITE_NAME,
     keywords: [],
-    authors: [{ name: "Ruthgyeul" }],
-    creator: "Ruthgyeul",
-    publisher: "Ruthgyeul",
+    authors: [{ name: AUTHOR_NAME }],
+    creator: AUTHOR_NAME,
+    publisher: AUTHOR_NAME,
     formatDetection: {
         telephone: true,
         date: true,
@@ -45,16 +46,16 @@ export const metadata: Metadata = {
         shortcut: ["/favicon.ico"]
     },
     openGraph: {
-        title: "RuthServer Cloud",
-        description: "RuthServer for multiple cloud platforms",
-        url: "https://ruthcloud.xyz",
-        siteName: "RuthServer Cloud",
+        title: SITE_NAME,
+        description: SITE_DESCRIPTION,
+        url: SITE_URL,
+        siteName: SITE_NAME,
         images: [
             {
-                url: "https://ruthcloud.xyz/screenshots/home.png",
+                url: `${SITE_URL}/screenshots/home.png`,
                 width: 1280,
                 height: 720,
-                alt: "RuthServer Home"
+                alt: `${SITE_SHORT_NAME} Home`
             }
         ],
         type: "website",
@@ -62,19 +63,19 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: "summary_large_image",
-        title: "RuthServer Cloud",
-        description: "RuthServer for multiple cloud platforms",
-        images: ["https://ruthcloud.xyz/screenshots/home.png"],
-        creator: "Ruthgyeul",
+        title: SITE_NAME,
+        description: SITE_DESCRIPTION,
+        images: [`${SITE_URL}/screenshots/home.png`],
+        creator: AUTHOR_NAME,
     },
     verification: {
         // Google Search Console 등에 사용되는 확인 코드가 있다면 추가
         // google: "VERIFICATION_CODE",
     },
     alternates: {
-        canonical: 'https://ruthcloud.syz',
+        canonical: SITE_URL,
         languages: {
-            'en-US': 'https://ruthcloud.xyz',
+            'en-US': SITE_URL,
         },
     },
 };
@@ -91,8 +92,8 @@ export default function RootLayout({
         <link rel="manifest" href="/manifest.json"/>
         <meta name="mobile-web-app-capable" content="yes"/>
         <meta name="mobile-web-app-status-bar-style" content="default"/>
-        <meta name="mobile-web-app-title" content="RuthServer"/>
-        <title>RuthServer Cloud</title>
+        <meta name="mobile-web-app-title" content={SITE_SHORT_NAME}/>
+        <title>{SITE_NAME}</title>
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased h-auto bg-gray-900 text-gray-100`}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,3 +1,5 @@
+import { SITE_URL } from '@/config/siteConfig';
+
 export default function robots() {
     return {
         rules: [
@@ -39,7 +41,7 @@ export default function robots() {
                 disallow: ['/'],
             },
         ],
-        sitemap: 'https://ruthcloud.xyz/sitemap.xml',
-        host: 'https://ruthcloud.xyz',
+        sitemap: `${SITE_URL}/sitemap.xml`,
+        host: SITE_URL,
     }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,7 @@
+import { SITE_URL } from '@/config/siteConfig';
+
 export default function sitemap() {
-    const baseUrl = 'https://ruthcloud.xyz';
+    const baseUrl = SITE_URL;
     const currentDate = new Date().toISOString();
 
     const routes = [

--- a/src/config/clusterConfig.ts
+++ b/src/config/clusterConfig.ts
@@ -9,6 +9,10 @@ export interface ClusterServer {
 
 export const CLUSTER_PORT = process.env.NEXT_PUBLIC_CLUSTER_PORT || '3000';
 
+// Configurable so dashboards served over HTTPS can point at nodes that also
+// terminate TLS, avoiding mixed-content blocks on an all-http default.
+export const CLUSTER_PROTOCOL = process.env.NEXT_PUBLIC_CLUSTER_PROTOCOL || 'http';
+
 function isClusterServer(value: unknown): value is ClusterServer {
     if (!value || typeof value !== 'object') return false;
     const server = value as Record<string, unknown>;

--- a/src/config/clusterConfig.ts
+++ b/src/config/clusterConfig.ts
@@ -1,0 +1,34 @@
+// Cluster dashboard server list, sourced from NEXT_PUBLIC_CLUSTER_SERVERS so
+// adding/removing/reassigning nodes never requires touching code.
+
+export interface ClusterServer {
+    name: string;
+    ip: string;
+    type: 'intel' | 'rpi';
+}
+
+export const CLUSTER_PORT = process.env.NEXT_PUBLIC_CLUSTER_PORT || '3000';
+
+function isClusterServer(value: unknown): value is ClusterServer {
+    if (!value || typeof value !== 'object') return false;
+    const server = value as Record<string, unknown>;
+    return (
+        typeof server.name === 'string' &&
+        typeof server.ip === 'string' &&
+        (server.type === 'intel' || server.type === 'rpi')
+    );
+}
+
+export function getClusterServers(): ClusterServer[] {
+    const raw = process.env.NEXT_PUBLIC_CLUSTER_SERVERS;
+    if (!raw) return [];
+
+    try {
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(isClusterServer);
+    } catch (error) {
+        console.error('Invalid NEXT_PUBLIC_CLUSTER_SERVERS value:', error);
+        return [];
+    }
+}

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -2,7 +2,15 @@
 // redeploy only requires editing .env instead of hunting through
 // layout.tsx, robots.ts and sitemap.ts.
 
-export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://ruthcloud.xyz';
+// Ensures a scheme is present and strips any trailing slash, so downstream
+// string concatenation (e.g. `${SITE_URL}/sitemap.xml`) never produces a
+// double slash and `new URL(SITE_URL)` never throws.
+function normalizeSiteUrl(url: string): string {
+    const withScheme = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+    return withScheme.replace(/\/+$/, '');
+}
+
+export const SITE_URL = normalizeSiteUrl(process.env.NEXT_PUBLIC_SITE_URL || 'https://ruthcloud.xyz');
 export const SITE_NAME = process.env.NEXT_PUBLIC_SITE_NAME || 'RuthServer Cloud';
 export const SITE_SHORT_NAME = process.env.NEXT_PUBLIC_SITE_SHORT_NAME || 'RuthServer';
 export const SITE_DESCRIPTION = process.env.NEXT_PUBLIC_SITE_DESCRIPTION || 'RuthServer for multiple cloud platforms';

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -1,0 +1,9 @@
+// Centralized site metadata, sourced from environment variables so a fork/
+// redeploy only requires editing .env instead of hunting through
+// layout.tsx, robots.ts and sitemap.ts.
+
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://ruthcloud.xyz';
+export const SITE_NAME = process.env.NEXT_PUBLIC_SITE_NAME || 'RuthServer Cloud';
+export const SITE_SHORT_NAME = process.env.NEXT_PUBLIC_SITE_SHORT_NAME || 'RuthServer';
+export const SITE_DESCRIPTION = process.env.NEXT_PUBLIC_SITE_DESCRIPTION || 'RuthServer for multiple cloud platforms';
+export const AUTHOR_NAME = process.env.NEXT_PUBLIC_AUTHOR_NAME || 'Ruthgyeul';


### PR DESCRIPTION
## Summary
- Add a proper `README.md` (project overview, features, setup, env var reference, scripts, cluster deployment notes).
- Move scattered IPs/ports/config into environment variables (documented in the new `.env.example`), so adding/repointing nodes or redeploying to a new domain is a `.env` edit instead of a code change:
  - `NEXT_PUBLIC_CLUSTER_SERVERS` / `NEXT_PUBLIC_CLUSTER_PORT` — cluster node list and port (`src/config/clusterConfig.ts`, used by `src/app/cluster/page.tsx`)
  - `ALLOWED_ORIGINS` — CORS allow-list (`src/app/api/system/route.ts`)
  - `NEXT_PUBLIC_SITE_URL` / `NEXT_PUBLIC_SITE_NAME` / `NEXT_PUBLIC_SITE_SHORT_NAME` / `NEXT_PUBLIC_SITE_DESCRIPTION` / `NEXT_PUBLIC_AUTHOR_NAME` — site metadata (`src/config/siteConfig.ts`, used by `layout.tsx`, `robots.ts`, `sitemap.ts`)
  - `KIOSK_USER` / `KIOSK_URL` — kiosk launch script (`scripts/run.sh`), now sourced from `.env` instead of hardcoding a specific Linux user
- `.gitignore` now excludes `.env.example` from the blanket `.env*` ignore rule so the template stays committed.
- No UI/design changes — only how config values are sourced.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint .` — no new errors (pre-existing warnings only)
- [x] `npm run build` succeeds with `.env` populated from `.env.example`
- [x] `npm run start` serves `/api/system` and `/cluster` (200 OK) with env-driven cluster server list


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsMV3iLiPqfeBRVvzsBi3B)_