### PR TITLE
Fix all-zero metrics by isolating collectors and reading /proc directly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ NEXT_PUBLIC_CLUSTER_PROTOCOL=http
 # Comma-separated list of origins allowed to call /api/system.
 ALLOWED_ORIGINS=http://localhost:3000,http://192.168.0.100:3000,http://192.168.0.200:3000,http://192.168.0.201:3000,http://192.168.0.202:3000,https://ruthcloud.xyz,https://cluster0.ruthcloud.xyz,https://cluster1.ruthcloud.xyz,https://cluster2.ruthcloud.xyz
 
+# --- Metrics collection (src/utils/systemMonitor.ts) -----------------------
+# Host pinged for the network latency reading. Defaults to 8.8.8.8.
+# If outbound ICMP is blocked, ping reads 0 — point this at a reachable host
+# (e.g. your gateway) instead.
+PING_HOST=8.8.8.8
+
 # --- Site metadata (layout.tsx, robots.ts, sitemap.ts) ---------------------
 NEXT_PUBLIC_SITE_URL=https://ruthcloud.xyz
 NEXT_PUBLIC_SITE_NAME=RuthServer Cloud

--- a/README.md
+++ b/README.md
@@ -26,16 +26,23 @@ that aggregates several nodes on one screen.
 - [Next.js](https://nextjs.org) (App Router) + React + TypeScript
 - Tailwind CSS
 - Recharts for network history charts
-- A shell script (`scripts/monitor.sh`) that shells out to standard Linux
-  tools (`top`, `free`, `df`, `sensors`, `ip`, `ps`, …) to collect metrics
+- `src/utils/systemMonitor.ts`, which reads metrics straight from `/proc` and
+  `/sys` and shells out only for `df`, `ps` and `ping`
 
 ## Getting started
 
 ### Prerequisites
 
 - Node.js 18+
-- A Linux host (metrics collection relies on `/proc`, `sensors`, `ip`, etc.)
-- `lm-sensors` installed and configured if you want temperature/fan readings
+- A Linux host (metrics come from `/proc/stat`, `/proc/meminfo`,
+  `/proc/net/route`, `/sys/class/net`, `/sys/class/thermal`, …)
+- `lm-sensors` is optional. Install it for per-chip temperatures and fan RPM;
+  without it those fall back to `/sys/class/thermal` and `/sys/class/hwmon`,
+  and anything still unavailable reads `N/A` rather than zeroing the dashboard
+
+If a metric looks wrong on a real host, `./scripts/diagnose.sh` prints what
+each of those sources actually returns, and `curl localhost:3000/api/system`
+includes a `warnings` array naming any collector that failed.
 
 ### Install
 
@@ -90,6 +97,7 @@ read on the server.
 | `NEXT_PUBLIC_SITE_SHORT_NAME` | `src/config/siteConfig.ts` | Short name used in the title template and mobile web app title. |
 | `NEXT_PUBLIC_SITE_DESCRIPTION` | `src/config/siteConfig.ts` | Site description used in metadata and social previews. |
 | `NEXT_PUBLIC_AUTHOR_NAME` | `src/config/siteConfig.ts` | Author/creator/publisher metadata. |
+| `PING_HOST` | `src/utils/systemMonitor.ts` | Host pinged for the latency reading. Defaults to `8.8.8.8`; set it to a reachable host if outbound ICMP is blocked, otherwise ping shows `0`. |
 | `KIOSK_USER` | `scripts/run.sh` | Linux user whose Firefox session is killed/relaunched in kiosk mode. |
 | `KIOSK_URL` | `scripts/run.sh` | URL opened in kiosk mode. |
 
@@ -98,10 +106,12 @@ Adding, removing, or repointing a cluster node is now a one-line edit in
 
 ## Scripts
 
-- `scripts/monitor.sh` — collects system metrics and prints them as JSON;
-  invoked by the API route on the host it runs on.
+- `scripts/diagnose.sh` — prints the raw contents of every source the API
+  reads, so you can see which metric is unavailable on a given host.
 - `scripts/run.sh` — launches the dashboard full-screen in Firefox kiosk
   mode, reading `KIOSK_USER`/`KIOSK_URL` from `.env` if present.
+- `scripts/monitor.sh` — standalone JSON dump of the same metrics. Not used by
+  the API route; kept for shelling out from other tooling.
 
 ## Deploying a cluster
 

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# 실제 서버에서 각 지표의 원본 소스가 읽히는지 하나씩 확인한다.
+# 앱과 동일한 조건으로 보려면 Next.js 를 띄우는 그 사용자로 실행할 것.
+#   ./scripts/diagnose.sh
+
+ok()   { printf '  \033[32mOK\033[0m   %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+
+echo "== 실행 환경 =="
+echo "  user : $(whoami)"
+echo "  arch : $(uname -m)"
+echo "  PATH : $PATH"
+echo
+
+echo "== CPU (/proc/stat) =="
+if grep -q '^cpu ' /proc/stat 2>/dev/null; then
+    ok "$(grep '^cpu ' /proc/stat)"
+else
+    fail "/proc/stat 를 읽을 수 없음"
+fi
+echo "  cores: $(nproc 2>/dev/null || echo '?')"
+echo
+
+echo "== 메모리 (/proc/meminfo) =="
+if grep -E '^(MemTotal|MemAvailable):' /proc/meminfo 2>/dev/null | sed 's/^/  /'; then
+    :
+else
+    fail "/proc/meminfo 를 읽을 수 없음"
+fi
+echo
+
+echo "== 디스크 (df -Pk /) =="
+df -Pk / 2>/dev/null | sed 's/^/  /' || fail "df 실패"
+echo
+
+echo "== 네트워크 기본 인터페이스 (/proc/net/route) =="
+IFACE=$(awk '$2 == "00000000" { print $1; exit }' /proc/net/route 2>/dev/null)
+if [ -n "$IFACE" ]; then
+    ok "default route -> $IFACE"
+    for stat in rx_bytes tx_bytes rx_packets tx_packets rx_errors tx_errors; do
+        value=$(cat "/sys/class/net/$IFACE/statistics/$stat" 2>/dev/null)
+        [ -n "$value" ] && echo "  $stat = $value" || fail "$stat 읽기 실패"
+    done
+else
+    fail "기본 경로 없음 — /sys/class/net 후보: $(ls /sys/class/net 2>/dev/null | tr '\n' ' ')"
+fi
+echo
+
+echo "== Ping (${PING_HOST:-8.8.8.8}) =="
+ping -c 1 -W 1 "${PING_HOST:-8.8.8.8}" 2>&1 | grep -E 'time[=<]' | sed 's/^/  /' || fail "응답 없음 (ping 0ms 로 표시됨)"
+echo
+
+echo "== 온도 / 팬 =="
+if command -v sensors >/dev/null 2>&1; then
+    ok "lm-sensors 설치됨"
+    sensors 2>/dev/null | sed 's/^/  /'
+else
+    fail "sensors 없음 — sysfs 로 대체 (sudo apt install lm-sensors 로 설치 가능)"
+fi
+echo "  -- /sys/class/thermal --"
+for zone in /sys/class/thermal/thermal_zone*; do
+    [ -r "$zone/temp" ] || continue
+    echo "  $(basename "$zone") ($(cat "$zone/type" 2>/dev/null)) = $(cat "$zone/temp" 2>/dev/null)"
+done
+echo "  -- /sys/class/hwmon fan --"
+find /sys/class/hwmon -name 'fan?_input' 2>/dev/null | while read -r f; do
+    echo "  $f = $(cat "$f" 2>/dev/null)"
+done
+echo
+
+echo "== 프로세스 (ps) =="
+ps -eo pid,pcpu,pmem,stat,args --sort=-pcpu 2>/dev/null | head -n 4 | sed 's/^/  /' || fail "ps --sort 미지원"
+echo
+
+echo "== Uptime =="
+echo "  $(cat /proc/uptime 2>/dev/null || echo '읽기 실패')"

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -1,27 +1,10 @@
 import { NextResponse } from 'next/server';
 import { getSystemInfo } from '@/utils/systemMonitor';
-import { ServerData } from '@/types/system';
 import { isValidServerData } from '@/utils/validation';
 
-// 기본 서버 데이터
-const defaultServerData: ServerData = {
-    cpu: { usage: 0, cores: 0, temperature: 0 },
-    memory: { used: 0, total: 0, percentage: 0 },
-    disk: { used: 0, total: 0, percentage: 0 },
-    network: {
-        download: 0,
-        upload: 0,
-        ping: 0,
-        errorRates: {
-            rx: '0',
-            tx: '0'
-        }
-    },
-    uptime: { days: 0, hours: 0, minutes: 0 },
-    temperature: { cpu: 0, gpu: 0, motherboard: 0 },
-    fan: { cpu: 0, case1: 0, case2: 0 },
-    processes: []
-};
+// 수집기별 실패는 systemMonitor 안에서 각자 fallback 으로 처리되므로,
+// 여기까지 올라온 에러는 진짜 고장이다. 0으로 채운 정상 응답을 돌려주면
+// 대시보드에 "모든 값이 0" 으로만 보이고 원인이 감춰지므로 5xx 로 알린다.
 
 // 허용된 origin 목록 (.env의 ALLOWED_ORIGINS로 설정, 콤마로 구분)
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
@@ -50,7 +33,8 @@ export async function GET(request: Request) {
         // 데이터 유효성 검사
         if (!data || !isValidServerData(data)) {
             console.error('Invalid server data received');
-            return new NextResponse(JSON.stringify(defaultServerData), {
+            return new NextResponse(JSON.stringify({ error: 'Invalid server data received' }), {
+                status: 500,
                 headers: getCorsHeaders(origin)
             });
         }
@@ -59,8 +43,10 @@ export async function GET(request: Request) {
             headers: getCorsHeaders(origin)
         });
     } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
         console.error('Error fetching system data:', error);
-        return new NextResponse(JSON.stringify(defaultServerData), {
+        return new NextResponse(JSON.stringify({ error: `Failed to collect system data: ${message}` }), {
+            status: 500,
             headers: getCorsHeaders(origin)
         });
     }

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -72,6 +72,9 @@ export interface ServerData {
         case2: number;
     };
     processes: Process[];
+    // 일부 수집기만 실패했을 때 어떤 지표가 왜 비었는지 알려준다.
+    // 헤드리스 서버에서 `curl localhost:3000/api/system` 만으로 진단할 수 있게 하는 용도.
+    warnings?: string[];
 }
 
 export interface NetworkHistoryEntry {

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -1,23 +1,51 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import path from 'path';
-import { readFile } from 'fs/promises';
+import os from 'os';
+import { readFile, readdir } from 'fs/promises';
 
-import { isValidServerData } from '@/utils/validation';
-import { ServerData, Process, X86TemperatureInfo, ARMTemperatureInfo, TemperatureValue, TemperatureInfo, isX86TemperatureInfo, isARMTemperatureInfo } from '@/types/system';
+import { ServerData, Process, X86TemperatureInfo, ARMTemperatureInfo, TemperatureInfo, TemperatureValue } from '@/types/system';
 
-const execAsync = promisify(exec);
+const execFile = promisify(exec);
 
 // 캐시된 시스템 정보
 let cachedData: ServerData | null = null;
 let lastUpdateTime = 0;
 const UPDATE_INTERVAL = 1000; // 1초마다 업데이트
-let isUpdating = false; // 업데이트 중복 방지
-let cachedArchitecture: 'x86' | 'arm' | 'unknown' | null = null; // 아키텍처 캐시
 
-// 네트워크 통계 저장
-let prevRxBytes = 0;
-let prevTxBytes = 0;
+// `ip`, `sensors`, `ps` 등은 /usr/sbin, /sbin 에 설치되는 경우가 많은데
+// 비-root 사용자로 뜬 systemd/pm2 서비스의 PATH 에는 그 경로가 빠져 있다.
+// 그래서 명령이 "not found" 로 끝나고, 지표가 통째로 0 이 된다.
+const EXEC_ENV = {
+  ...process.env,
+  PATH: [process.env.PATH, '/usr/local/sbin', '/usr/sbin', '/sbin'].filter(Boolean).join(':'),
+  LC_ALL: 'C', // 로케일에 따라 소수점이 ','가 되면 parseFloat가 잘라먹는다
+  LANG: 'C'
+};
+
+async function run(command: string): Promise<string> {
+  const { stdout } = await execFile(command, { env: EXEC_ENV, timeout: 5000 });
+  return stdout.trim();
+}
+
+async function readSys(filePath: string): Promise<string | null> {
+  try {
+    return (await readFile(filePath, 'utf-8')).trim();
+  } catch {
+    return null;
+  }
+}
+
+// 수집기 하나가 실패해도 나머지 지표는 살려 보낸다.
+async function collect<T>(name: string, fn: () => Promise<T>, fallback: T, warnings: string[]): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`${name}: ${message}`);
+    console.warn(`[systemMonitor] ${name} failed:`, message);
+    return fallback;
+  }
+}
 
 interface CpuInfo {
   usage: number;
@@ -59,342 +87,432 @@ interface UptimeInfo {
   minutes: number;
 }
 
-// 아키텍처 감지 함수
-async function getArchitecture(): Promise<'x86' | 'arm' | 'unknown'> {
-    if (cachedArchitecture !== null) {
-        return cachedArchitecture;
-    }
-    
-    const { stdout } = await execAsync('uname -m');
-    const arch = stdout.trim();
-    
-    if (arch === 'x86_64' || arch === 'i686') {
-        cachedArchitecture = 'x86';
-    } else if (arch === 'aarch64' || arch === 'armv7l') {
-        cachedArchitecture = 'arm';
-    } else {
-        cachedArchitecture = 'unknown';
-    }
-    
-    return cachedArchitecture;
+function getArchitecture(): 'x86' | 'arm' | 'unknown' {
+  const arch = os.arch();
+  if (arch === 'x64' || arch === 'ia32') return 'x86';
+  if (arch === 'arm64' || arch === 'arm') return 'arm';
+  return 'unknown';
 }
 
-async function getCpuInfo(): Promise<CpuInfo> {
-    const { stdout } = await execAsync('top -bn1 | grep "Cpu(s)" | awk \'{print $2}\'');
-    const { stdout: cores } = await execAsync('nproc');
-    const arch = await getArchitecture();
-    
-    let temp: number | 'N/A' = 'N/A';
-    try {
-        if (arch === 'x86') {
-            const { stdout: x86Temp } = await execAsync('sensors | grep "Package id 0" | awk \'{print $4}\' | sed \'s/+//\' | sed \'s/°C//\'');
-            if (x86Temp.trim()) {
-                temp = parseFloat(x86Temp.trim());
-            }
-        } else {
-            const { stdout: armTemp } = await execAsync('sensors | grep "cpu_thermal" | grep "temp1" | awk \'{print $2}\' | sed \'s/+//\' | sed \'s/°C//\'');
-            if (armTemp.trim()) {
-                temp = parseFloat(armTemp.trim());
-            }
-        }
-    } catch (error) {
-        console.warn('Failed to get CPU temperature:', error);
-    }
-    
-    return {
-        usage: parseFloat(stdout.trim()),
-        cores: parseInt(cores.trim()),
-        temperature: temp
-    };
+// --- CPU ---------------------------------------------------------------
+
+// `top -bn1` 의 첫 샘플은 부팅 이후 누적 평균이라 항상 0에 가깝게 나온다.
+// /proc/stat 를 두 번 읽어 그 사이의 변화량으로 계산한다.
+let prevCpuStat: { idle: number; total: number } | null = null;
+
+async function readCpuStat(): Promise<{ idle: number; total: number }> {
+  const contents = await readFile('/proc/stat', 'utf-8');
+  const line = contents.split('\n').find(l => l.startsWith('cpu '));
+  if (!line) throw new Error('no "cpu" line in /proc/stat');
+
+  const values = line.trim().split(/\s+/).slice(1).map(Number);
+  if (values.length < 4 || values.some(Number.isNaN)) {
+    throw new Error(`unparsable /proc/stat cpu line: ${line}`);
+  }
+
+  const idle = values[3] + (values[4] ?? 0); // idle + iowait
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return { idle, total };
 }
+
+async function getCpuUsage(): Promise<number> {
+  let previous = prevCpuStat;
+
+  // 첫 호출이면 짧게 두 번 재서 0% 를 반환하지 않도록 한다.
+  if (!previous) {
+    previous = await readCpuStat();
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+
+  const current = await readCpuStat();
+  prevCpuStat = current;
+
+  const totalDelta = current.total - previous.total;
+  const idleDelta = current.idle - previous.idle;
+  if (totalDelta <= 0) return 0;
+
+  const usage = (1 - idleDelta / totalDelta) * 100;
+  return parseFloat(Math.min(100, Math.max(0, usage)).toFixed(1));
+}
+
+async function getCpuInfo(warnings: string[]): Promise<CpuInfo> {
+  const [usage, temperature] = await Promise.all([
+    collect('cpu.usage', getCpuUsage, 0, warnings),
+    collect<number | 'N/A'>('cpu.temperature', getCpuTemperature, 'N/A', warnings)
+  ]);
+
+  return { usage, cores: os.cpus().length, temperature };
+}
+
+// --- Memory ------------------------------------------------------------
 
 async function getMemoryInfo(): Promise<MemoryInfo> {
-  const { stdout } = await execAsync('free -m | grep Mem');
-  const [, total, used] = stdout.trim().split(/\s+/);
-  const percentage = (parseInt(used) / parseInt(total)) * 100;
-  
+  const contents = await readFile('/proc/meminfo', 'utf-8');
+  const field = (key: string) => {
+    const match = contents.match(new RegExp(`^${key}:\\s+(\\d+) kB`, 'm'));
+    return match ? parseInt(match[1], 10) : null;
+  };
+
+  const totalKb = field('MemTotal');
+  if (!totalKb) throw new Error('MemTotal missing from /proc/meminfo');
+
+  // MemAvailable 이 커널에 없으면(3.14 미만) free + buffers + cached 로 근사한다.
+  const availableKb =
+    field('MemAvailable') ?? (field('MemFree') ?? 0) + (field('Buffers') ?? 0) + (field('Cached') ?? 0);
+
+  const usedKb = Math.max(0, totalKb - availableKb);
   return {
-    used: parseInt(used),
-    total: parseInt(total),
-    percentage: parseFloat(percentage.toFixed(1))
+    used: Math.round(usedKb / 1024),
+    total: Math.round(totalKb / 1024),
+    percentage: parseFloat(((usedKb / totalKb) * 100).toFixed(1))
   };
 }
 
+// --- Disk --------------------------------------------------------------
+
 async function getDiskInfo(): Promise<DiskInfo> {
-  const { stdout } = await execAsync('df -h / | tail -n 1');
-  const [, total, used, , percentage] = stdout.trim().split(/\s+/);
-  
+  // -P 는 긴 장치명 때문에 줄이 두 줄로 접히는 것을 막고,
+  // -k 는 1K 블록으로 고정해 "20G"/"1.5T"/"800M" 단위 파싱을 없앤다.
+  const stdout = await run('df -Pk /');
+  const line = stdout.split('\n').pop() ?? '';
+  const [, totalKb, usedKb, , percentage] = line.trim().split(/\s+/);
+
+  const total = parseInt(totalKb, 10);
+  const used = parseInt(usedKb, 10);
+  if (Number.isNaN(total) || Number.isNaN(used)) {
+    throw new Error(`unparsable df output: ${line}`);
+  }
+
+  const toGb = (kb: number) => parseFloat((kb / 1024 / 1024).toFixed(2));
   return {
-    used: parseFloat(used.replace('G', '')),
-    total: parseFloat(total.replace('G', '')),
-    percentage: parseInt(percentage.replace('%', ''))
+    used: toGb(used),
+    total: toGb(total),
+    percentage: parseInt(percentage.replace('%', ''), 10) || parseFloat(((used / total) * 100).toFixed(1))
   };
 }
+
+// --- Network -----------------------------------------------------------
 
 // Linux network interface names are restricted to this charset (see netdevice(7)).
 // Validating against it before touching sysfs paths keeps a value derived from
-// command output from ever being treated as shell syntax.
+// command output from ever being treated as a path traversal.
 const INTERFACE_NAME_PATTERN = /^[a-zA-Z0-9@.:_-]+$/;
 
-async function readInterfaceStat(interfaceName: string, stat: string): Promise<string> {
-  const contents = await readFile(`/sys/class/net/${interfaceName}/statistics/${stat}`, 'utf-8');
-  return contents.trim();
+let prevNetSample: { rx: number; tx: number; at: number } | null = null;
+
+async function readInterfaceStat(interfaceName: string, stat: string): Promise<number> {
+  const contents = await readSys(`/sys/class/net/${interfaceName}/statistics/${stat}`);
+  const value = contents === null ? NaN : parseInt(contents, 10);
+  return Number.isNaN(value) ? 0 : value;
 }
 
-async function getNetworkInfo(): Promise<NetworkInfo> {
-  const { stdout: netInterface } = await execAsync('ip route | grep default | awk \'{print $5}\'');
-  const interfaceName = netInterface.trim();
+// `ip route` 는 /usr/sbin 에 있어 서비스 PATH 에서 빠지기 쉽다.
+// /proc/net/route 를 직접 읽으면 외부 바이너리가 전혀 필요 없다.
+async function getDefaultInterface(): Promise<string> {
+  const contents = await readFile('/proc/net/route', 'utf-8');
+  const lines = contents.split('\n').slice(1);
 
-  if (!INTERFACE_NAME_PATTERN.test(interfaceName)) {
-    throw new Error(`Unexpected network interface name: ${interfaceName}`);
+  for (const line of lines) {
+    const [iface, destination] = line.trim().split(/\s+/);
+    if (destination === '00000000' && iface && INTERFACE_NAME_PATTERN.test(iface)) {
+      return iface;
+    }
   }
 
-  const [rx_bytes, tx_bytes, rx_errors, tx_errors] = await Promise.all([
+  // 기본 경로가 없으면(컨테이너 등) 트래픽이 가장 많은 물리 인터페이스로 대체한다.
+  const candidates = (await readdir('/sys/class/net')).filter(
+    name => name !== 'lo' && INTERFACE_NAME_PATTERN.test(name)
+  );
+  let best = '';
+  let bestBytes = -1;
+  for (const name of candidates) {
+    const bytes = await readInterfaceStat(name, 'rx_bytes');
+    if (bytes > bestBytes) {
+      best = name;
+      bestBytes = bytes;
+    }
+  }
+
+  if (!best) throw new Error('no usable network interface found');
+  return best;
+}
+
+async function getPing(): Promise<number> {
+  const host = process.env.PING_HOST || '8.8.8.8';
+  if (!/^[a-zA-Z0-9.:-]+$/.test(host)) {
+    throw new Error(`invalid PING_HOST: ${host}`);
+  }
+
+  // -W 1: 응답이 없을 때 기본 10초를 기다리며 요청 전체를 붙잡는 것을 막는다.
+  const stdout = await run(`ping -c 1 -W 1 ${host} || true`);
+  const match = stdout.match(/time[=<]\s*([\d.]+)\s*ms/);
+  return match ? parseFloat(match[1]) : 0;
+}
+
+async function getNetworkInfo(warnings: string[]): Promise<NetworkInfo> {
+  const interfaceName = await getDefaultInterface();
+
+  const [rxBytes, txBytes, rxErrors, txErrors, rxPackets, txPackets] = await Promise.all([
     readInterfaceStat(interfaceName, 'rx_bytes'),
     readInterfaceStat(interfaceName, 'tx_bytes'),
     readInterfaceStat(interfaceName, 'rx_errors'),
-    readInterfaceStat(interfaceName, 'tx_errors')
+    readInterfaceStat(interfaceName, 'tx_errors'),
+    readInterfaceStat(interfaceName, 'rx_packets'),
+    readInterfaceStat(interfaceName, 'tx_packets')
   ]);
-  const { stdout: ping } = await execAsync('ping -c 1 8.8.8.8 | grep "time=" | awk \'{print $7}\' | sed \'s/time=//\'');
 
-  const currentRxBytes = parseInt(rx_bytes.trim());
-  const currentTxBytes = parseInt(tx_bytes.trim());
-  
-  // 속도 계산 (KB/s)
-  const download = prevRxBytes ? (currentRxBytes - prevRxBytes) / 1024 : 0;
-  const upload = prevTxBytes ? (currentTxBytes - prevTxBytes) / 1024 : 0;
-  
-  // 현재 값을 이전 값으로 저장
-  prevRxBytes = currentRxBytes;
-  prevTxBytes = currentTxBytes;
-  
-  // 에러율 계산 (퍼센트)
-  const rxErrorRate = ((parseInt(rx_errors.trim()) / currentRxBytes) * 100).toFixed(2);
-  const txErrorRate = ((parseInt(tx_errors.trim()) / currentTxBytes) * 100).toFixed(2);
-  
+  const now = Date.now();
+  const previous = prevNetSample;
+  prevNetSample = { rx: rxBytes, tx: txBytes, at: now };
+
+  // 이전 샘플과의 실제 경과 시간으로 나눈다. 폴링 간격이 정확히 1초라고
+  // 가정하면 요청이 밀릴 때마다 속도가 부풀려진다.
+  let download = 0;
+  let upload = 0;
+  if (previous) {
+    const elapsedSeconds = (now - previous.at) / 1000;
+    if (elapsedSeconds > 0) {
+      // 카운터가 리셋(재부팅/인터페이스 교체)되면 음수가 나오므로 0으로 막는다.
+      download = Math.max(0, (rxBytes - previous.rx) / 1024 / elapsedSeconds);
+      upload = Math.max(0, (txBytes - previous.tx) / 1024 / elapsedSeconds);
+    }
+  }
+
+  // 에러율은 바이트가 아니라 패킷 대비로 계산해야 의미가 있다.
+  const rate = (errors: number, packets: number) => (packets > 0 ? ((errors / packets) * 100).toFixed(2) : '0.00');
+
+  const ping = await collect('network.ping', getPing, 0, warnings);
+
   return {
     download: parseFloat(download.toFixed(2)),
     upload: parseFloat(upload.toFixed(2)),
-    ping: parseFloat(ping.trim()),
+    ping,
     errorRates: {
-      rx: rxErrorRate,
-      tx: txErrorRate
+      rx: rate(rxErrors, rxPackets),
+      tx: rate(txErrors, txPackets)
     }
   };
+}
+
+// --- Temperature / Fan -------------------------------------------------
+
+async function readSensors(): Promise<string> {
+  return run('sensors');
+}
+
+// lm-sensors 가 없는 서버(대부분의 VPS/컨테이너)를 위한 sysfs 대체 경로.
+async function readThermalZone(): Promise<number | 'N/A'> {
+  let entries: string[];
+  try {
+    entries = await readdir('/sys/class/thermal');
+  } catch {
+    return 'N/A';
+  }
+
+  const zones = entries.filter(name => /^thermal_zone\d+$/.test(name));
+  const preferred = ['x86_pkg_temp', 'cpu_thermal', 'coretemp', 'cpu-thermal', 'soc_thermal'];
+
+  let fallback: number | 'N/A' = 'N/A';
+  for (const zone of zones) {
+    const raw = await readSys(`/sys/class/thermal/${zone}/temp`);
+    if (raw === null) continue;
+    const milliCelsius = parseInt(raw, 10);
+    if (Number.isNaN(milliCelsius)) continue;
+
+    const celsius = parseFloat((milliCelsius / 1000).toFixed(1));
+    const type = (await readSys(`/sys/class/thermal/${zone}/type`)) ?? '';
+    if (preferred.includes(type)) return celsius;
+    if (fallback === 'N/A') fallback = celsius;
+  }
+
+  return fallback;
+}
+
+async function getCpuTemperature(): Promise<number | 'N/A'> {
+  const arch = getArchitecture();
+
+  try {
+    const sensors = await readSensors();
+    const match =
+      arch === 'x86'
+        ? sensors.match(/Package id 0:\s+\+?([\d.]+)°C/)
+        : sensors.match(/cpu_thermal[\s\S]*?temp1:\s*\+?([\d.]+)°C/);
+    if (match) return parseFloat(match[1]);
+  } catch {
+    // sensors 미설치. 아래 sysfs 경로로 넘어간다.
+  }
+
+  return readThermalZone();
 }
 
 async function getTemperature(): Promise<TemperatureInfo> {
-    const arch = await getArchitecture();
-    
-    try {
-        const { stdout } = await execAsync('sensors');
-        
-        if (arch === 'x86') {
-            const cpuMatch = stdout.match(/Package id 0:\s+\+(\d+\.\d+)°C/);
-            const gpuMatch = stdout.match(/edge:\s+\+(\d+\.\d+)°C/);
-            const mbMatch = stdout.match(/temp1:\s+\+(\d+\.\d+)°C/);
-            
-            const x86Temp: X86TemperatureInfo = {
-                cpu: cpuMatch ? parseFloat(cpuMatch[1]) : 'N/A',
-                gpu: gpuMatch ? parseFloat(gpuMatch[1]) : 'N/A',
-                motherboard: mbMatch ? parseFloat(mbMatch[1]) : 'N/A'
-            };
-            return x86Temp;
-        } else {
-            // ARM 아키텍처 (Raspberry Pi 등)
-            const cpuMatch = stdout.match(/cpu_thermal-virtual-0[\s\S]*?temp1:\s*\+?([\d.]+)°C/);
-            const rp1Match = stdout.match(/rp1_adc-isa-0000[\s\S]*?temp1:\s*\+?([\d.]+)°C/);
-            const ssdMatch = stdout.match(/nvme-pci-0100[\s\S]*?Composite:\s*\+?([\d.]+)°C/);
-            
-            const armTemp: ARMTemperatureInfo = {
-                cpu: cpuMatch ? parseFloat(cpuMatch[1]) : 'N/A',
-                rp1: rp1Match ? parseFloat(rp1Match[1]) : 'N/A',
-                ssd: ssdMatch ? parseFloat(ssdMatch[1]) : 'N/A'
-            };
-            return armTemp;
-        }
-    } catch (error) {
-        console.warn('Failed to get temperature information:', error);
-        
-        // 에러 발생 시 기본값 반환
-        if (arch === 'x86') {
-            const x86Temp: X86TemperatureInfo = {
-                cpu: 'N/A' as TemperatureValue,
-                gpu: 'N/A' as TemperatureValue,
-                motherboard: 'N/A' as TemperatureValue
-            };
-            return x86Temp;
-        } else {
-            const armTemp: ARMTemperatureInfo = {
-                cpu: 'N/A' as TemperatureValue,
-                rp1: 'N/A' as TemperatureValue,
-                ssd: 'N/A' as TemperatureValue
-            };
-            return armTemp;
-        }
+  const arch = getArchitecture();
+  let sensors = '';
+  try {
+    sensors = await readSensors();
+  } catch {
+    sensors = '';
+  }
+
+  const pick = (pattern: RegExp): TemperatureValue => {
+    const match = sensors.match(pattern);
+    return match ? parseFloat(match[1]) : 'N/A';
+  };
+
+  const cpu = await getCpuTemperature();
+
+  if (arch === 'x86') {
+    const x86: X86TemperatureInfo = {
+      cpu,
+      gpu: pick(/edge:\s+\+?([\d.]+)°C/),
+      motherboard: pick(/(?:SYSTIN|temp1):\s+\+?([\d.]+)°C/)
+    };
+    return x86;
+  }
+
+  const arm: ARMTemperatureInfo = {
+    cpu,
+    rp1: pick(/rp1_adc-isa-0000[\s\S]*?temp1:\s*\+?([\d.]+)°C/),
+    ssd: pick(/nvme-pci-\w+[\s\S]*?Composite:\s*\+?([\d.]+)°C/)
+  };
+  return arm;
+}
+
+// lm-sensors 가 없으면 hwmon 의 fan*_input 을 직접 읽는다.
+async function readHwmonFans(): Promise<number[]> {
+  let hwmons: string[];
+  try {
+    hwmons = await readdir('/sys/class/hwmon');
+  } catch {
+    return [];
+  }
+
+  const speeds: number[] = [];
+  for (const hwmon of hwmons) {
+    for (const index of [1, 2, 3]) {
+      const raw = await readSys(`/sys/class/hwmon/${hwmon}/fan${index}_input`);
+      if (raw === null) continue;
+      const rpm = parseInt(raw, 10);
+      if (!Number.isNaN(rpm)) speeds.push(rpm);
     }
+  }
+  return speeds;
 }
 
 async function getFanSpeed(): Promise<FanInfo> {
-  const { stdout } = await execAsync('sensors');
-  const cpuFan = stdout.match(/fan1:\s+(\d+)/)?.[1] || '0';
-  const caseFan1 = stdout.match(/fan2:\s+(\d+)/)?.[1] || '0';
-  const caseFan2 = stdout.match(/fan3:\s+(\d+)/)?.[1] || '0';
-  
-  return {
-    cpu: parseInt(cpuFan),
-    case1: parseInt(caseFan1),
-    case2: parseInt(caseFan2)
-  };
+  try {
+    const sensors = await readSensors();
+    const read = (pattern: RegExp) => parseInt(sensors.match(pattern)?.[1] ?? '0', 10) || 0;
+    const fans = {
+      cpu: read(/fan1:\s+(\d+)/),
+      case1: read(/fan2:\s+(\d+)/),
+      case2: read(/fan3:\s+(\d+)/)
+    };
+    if (fans.cpu || fans.case1 || fans.case2) return fans;
+  } catch {
+    // sensors 미설치. hwmon 으로 넘어간다.
+  }
+
+  const [cpu = 0, case1 = 0, case2 = 0] = await readHwmonFans();
+  return { cpu, case1, case2 };
 }
 
+// --- Processes / Uptime ------------------------------------------------
+
 async function getProcesses(): Promise<Process[]> {
-  const { stdout } = await execAsync('ps aux --sort=-%cpu | head -n 21 | tail -n 20');
-  const processes = stdout.split('\n')
-    .filter(line => line.trim())
+  // 파이프라인의 종료 코드는 head 의 것이라 ps 가 실패해도 0 이 된다.
+  // 빈 출력을 그대로 넘기면 원인 없이 목록만 비므로 여기서 에러로 올린다.
+  const stdout = await run('ps -eo pid,pcpu,pmem,stat,args --sort=-pcpu | head -n 21');
+  const lines = stdout.split('\n').slice(1); // 헤더 제거
+  if (lines.length === 0) {
+    throw new Error('ps returned no rows (does this ps support --sort?)');
+  }
+
+  const processes = lines
     .map((line, index) => {
-      // Skip header line
-      if (line.includes('USER') || line.includes('PID')) {
-        return null;
-      }
-
       const parts = line.trim().split(/\s+/);
-      if (parts.length < 11) {
-        console.warn(`Invalid process line format: ${line}`);
-        return null;
-      }
+      if (parts.length < 5) return null;
 
-      try {
-        // ps aux output fields:
-        // USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND
-        const [user, pid, cpu, mem, , , , , , , ...commandParts] = parts;
-        const command = commandParts.join(' ');
+      const [, cpu, mem, stat, ...commandParts] = parts;
+      const cpuUsage = parseFloat(cpu);
+      const memUsage = parseFloat(mem);
+      if (Number.isNaN(cpuUsage) || Number.isNaN(memUsage)) return null;
 
-        return {
-          id: index + 1,
-          name: command,
-          cpu: parseFloat(cpu),
-          memory: parseFloat(mem),
-          status: 'running' as 'running' | 'sleeping'
-        };
-      } catch (error) {
-        console.error(`Error parsing process line: ${line}`, error);
-        return null;
-      }
+      return {
+        id: index + 1,
+        name: commandParts.join(' '),
+        cpu: cpuUsage,
+        memory: memUsage,
+        status: stat.startsWith('R') ? 'running' : 'sleeping'
+      } as Process;
     })
-    .filter((proc): proc is NonNullable<typeof proc> => proc !== null);
+    .filter((process): process is Process => process !== null);
+
+  if (processes.length === 0) {
+    throw new Error(`ps output could not be parsed: ${lines[0]}`);
+  }
   return processes;
 }
 
 async function getUptime(): Promise<UptimeInfo> {
-  const { stdout } = await execAsync('uptime -p');
-  const days = stdout.match(/(\d+) day/)?.[1] || '0';
-  const hours = stdout.match(/(\d+) hour/)?.[1] || '0';
-  const minutes = stdout.match(/(\d+) minute/)?.[1] || '0';
-  
+  // `uptime -p` 는 busybox 에 없고 출력이 로케일을 탄다. os.uptime() 이 안전하다.
+  const seconds = os.uptime();
   return {
-    days: parseInt(days),
-    hours: parseInt(hours),
-    minutes: parseInt(minutes)
+    days: Math.floor(seconds / 86400),
+    hours: Math.floor((seconds % 86400) / 3600),
+    minutes: Math.floor((seconds % 3600) / 60)
   };
 }
 
-// 시스템 정보 업데이트 함수
-export async function updateSystemInfo() {
-    if (isUpdating) return cachedData;
-    
-    try {
-        isUpdating = true;
-        const scriptPath = path.join(process.cwd(), 'monitor.sh');
-        
-        // 스크립트 실행 권한 확인 및 설정
-        try {
-            await execAsync(`chmod +x ${scriptPath}`);
-        } catch (error) {
-            console.error('Error setting script permissions:', error);
-        }
-        
-        const { stdout } = await execAsync(scriptPath);
-        const parsedData = JSON.parse(stdout);
-        
-        // 데이터 유효성 검사
-        if (!isValidServerData(parsedData)) {
-            throw new Error('Invalid server data format');
-        }
-        
-        cachedData = parsedData;
-        lastUpdateTime = Date.now();
-        return cachedData;
-    } catch (error) {
-        console.error('Error updating system data:', error);
-        return null;
-    } finally {
-        isUpdating = false;
-    }
+// --- Public API --------------------------------------------------------
+
+function emptyTemperature(): TemperatureInfo {
+  return getArchitecture() === 'x86'
+    ? { cpu: 'N/A', gpu: 'N/A', motherboard: 'N/A' }
+    : { cpu: 'N/A', rp1: 'N/A', ssd: 'N/A' };
 }
 
-// 시스템 정보 가져오기
 export async function getSystemInfo(): Promise<ServerData> {
-    const now = Date.now();
-    
-    if (cachedData && now - lastUpdateTime < UPDATE_INTERVAL) {
-        return cachedData;
-    }
-    
-    try {
-        const [cpu, memory, disk, network, temperature, fan, processes, uptime] = await Promise.all([
-            getCpuInfo(),
-            getMemoryInfo(),
-            getDiskInfo(),
-            getNetworkInfo(),
-            getTemperature(),
-            getFanSpeed(),
-            getProcesses(),
-            getUptime()
-        ]);
-        
-        const data: ServerData = {
-            cpu,
-            memory,
-            disk,
-            network,
-            temperature,
-            fan,
-            processes,
-            uptime
-        };
-        
-        cachedData = data;
-        lastUpdateTime = now;
-        
-        return data;
-    } catch (error) {
-        console.error('Error updating system data:', error);
-        if (cachedData) {
-            return cachedData;
-        }
-        throw error;
-    }
-}
+  const now = Date.now();
 
-// 기본 서버 데이터
-function getDefaultServerData(): ServerData {
-    return {
-        cpu: { usage: 0, cores: 0, temperature: 'N/A' },
-        memory: { used: 0, total: 0, percentage: 0 },
-        disk: { used: 0, total: 0, percentage: 0 },
-        network: { 
-            download: 0, 
-            upload: 0, 
-            ping: 0,
-            errorRates: {
-                rx: '0',
-                tx: '0'
-            }
-        },
-        uptime: { days: 0, hours: 0, minutes: 0 },
-        temperature: { cpu: 'N/A', gpu: 'N/A', motherboard: 'N/A' },
-        fan: { cpu: 0, case1: 0, case2: 0 },
-        processes: []
-    };
-} 
+  if (cachedData && now - lastUpdateTime < UPDATE_INTERVAL) {
+    return cachedData;
+  }
+
+  const warnings: string[] = [];
+
+  // Promise.all 이 아니라 개별 fallback 으로 감싼다. 예전에는 수집기 하나만
+  // 실패해도 전체 응답이 0으로 떨어졌다.
+  const [cpu, memory, disk, network, temperature, fan, processes, uptime] = await Promise.all([
+    getCpuInfo(warnings),
+    collect('memory', getMemoryInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+    collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+    collect(
+      'network',
+      () => getNetworkInfo(warnings),
+      { download: 0, upload: 0, ping: 0, errorRates: { rx: '0.00', tx: '0.00' } },
+      warnings
+    ),
+    collect('temperature', getTemperature, emptyTemperature(), warnings),
+    collect('fan', getFanSpeed, { cpu: 0, case1: 0, case2: 0 }, warnings),
+    collect<Process[]>('processes', getProcesses, [], warnings),
+    collect('uptime', getUptime, { days: 0, hours: 0, minutes: 0 }, warnings)
+  ]);
+
+  const data: ServerData = {
+    cpu,
+    memory,
+    disk,
+    network,
+    temperature,
+    fan,
+    processes,
+    uptime,
+    ...(warnings.length > 0 ? { warnings } : {})
+  };
+
+  cachedData = data;
+  lastUpdateTime = now;
+
+  return data;
+}


### PR DESCRIPTION
## Problem

On a real server every metric on the dashboard rendered as `0`.

The cause was structural rather than any single bad parse. `getSystemInfo()` ran all eight collectors in one `Promise.all`, so a single rejection discarded the entire batch — and [route.ts](src/app/api/system/route.ts) caught that and returned an all-zero payload with **HTTP 200**. The failure was completely invisible: no error banner, no bad status code, just plausible-looking zeros.

Two collectors reject easily on a real host, both confirmed by reproducing the exact `child_process` behaviour:

- **`getFanSpeed()`** ran bare `sensors` with no `try`/`catch`. A host without `lm-sensors` exits 127 → rejects → every metric zeroed.
- **`getNetworkInfo()`** ran `ip route`, but `ip` lives in `/usr/sbin`, which is absent from the `PATH` of a service running as a non-root user (systemd/pm2). A pipeline's exit code comes from the trailing `awk`, so this surfaced *only* as empty stdout, tripping the interface-name validation and throwing.

## Approach

Metrics now come from `/proc` and `/sys` instead of parsing command output.

This is not a different data source — `top`, `free`, `uptime`, and `ip route` all read the same kernel data. What they add is a human-readable text layer, and that layer is precisely what carried the `PATH`, locale, and formatting dependencies that broke here.

Commands are kept only where they earn it:
- **`sensors`** — the one command with real added value: it attaches chip labels (`Package id 0`, `edge`, `fan1`) to otherwise anonymous hwmon values. Kept as the primary source with a `/sys/class/thermal` + `/sys/class/hwmon` fallback.
- **`df`, `ps`, `ping`** — retained, but now run with `/usr/sbin`:`/sbin` appended to `PATH` and `LC_ALL=C` pinned.

Each collector has its own fallback, so one failure no longer zeroes the rest, and the failing collector is named in a new optional `warnings` field. Errors that still reach the route now return **500** instead of a convincing zero payload.

## Also fixed

Several metrics were wrong even when nothing rejected:

- **CPU** used `top -bn1`, whose first sample is the average *since boot* — structurally incapable of showing live usage. Now a delta over two `/proc/stat` reads, which lines up naturally with the 1s poll interval.
- **Network rates** assumed a poll interval of exactly 1s, inflating throughput whenever requests backed up. Now divided by actual elapsed time, and clamped so a counter reset (reboot, interface swap) cannot report a negative rate.
- **Error rates** divided errors by *bytes* rather than packets, and yielded `NaN` on an idle interface.
- **`df -h`** mis-parsed `T`/`M` units and silently mis-parsed hosts whose long device names wrap the output onto two lines. Now `df -Pk`.
- **Locale** — a decimal comma (`0,0`) made `parseFloat` truncate to `0`.
- **`ping`** had no timeout, holding a request up to 10s where outbound ICMP is blocked. Now `-W 1`, host configurable via `PING_HOST`.

Also removes `updateSystemInfo()`, which was dead code pointing at a `monitor.sh` path that does not exist (`process.cwd()/monitor.sh`; the script lives in `scripts/`), and corrects the README, which described that script as the collector.

## Verifying

`npx tsc --noEmit`, `npx eslint src/`, and `npm run build` all pass. The remaining lint warnings are pre-existing in files this PR does not touch.

Resilience was verified by running the built server on macOS — a worst case with no `/proc` at all. Previously this would have produced an all-zero 200. Now the metrics that *can* resolve still do (disk, core count, uptime), and only the genuinely unavailable ones fall back, each named:

```json
"warnings": [
  "cpu.usage: ENOENT: no such file or directory, open '/proc/stat'",
  "memory: ENOENT: no such file or directory, open '/proc/meminfo'",
  "network: ENOENT: no such file or directory, open '/proc/net/route'",
  "processes: ps returned no rows (does this ps support --sort?)"
]
```

On a Linux host, `warnings` should be absent entirely.

## Notes for the reviewer

- **`/cluster` is unaffected by the new 500.** It already gates on `response.ok`, so a failing node degrades as offline rather than reporting fake zeros.
- **`scripts/diagnose.sh`** is new: it dumps what every source actually returns on a given host. Run it as the same user that runs Next.js, since the `PATH` difference is what caused this bug.
- **`package-lock.json` is deliberately excluded.** It was already modified before this work began (an unrelated transitive dependency refresh, ~1060 lines) and remains uncommitted in the working tree.
- The commit uses `72477746+Ruthgyeul@users.noreply.github.com`, already present in this repo's history, because GitHub's email privacy setting rejected a push authored with the gmail address. No git config was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)