### PR TITLE
Rebuild dashboard from design, expand metrics, add responsive layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,5 +43,9 @@ NEXT_PUBLIC_AUTHOR_NAME=Ruthgyeul
 # --- Kiosk launch script (scripts/run.sh) ----------------------------------
 # Linux user whose Firefox session is killed/relaunched in kiosk mode, and
 # the URL that gets opened.
+#
+# The dashboard picks the fixed 1024x600 layout automatically on a 7-inch
+# panel. Append `?kiosk=1` here only if the browser reports a viewport that
+# makes it fall back to the responsive layout (`?kiosk=0` forces the opposite).
 KIOSK_USER=ruthgyeul
 KIOSK_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@ that aggregates several nodes on one screen.
 
 ## Features
 
-- **Live dashboard** (`/`) — CPU/memory/disk usage, network throughput and
-  error rates, temperature, fan speed, uptime, and a top-processes list,
-  polling `/api/system` every second.
+- **Live dashboard** (`/`) — polls `/api/system` every second and renders in
+  one of two layouts (see [Layouts](#layouts)):
+  - CPU/GPU/RAM/disk gauges, per-core bars, and a 24-hour hourly load heatmap
+  - load average with a 12-hour history grid, swap, and disk I/O throughput
+  - network throughput chart, interfaces, link utilisation, ping, error
+    rates, established connections and listening ports
+  - temperature against its alert threshold, fan RPM, uptime and last reboot
+  - alert log, top processes, SSH sessions, top traffic peers, firewall state
+  - keeps the last known values on screen when a poll fails, and says so in
+    the header instead of blanking the display
 - **Cluster view** (`/cluster`) — a compact grid that polls multiple
   ServerMonitor instances (e.g. an x86 server plus several Raspberry Pi
   nodes) and shows their status side by side.
@@ -21,13 +28,34 @@ that aggregates several nodes on one screen.
 - **Kiosk launch script** — boots the dashboard full-screen in Firefox for
   a dedicated status display.
 
+## Layouts
+
+The dashboard ships two layouts and picks one from the viewport on load and
+on every resize/orientation change:
+
+| Layout | When | Behaviour |
+| --- | --- | --- |
+| **Kiosk** | the 1024x600 canvas fits at ≥ 0.8 scale — i.e. ≥ 819x480 CSS px | the fixed three-column design, scaled as a whole and letterboxed. The 7-inch panel (1024x600) renders it at scale 1.0, exactly as designed. |
+| **Responsive** | anything smaller — phones, portrait tablets, narrow windows | the same panels reflowed into a scrolling 1/2/3-column grid with larger type, horizontal per-core bars, and the host name added to the header. |
+
+The threshold is deliberately well below the kiosk panel's own scale, so a
+7-inch display never falls into the responsive layout. If a kiosk browser
+still reports an odd viewport, `?kiosk=1` forces the fixed layout and
+`?kiosk=0` forces the responsive one:
+
+```bash
+KIOSK_URL=http://localhost:3000/?kiosk=1
+```
+
 ## Tech stack
 
 - [Next.js](https://nextjs.org) (App Router) + React + TypeScript
 - Tailwind CSS
-- Recharts for network history charts
-- `src/utils/systemMonitor.ts`, which reads metrics straight from `/proc` and
-  `/sys` and shells out only for `df`, `ps` and `ping`
+- Hand-rolled SVG charts on the main dashboard (viewBox-based, so the same
+  component serves both layouts); Recharts on the cluster view
+- `src/utils/systemMonitor.ts` and `src/utils/collectors/*`, which read
+  metrics straight from `/proc` and `/sys` and shell out only for `df`, `ps`,
+  `ping`, `who`, `last`, `systemctl` and `journalctl`
 
 ## Getting started
 
@@ -39,6 +67,19 @@ that aggregates several nodes on one screen.
 - `lm-sensors` is optional. Install it for per-chip temperatures and fan RPM;
   without it those fall back to `/sys/class/thermal` and `/sys/class/hwmon`,
   and anything still unavailable reads `N/A` rather than zeroing the dashboard
+
+Every panel degrades to `N/A` (never to a fake zero) when its source is
+missing. A few need more than `/proc` to show real numbers:
+
+| Panel | Needs |
+| --- | --- |
+| GPU usage/temperature | an AMD card (`gpu_busy_percent` in sysfs) or `nvidia-smi`. Intel iGPUs have no percentage to read, so they stay `N/A`. |
+| Top traffic IPs (in bytes) | `nf_conntrack` with `net.netfilter.nf_conntrack_acct=1`. Without it the panel ranks peers by open connections instead. |
+| Firewall blocked attempts | read access to the kernel journal (usually membership in `systemd-journal` or `adm`). |
+| Last reboot reason | readable `/var/log/wtmp` and a `last` binary; reports whether the previous shutdown was clean. |
+
+The 12-hour load grid and 24-hour CPU heatmap are kept in memory by the
+running process, so they start empty after a restart and fill in over time.
 
 If a metric looks wrong on a real host, `./scripts/diagnose.sh` prints what
 each of those sources actually returns, and `curl localhost:3000/api/system`

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Suspense } from "react";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { ErrorBoundary } from "react-error-boundary";
 import { Geist, Geist_Mono } from "next/font/google";
 
@@ -18,6 +18,14 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+// 모바일에서 CSS 픽셀이 기기 폭을 따라가야 반응형 레이아웃이 의도대로 접힌다.
+// 키오스크 배치는 자체 배율로 맞추므로 확대/축소는 막지 않는다.
+export const viewport: Viewport = {
+    width: "device-width",
+    initialScale: 1,
+    themeColor: "#111827"
+};
 
 export const metadata: Metadata = {
     metadataBase: new URL(SITE_URL),
@@ -88,7 +96,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="theme-color" content="#111827"/>
+        {/* theme-color 는 위의 viewport export 가 넣어준다. */}
         <link rel="manifest" href="/manifest.json"/>
         <meta name="mobile-web-app-capable" content="yes"/>
         <meta name="mobile-web-app-status-bar-style" content="default"/>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,76 +1,17 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
-import { Header } from '@/components/common/Header';
-import { SystemStats } from '@/components/stats/SystemStats';
-import { ResourceUsage } from '@/components/stats/ResourceUsage';
-import { ProcessList } from '@/components/stats/ProcessList';
-import { fetchSystemData } from '@/services/systemService';
-import { ServerData, NetworkHistoryEntry } from '@/types/system';
+import { KioskDashboard, KIOSK_HEIGHT, KIOSK_WIDTH } from '@/components/dashboard/KioskDashboard';
+import { ResponsiveDashboard } from '@/components/dashboard/ResponsiveDashboard';
+import { useNow } from '@/hooks/useNow';
+import { useSystemData } from '@/hooks/useSystemData';
+import { useViewMode } from '@/hooks/useViewMode';
 
 export default function DisplayPage() {
-  const [systemData, setSystemData] = useState<ServerData | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [networkHistory, setNetworkHistory] = useState<NetworkHistoryEntry[]>([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch('/api/system');
-        if (!response.ok) {
-          throw new Error('Failed to fetch system data');
-        }
-        const data = await response.json();
-        
-        // 데이터 유효성 검사
-        if (!data || typeof data !== 'object') {
-          throw new Error('Invalid data format received');
-        }
-
-        // 필수 필드 확인
-        const requiredFields = ['cpu', 'memory', 'disk', 'network', 'uptime', 'temperature', 'fan', 'processes'];
-        const missingFields = requiredFields.filter(field => !data[field]);
-        
-        if (missingFields.length > 0) {
-          throw new Error(`Missing required fields: ${missingFields.join(', ')}`);
-        }
-
-        setSystemData(data);
-        setError(null);
-
-        // 네트워크 히스토리 업데이트
-        const now = new Date();
-        const time = now.toLocaleTimeString('ko-KR', { 
-          hour: '2-digit', 
-          minute: '2-digit', 
-          second: '2-digit',
-          hour12: false 
-        });
-        
-        setNetworkHistory(prev => {
-          const newHistory = [
-            ...prev,
-            {
-              time,
-              download: data.network.download,
-              upload: data.network.upload
-            }
-          ];
-          // 최대 60개의 데이터 포인트만 유지
-          return newHistory.slice(-60);
-        });
-      } catch (err) {
-        console.error('Error fetching system data:', err);
-        setError(err instanceof Error ? err.message : 'Unknown error occurred');
-        setSystemData(null);
-      }
-    };
-
-    fetchData();
-    const interval = setInterval(fetchData, 1000);
-    return () => clearInterval(interval);
-  }, []);
+  const { data, error, connected, lastUpdate, networkHistory, diskIoHistory } = useSystemData();
+  const now = useNow();
+  const { mode, scale } = useViewMode(KIOSK_WIDTH, KIOSK_HEIGHT);
 
   useEffect(() => {
     // 화면 잠김 방지
@@ -86,51 +27,56 @@ export default function DisplayPage() {
     wakeLock();
   }, []);
 
-  if (error) {
+  // 뷰포트를 재기 전에는 어느 배치가 맞는지 알 수 없다. 한 프레임 잘못 그리고
+  // 튀는 것보다, 배경만 깔고 기다리는 편이 낫다.
+  if (mode === null || data === null) {
     return (
-      <div className="min-h-screen bg-gray-900 text-gray-100">
-        <Header error={error} />
-        <div className="p-4">
-          <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 text-red-400">
-            {error}
-          </div>
-        </div>
+      <div className="flex h-screen w-screen items-center justify-center bg-gray-900 text-gray-100">
+        <StartupState error={error} />
       </div>
     );
   }
 
-  if (!systemData) {
+  if (mode === 'responsive') {
     return (
-      <div className="min-h-screen bg-gray-900 text-gray-100">
-        <Header error={null} />
-        <div className="p-4">
-          <div className="animate-pulse space-y-4">
-            <div className="h-8 bg-gray-800 rounded w-1/4"></div>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              {[...Array(8)].map((_, i) => (
-                <div key={i} className="h-32 bg-gray-800 rounded"></div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
+      <ResponsiveDashboard
+        data={data}
+        connected={connected}
+        lastUpdate={lastUpdate}
+        now={now}
+        networkHistory={networkHistory}
+        diskIoHistory={diskIoHistory}
+      />
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100">
-      <Header error={error} />
-      <div className="p-2 sm:p-4">
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-2 sm:gap-4">
-          <div className="lg:col-span-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-4">
-            <SystemStats serverData={systemData} />
-            <ResourceUsage serverData={systemData} networkHistory={networkHistory} />
-          </div>
-          <div className="h-[300px] sm:h-[calc(100vh-7rem)]">
-            <ProcessList processes={systemData.processes} />
-          </div>
-        </div>
-      </div>
-    </div>
+    <KioskDashboard
+      data={data}
+      connected={connected}
+      lastUpdate={lastUpdate}
+      now={now}
+      networkHistory={networkHistory}
+      diskIoHistory={diskIoHistory}
+      scale={scale}
+    />
   );
 }
+
+// 첫 응답을 받기 전에만 보인다. 한 번이라도 받은 뒤에는 연결이 끊겨도
+// 마지막 값을 계속 띄우고, 헤더의 표시등으로 상태를 알린다.
+const StartupState: React.FC<{ error: string | null }> = ({ error }) => (
+  <div className="flex flex-col items-center justify-center gap-3 p-8">
+    {error ? (
+      <>
+        <div className="text-sm font-bold text-red-400">Cannot reach /api/system</div>
+        <div className="max-w-[600px] text-center text-xs text-gray-400">{error}</div>
+      </>
+    ) : (
+      <>
+        <div className="h-2 w-2 animate-[pulseDot_1s_ease-in-out_infinite] rounded-full bg-blue-400" />
+        <div className="text-xs text-gray-400">Connecting to /api/system…</div>
+      </>
+    )}
+  </div>
+);

--- a/src/components/charts/NetworkAreaChart.tsx
+++ b/src/components/charts/NetworkAreaChart.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+import { NetworkHistoryEntry } from '@/types/system';
+import { rateUnit } from '@/utils/format';
+
+// 시안의 차트를 그대로 옮긴 SVG. 고정 캔버스(1024x600) 안에서는 recharts 의
+// 반응형 측정이 필요 없고, viewBox 만으로 정확히 같은 비율이 나온다.
+const WIDTH = 700;
+const HEIGHT = 260;
+const PAD_LEFT = 50;
+const PAD_RIGHT = 10;
+const PAD_TOP = 8;
+const PAD_BOTTOM = 16;
+const TICK_COUNT = 4;
+
+// 축 최댓값을 1/2/5 배수로 올려 눈금 숫자가 지저분해지지 않게 한다.
+function niceMax(value: number): number {
+  if (value <= 0) return 4;
+  const raw = value / TICK_COUNT;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(raw)));
+  const normalized = raw / magnitude;
+  const nice = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return nice * magnitude * TICK_COUNT;
+}
+
+interface NetworkAreaChartProps {
+  data: NetworkHistoryEntry[];
+}
+
+export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
+  if (data.length < 2) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-[10px] text-gray-500">
+        Collecting network data…
+      </div>
+    );
+  }
+
+  const innerWidth = WIDTH - PAD_LEFT - PAD_RIGHT;
+  const innerHeight = HEIGHT - PAD_TOP - PAD_BOTTOM;
+
+  const peak = Math.max(0.001, ...data.flatMap(entry => [entry.download, entry.upload]));
+  const { unit, divisor } = rateUnit(peak);
+  const max = niceMax(peak / divisor);
+
+  const x = (index: number) => PAD_LEFT + (index / (data.length - 1)) * innerWidth;
+  const y = (value: number) =>
+    PAD_TOP + innerHeight - (Math.max(0, Math.min(max, value / divisor)) / max) * innerHeight;
+
+  const line = (key: 'download' | 'upload') =>
+    data.map((entry, index) => `${index === 0 ? 'M' : 'L'}${x(index).toFixed(1)},${y(entry[key]).toFixed(1)}`).join(' ');
+
+  const area = (key: 'download' | 'upload') =>
+    `${line(key)} L${x(data.length - 1).toFixed(1)},${PAD_TOP + innerHeight} L${x(0).toFixed(1)},${PAD_TOP + innerHeight} Z`;
+
+  const ticks = Array.from({ length: TICK_COUNT + 1 }, (_, index) => (max / TICK_COUNT) * index);
+
+  return (
+    <svg width="100%" height="100%" viewBox={`0 0 ${WIDTH} ${HEIGHT}`} preserveAspectRatio="xMidYMid meet">
+      <defs>
+        <linearGradient id="downloadArea" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.35} />
+          <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+        </linearGradient>
+        <linearGradient id="uploadArea" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#10b981" stopOpacity={0.35} />
+          <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+
+      <line x1={PAD_LEFT} y1={PAD_TOP} x2={PAD_LEFT} y2={PAD_TOP + innerHeight} stroke="#374151" strokeWidth={1} />
+      <line
+        x1={PAD_LEFT}
+        y1={PAD_TOP + innerHeight}
+        x2={PAD_LEFT + innerWidth}
+        y2={PAD_TOP + innerHeight}
+        stroke="#374151"
+        strokeWidth={1}
+      />
+
+      {ticks.map(tick => (
+        <g key={tick}>
+          <line x1={PAD_LEFT - 4} y1={y(tick * divisor)} x2={PAD_LEFT} y2={y(tick * divisor)} stroke="#4b5563" strokeWidth={1} />
+          <text x={PAD_LEFT - 8} y={y(tick * divisor) + 3} fontSize={9} fill="#9ca3af" textAnchor="end">
+            {`${tick.toFixed(tick < 2 ? 1 : 0)} ${unit}`}
+          </text>
+        </g>
+      ))}
+
+      <path d={area('download')} fill="url(#downloadArea)" stroke="none" />
+      <path d={area('upload')} fill="url(#uploadArea)" stroke="none" />
+      <path d={line('download')} fill="none" stroke="#3b82f6" strokeWidth={2} />
+      <path d={line('upload')} fill="none" stroke="#10b981" strokeWidth={2} />
+
+      <text x={PAD_LEFT + innerWidth} y={PAD_TOP + innerHeight + 14} fontSize={9} fill="#6b7280" textAnchor="end">
+        now
+      </text>
+    </svg>
+  );
+};

--- a/src/components/dashboard/AlertBanner.tsx
+++ b/src/components/dashboard/AlertBanner.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { TriangleAlert } from 'lucide-react';
+
+import { DashboardData } from '@/utils/dashboardData';
+
+// 배너에 띄울 만한 "지금 당장 문제" 만 고른다. 지나간 사건은 우측 ALERTS LOG 가 맡는다.
+export function currentAlerts(data: DashboardData): string[] {
+  const alerts: string[] = [];
+
+  if (data.cpu.usage > 85) alerts.push(`CPU ${data.cpu.usage.toFixed(1)}%`);
+  if (data.memory.percentage > 90) alerts.push(`RAM ${data.memory.percentage.toFixed(1)}%`);
+  if (data.disk.percentage > 90) alerts.push(`Disk ${data.disk.percentage.toFixed(1)}%`);
+  if (data.cpu.temperature !== 'N/A' && data.cpu.temperature > 74) {
+    alerts.push(`Temp ${data.cpu.temperature.toFixed(1)}°C`);
+  }
+  if (data.swap.total > 0 && data.swap.percentage > 80) alerts.push('Swap high');
+  if (data.security.firewall.status === 'inactive') alerts.push('Firewall inactive');
+
+  return alerts;
+}
+
+interface AlertBannerProps {
+  alerts: string[];
+}
+
+export const AlertBanner: React.FC<AlertBannerProps> = ({ alerts }) => {
+  const hasAlert = alerts.length > 0;
+  const color = hasAlert ? '#f87171' : '#4ade80';
+
+  return (
+    <div
+      className={`flex h-[22px] shrink-0 items-center gap-1.5 border-b border-gray-700 px-3 ${
+        hasAlert ? 'animate-[alertBlink_1.2s_ease-in-out_infinite]' : ''
+      }`}
+      style={{ background: hasAlert ? 'rgba(239,68,68,0.12)' : 'rgba(16,185,129,0.08)' }}
+    >
+      <TriangleAlert size={12} color={color} strokeWidth={2} className="shrink-0" />
+      <span className="truncate text-[11px]" style={{ color }}>
+        {hasAlert ? `Warning: ${alerts.join(' · ')}` : 'All systems normal'}
+      </span>
+    </div>
+  );
+};

--- a/src/components/dashboard/CenterColumn.tsx
+++ b/src/components/dashboard/CenterColumn.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { Activity, Cpu, HardDrive, MemoryStick, Monitor, Network, TrendingUp } from 'lucide-react';
+
+import { NetworkAreaChart } from '@/components/charts/NetworkAreaChart';
+import { Bar, EmptyRow, Gauge, Panel, PanelTitle } from '@/components/dashboard/primitives';
+import { NetworkHistoryEntry } from '@/types/system';
+import { DashboardData } from '@/utils/dashboardData';
+import { formatLinkSpeed } from '@/utils/format';
+import { COLORS, statusColor } from '@/utils/statusColors';
+
+interface CenterColumnProps {
+  data: DashboardData;
+  networkHistory: NetworkHistoryEntry[];
+}
+
+export const CenterColumn: React.FC<CenterColumnProps> = ({ data, networkHistory }) => (
+  <div className="flex min-h-0 flex-1 flex-col gap-2 px-1">
+    <GaugeRow data={data} />
+    <CpuDayHeatmap data={data} />
+
+    <Panel className="flex shrink-0 basis-[230px] flex-col p-2">
+      <PanelTitle icon={Network} color="#22d3ee" label="NETWORK ACTIVITY" className="mb-[2px] shrink-0" />
+      <div className="flex shrink-0 items-center justify-center gap-3.5 text-[9px] text-gray-400">
+        <div className="flex items-center gap-[3px]">
+          <div className="h-[7px] w-[7px] rounded-full bg-blue-500" />
+          Download
+        </div>
+        <div className="flex items-center gap-[3px]">
+          <div className="h-[7px] w-[7px] rounded-full bg-emerald-500" />
+          Upload
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 py-[2px]">
+        <NetworkAreaChart data={networkHistory} />
+      </div>
+    </Panel>
+
+    <div className="flex shrink-0 gap-2">
+      <InterfacesCard data={data} />
+      <BandwidthCard data={data} />
+    </div>
+
+    <NetworkStrip data={data} />
+  </div>
+);
+
+interface GaugeCardProps {
+  icon: typeof Cpu;
+  iconColor: string;
+  label: string;
+  percentage: number | null;
+  caption: string;
+}
+
+const GaugeCard: React.FC<GaugeCardProps> = ({ icon: Icon, iconColor, label, percentage, caption }) => {
+  const color = percentage === null ? COLORS.muted : statusColor(percentage);
+
+  return (
+    <Panel className="flex flex-col items-center overflow-hidden p-1.5">
+      <div className="mb-1 flex w-full items-center gap-1">
+        <Icon size={11} color={iconColor} strokeWidth={2} />
+        <span className="text-[8.5px] text-gray-300">{label}</span>
+      </div>
+      <Gauge percentage={percentage ?? 0} color={color} />
+      <div className="mt-[3px] text-[12px] font-bold" style={{ color }}>
+        {percentage === null ? 'N/A' : `${percentage.toFixed(1)}%`}
+      </div>
+      <div className="text-[8px] text-gray-400">{caption}</div>
+    </Panel>
+  );
+};
+
+const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const toGb = (mb: number) => (mb / 1024).toFixed(2);
+  const gpuTemperature = data.gpu.temperature === 'N/A' ? 'no sensor' : `${data.gpu.temperature.toFixed(1)}°C`;
+
+  return (
+    <div className="grid shrink-0 grid-cols-4 gap-2">
+      <GaugeCard
+        icon={Cpu}
+        iconColor="#60a5fa"
+        label="CPU"
+        percentage={data.cpu.usage}
+        caption={`${data.cpu.cores} cores`}
+      />
+      <GaugeCard
+        icon={Monitor}
+        iconColor="#c084fc"
+        label="GPU"
+        percentage={data.gpu.usage === 'N/A' ? null : data.gpu.usage}
+        caption={gpuTemperature}
+      />
+      <GaugeCard
+        icon={MemoryStick}
+        iconColor="#4ade80"
+        label="RAM"
+        percentage={data.memory.percentage}
+        caption={`${toGb(data.memory.used)}/${toGb(data.memory.total)}G`}
+      />
+      <GaugeCard
+        icon={HardDrive}
+        iconColor="#facc15"
+        label="DISK"
+        percentage={data.disk.percentage}
+        caption={`${data.disk.used.toFixed(1)}/${data.disk.total.toFixed(1)}G`}
+      />
+    </div>
+  );
+};
+
+const CpuDayHeatmap: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Panel className="flex shrink-0 flex-col gap-1 p-[7px]">
+    <PanelTitle icon={Activity} color="#fb923c" label="CPU LOAD — LAST 24H" />
+    <div className="flex gap-[2px]">
+      {data.history.cpuHourly.map(sample => (
+        <div
+          key={sample.at}
+          className="h-4 flex-1 rounded-[2px]"
+          style={{ background: sample.usage === null ? COLORS.empty : statusColor(sample.usage) }}
+          title={
+            sample.usage === null
+              ? `${new Date(sample.at).getHours()}:00 — no data`
+              : `${new Date(sample.at).getHours()}:00 — ${sample.usage.toFixed(0)}%`
+          }
+        />
+      ))}
+      {data.history.cpuHourly.length === 0 && <EmptyRow>collecting hourly averages…</EmptyRow>}
+    </div>
+  </Panel>
+);
+
+const InterfacesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  // 3개까지만 보여준다. 도커 브리지까지 다 그리면 카드가 넘친다.
+  const interfaces = data.network.interfaces.slice(0, 3);
+
+  return (
+    <Panel className="flex min-w-0 flex-1 flex-col gap-1 p-[7px]">
+      <PanelTitle icon={Network} color="#22d3ee" label="INTERFACES" />
+      {interfaces.length === 0 && <EmptyRow>no interfaces detected</EmptyRow>}
+      {interfaces.map(entry => (
+        <div key={entry.name} className="flex justify-between gap-2 text-[9.5px]">
+          <span className="truncate text-gray-400">
+            {entry.name} <span className="text-gray-500">{entry.ip ?? '—'}</span>
+          </span>
+          <span
+            className={`shrink-0 font-mono ${entry.state === 'up' ? 'text-green-400' : 'text-gray-500'}`}
+          >
+            {entry.state !== 'up'
+              ? entry.state
+              : entry.speedMbps === null
+                ? 'up'
+                : entry.speedMbps >= 1000
+                  ? `${entry.speedMbps / 1000}Gbps`
+                  : `${entry.speedMbps}Mbps`}
+          </span>
+        </div>
+      ))}
+    </Panel>
+  );
+};
+
+const BandwidthCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const percentage = data.network.bandwidthPercentage;
+  const color = statusColor(percentage);
+
+  return (
+    <Panel className="flex min-w-0 flex-1 flex-col gap-1 p-[7px]">
+      <PanelTitle
+        icon={TrendingUp}
+        color="#a78bfa"
+        label="BANDWIDTH"
+        right={
+          <span className="text-[9px]" style={{ color }}>
+            {data.network.linkSpeedMbps === null ? '—' : `${percentage.toFixed(1)}%`}
+          </span>
+        }
+      />
+      <Bar percentage={percentage} color={color} />
+      <div className="text-[8px] text-gray-500">of {formatLinkSpeed(data.network.linkSpeedMbps)}</div>
+    </Panel>
+  );
+};
+
+const NetworkStrip: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Panel className="flex shrink-0 items-center justify-around px-2.5 py-1.5">
+    <StripItem value={data.network.ping.toFixed(1)} unit="ms ping" color="text-yellow-400" />
+    <StripItem
+      value={`${data.network.errorRates.rx}/${data.network.errorRates.tx}%`}
+      unit="err"
+      color="text-red-400"
+    />
+    <StripItem value={String(data.network.connections)} unit="conns" color="text-green-400" />
+    <StripItem value={String(data.network.listeningPorts)} unit="ports" color="text-sky-400" />
+  </Panel>
+);
+
+const StripItem: React.FC<{ value: string; unit: string; color: string }> = ({ value, unit, color }) => (
+  <div className="shrink-0 whitespace-nowrap text-[10px]">
+    <span className={`font-mono ${color}`}>{value}</span>
+    <span className="text-gray-500"> {unit}</span>
+  </div>
+);

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Server } from 'lucide-react';
+
+import { HostInfo } from '@/types/system';
+import { formatClock, shortKernel } from '@/utils/format';
+
+interface DashboardHeaderProps {
+  host: HostInfo;
+  connected: boolean;
+  lastUpdate: number | null;
+  now: number | null;
+}
+
+export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ host, connected, lastUpdate, now }) => {
+  const secondsAgo = now !== null && lastUpdate !== null ? Math.max(0, Math.round((now - lastUpdate) / 1000)) : 0;
+
+  return (
+    <div className="flex h-9 shrink-0 items-center justify-between border-b border-gray-700 bg-gray-800 px-3">
+      <div className="flex min-w-0 items-center gap-[7px]">
+        <Server size={16} color="#60a5fa" strokeWidth={2} />
+        <h1 className="m-0 text-[14px] font-bold">Server Monitor</h1>
+        <div className="h-[7px] w-[7px] animate-[pulseDot_2s_ease-in-out_infinite] rounded-full bg-green-400" />
+      </div>
+
+      <div className="flex items-center gap-2.5">
+        <div className="flex items-center gap-1">
+          <div
+            className={`h-1.5 w-1.5 rounded-full ${
+              connected
+                ? 'animate-[pulseDot_2s_ease-in-out_infinite] bg-green-400'
+                : 'animate-[pulseDot_0.6s_ease-in-out_infinite] bg-red-400'
+            }`}
+          />
+          <span className={`text-[9.5px] ${connected ? 'text-gray-400' : 'text-red-400'}`}>
+            {connected ? `Live · updated ${secondsAgo}s ago` : 'Reconnecting…'}
+          </span>
+        </div>
+
+        <span className="whitespace-nowrap font-mono text-[10.5px] text-gray-500">
+          {/* 배포판 이름을 못 읽으면 os 자체가 커널 문자열이라, 같은 값을 두 번 쓰지 않는다. */}
+          {host.os.includes(shortKernel(host.kernel)) ? host.os : `${host.os} · ${shortKernel(host.kernel)}`}
+        </span>
+
+        <div className="whitespace-nowrap font-mono text-[12px] text-gray-300">
+          {/* 마운트 전에는 시각을 그리지 않는다(하이드레이션 불일치 방지). */}
+          {now === null ? ' ' : formatClock(new Date(now))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/KioskDashboard.tsx
+++ b/src/components/dashboard/KioskDashboard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { AlertBanner, currentAlerts } from '@/components/dashboard/AlertBanner';
+import { CenterColumn } from '@/components/dashboard/CenterColumn';
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
+import { LeftColumn } from '@/components/dashboard/LeftColumn';
+import { RightColumn } from '@/components/dashboard/RightColumn';
+import { DiskIoPoint } from '@/hooks/useSystemData';
+import { NetworkHistoryEntry } from '@/types/system';
+import { DashboardData } from '@/utils/dashboardData';
+
+// 7인치 키오스크 패널(1024x600) 전용 배치. 화면 크기가 달라져도 레이아웃을
+// 다시 짜지 않고 캔버스째 확대/축소하므로, 어디서 열든 같은 그림이 나온다.
+export const KIOSK_WIDTH = 1024;
+export const KIOSK_HEIGHT = 600;
+
+interface KioskDashboardProps {
+  data: DashboardData;
+  connected: boolean;
+  lastUpdate: number | null;
+  now: number | null;
+  networkHistory: NetworkHistoryEntry[];
+  diskIoHistory: DiskIoPoint[];
+  scale: number;
+}
+
+export const KioskDashboard: React.FC<KioskDashboardProps> = ({
+  data,
+  connected,
+  lastUpdate,
+  now,
+  networkHistory,
+  diskIoHistory,
+  scale
+}) => (
+  <div className="relative h-screen w-screen overflow-hidden bg-black">
+    <div
+      className="absolute left-1/2 top-1/2 flex flex-col overflow-hidden bg-gray-900 text-gray-100"
+      style={{
+        width: KIOSK_WIDTH,
+        height: KIOSK_HEIGHT,
+        transform: `translate(-50%, -50%) scale(${scale})`,
+        transformOrigin: 'center center'
+      }}
+    >
+      <DashboardHeader host={data.host} connected={connected} lastUpdate={lastUpdate} now={now} />
+      <AlertBanner alerts={currentAlerts(data)} />
+
+      <div className="flex min-h-0 flex-1 items-start gap-2 p-2">
+        <LeftColumn data={data} diskIoHistory={diskIoHistory} />
+        <CenterColumn data={data} networkHistory={networkHistory} />
+        <RightColumn data={data} now={now} />
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/dashboard/LeftColumn.tsx
+++ b/src/components/dashboard/LeftColumn.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { Activity, Clock, Cpu, Fan, HardDriveDownload, MemoryStick, Thermometer } from 'lucide-react';
+
+import { Bar, EmptyRow, Panel, PanelTitle, Sparkline } from '@/components/dashboard/primitives';
+import { DiskIoPoint } from '@/hooks/useSystemData';
+import { DashboardData } from '@/utils/dashboardData';
+import { formatShortDateTime } from '@/utils/format';
+import { loadCellColor, loadColor, statusColor, tempColor } from '@/utils/statusColors';
+
+// 온도 막대는 0~90°C 를 눈금 삼는다. 경고선(65°C)과 위험선(74°C)을 같은 척도로 찍는다.
+const TEMP_SCALE_MAX = 90;
+const TEMP_WARN = 65;
+const TEMP_CRITICAL = 74;
+
+// 코어가 많으면 막대가 238px 안에 들어가지 않는다. 표시 개수를 자르고 나머지는 숫자로 알린다.
+const MAX_CORE_BARS = 16;
+
+interface LeftColumnProps {
+  data: DashboardData;
+  diskIoHistory: DiskIoPoint[];
+}
+
+export const LeftColumn: React.FC<LeftColumnProps> = ({ data, diskIoHistory }) => (
+  <div className="flex min-h-0 shrink-0 basis-[238px] flex-col gap-1.5">
+    <UptimeCard data={data} />
+    <LoadAverageCard data={data} />
+    <CpuCoresCard data={data} />
+    <SwapCard data={data} />
+    <DiskIoCard data={data} history={diskIoHistory} />
+
+    <div className="grid w-full grid-cols-2 gap-1.5">
+      <FanCard data={data} />
+      <TemperatureCard data={data} />
+    </div>
+  </div>
+);
+
+const UptimeCard: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Panel className="flex w-full flex-col justify-center p-[9px]">
+    <PanelTitle icon={Clock} color="#4ade80" label="UPTIME" className="mb-[3px]" />
+    <div className="text-[15px] font-bold text-white">
+      {data.uptime.days}d {data.uptime.hours}h
+    </div>
+    <div className="text-[9px] text-gray-400">{data.uptime.minutes}m</div>
+    <div className="mt-[3px] border-t border-gray-700 pt-[3px] text-[8px] leading-[1.3] text-gray-500">
+      Last reboot: {formatShortDateTime(data.host.bootTime)}
+      <br />
+      reason: {data.host.rebootReason ?? 'unknown'}
+    </div>
+  </Panel>
+);
+
+const LoadAverageCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const { load, cpu, history } = data;
+
+  // 히스토리가 아직 48칸을 못 채웠으면 앞쪽을 빈 칸으로 메워 격자 모양을 유지한다.
+  const cells = [...Array(Math.max(0, 48 - history.load.length)).fill(null), ...history.load.slice(-48)];
+
+  return (
+    <Panel className="flex w-full flex-col p-[9px]">
+      <PanelTitle
+        icon={Activity}
+        color="#f472b6"
+        label="LOAD AVG"
+        className="mb-[2px]"
+        right={
+          <span className="text-[8px]" style={{ color: loadColor(load.avg1, cpu.cores) }}>
+            1m {load.avg1.toFixed(2)}
+          </span>
+        }
+      />
+      <div className="mb-[2px] flex items-center justify-between text-[8px] text-gray-500">
+        <span>Last 12h</span>
+        <span>
+          5m {load.avg5.toFixed(2)} · 15m {load.avg15.toFixed(2)}
+        </span>
+      </div>
+      <div className="grid grid-cols-12 grid-rows-4 gap-[3px]">
+        {cells.map((cell, index) => (
+          <div
+            key={cell ? cell.at : `empty-${index}`}
+            className="aspect-square rounded-[2px]"
+            style={{ background: loadCellColor(cell?.avg1 ?? null, cpu.cores) }}
+            title={cell?.avg1 != null ? `${formatShortDateTime(cell.at)} · load ${cell.avg1.toFixed(2)}` : 'no data'}
+          />
+        ))}
+      </div>
+    </Panel>
+  );
+};
+
+const CpuCoresCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const all = data.cpu.perCore;
+  const cores = all.slice(0, MAX_CORE_BARS);
+  const hidden = all.length - cores.length;
+
+  // 코어 수에 따라 막대 폭과 간격을 줄여 한 줄에 담는다.
+  const compact = cores.length > 8;
+  const barWidth = cores.length <= 4 ? 28 : cores.length <= 8 ? 18 : 9;
+  const gap = cores.length <= 4 ? 10 : cores.length <= 8 ? 6 : 3;
+
+  return (
+    <Panel className="flex w-full flex-col gap-[5px] p-[7px]">
+      <PanelTitle
+        icon={Cpu}
+        color="#60a5fa"
+        label="CPU CORES"
+        right={hidden > 0 ? <span className="text-[8px] text-gray-500">+{hidden}</span> : undefined}
+      />
+      {cores.length === 0 ? (
+        <EmptyRow>per-core data unavailable</EmptyRow>
+      ) : (
+        <div className="flex h-10 items-end justify-center" style={{ gap }}>
+          {cores.map((usage, index) => (
+            <div key={index} className="flex h-full flex-col items-center justify-end gap-[2px]">
+              {!compact && <span className="text-[8px] text-gray-400">{usage.toFixed(0)}</span>}
+              <div
+                className="flex flex-1 items-end overflow-hidden rounded-[2px] bg-gray-900"
+                style={{ width: barWidth }}
+                title={`C${index} · ${usage.toFixed(1)}%`}
+              >
+                <div className="w-full" style={{ height: `${usage}%`, background: statusColor(usage) }} />
+              </div>
+              {!compact && <span className="text-[8px] text-gray-500">C{index}</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </Panel>
+  );
+};
+
+const SwapCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const { swap } = data;
+  const color = statusColor(swap.percentage);
+
+  return (
+    <Panel className="flex w-full flex-col justify-center gap-1 p-[9px]">
+      <PanelTitle
+        icon={MemoryStick}
+        color="#38bdf8"
+        label="SWAP"
+        right={
+          <span className="text-[9px]" style={{ color }}>
+            {swap.total > 0 ? `${swap.percentage.toFixed(0)}%` : 'off'}
+          </span>
+        }
+      />
+      <Bar percentage={swap.percentage} color={color} />
+      <div className="text-[8.5px] text-gray-400">
+        {swap.total > 0 ? `${swap.used.toFixed(2)}/${swap.total.toFixed(1)}GB` : 'no swap configured'}
+      </div>
+    </Panel>
+  );
+};
+
+const DiskIoCard: React.FC<{ data: DashboardData; history: DiskIoPoint[] }> = ({ data, history }) => (
+  <Panel className="flex w-full flex-col p-[9px]">
+    <PanelTitle
+      icon={HardDriveDownload}
+      color="#38bdf8"
+      label="DISK I/O"
+      className="mb-[2px]"
+      right={
+        <span className="whitespace-nowrap text-[8px]">
+          <span className="text-blue-400">R {data.diskIO.read.toFixed(1)}</span>{' '}
+          <span className="text-pink-400">W {data.diskIO.write.toFixed(1)}</span>{' '}
+          <span className="text-gray-500">MB/s</span>
+        </span>
+      }
+    />
+    <div className="h-[30px]">
+      <Sparkline
+        series={[
+          { key: 'read', values: history.map(point => point.read), color: '#60a5fa' },
+          { key: 'write', values: history.map(point => point.write), color: '#f472b6' }
+        ]}
+      />
+    </div>
+  </Panel>
+);
+
+const FanCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  // 메인보드마다 어느 커넥터에 팬이 꽂혀 있는지 달라서, 값이 잡히는 첫 번째를 쓴다.
+  const rpm = [data.fan.cpu, data.fan.case1, data.fan.case2].find(value => value > 0) ?? 0;
+
+  return (
+    <Panel className="flex flex-col justify-center p-[9px]">
+      <PanelTitle icon={Fan} color="#c084fc" label="FAN" className="mb-[3px]" />
+      <div className="text-[15px] font-bold text-white">{rpm > 0 ? rpm.toLocaleString() : 'N/A'}</div>
+      <div className="text-[9px] text-gray-400">RPM</div>
+    </Panel>
+  );
+};
+
+const TemperatureCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const temperature = data.cpu.temperature;
+  const color = tempColor(temperature);
+  const percentage = temperature === 'N/A' ? 0 : Math.min(100, (temperature / TEMP_SCALE_MAX) * 100);
+
+  const headroom =
+    temperature === 'N/A'
+      ? 'no sensor'
+      : temperature >= TEMP_CRITICAL
+        ? `${(temperature - TEMP_CRITICAL).toFixed(1)}° over alert threshold`
+        : `${(TEMP_CRITICAL - temperature).toFixed(1)}° to alert threshold`;
+
+  return (
+    <Panel className="flex flex-col gap-1 p-[7px]">
+      <PanelTitle icon={Thermometer} color="#fb923c" label="TEMP CPU" />
+      <span className="text-[13px] font-bold" style={{ color }}>
+        {temperature === 'N/A' ? 'N/A' : `${temperature.toFixed(1)}°C`}
+      </span>
+      <Bar percentage={percentage} color={color} className="overflow-visible">
+        <div
+          className="absolute top-[-1px] h-[7px] w-px bg-yellow-400"
+          style={{ left: `${(TEMP_WARN / TEMP_SCALE_MAX) * 100}%` }}
+        />
+        <div
+          className="absolute top-[-1px] h-[7px] w-px bg-red-400"
+          style={{ left: `${(TEMP_CRITICAL / TEMP_SCALE_MAX) * 100}%` }}
+        />
+      </Bar>
+      <div className="text-[8px] text-gray-500">{headroom}</div>
+    </Panel>
+  );
+};

--- a/src/components/dashboard/ResponsiveDashboard.tsx
+++ b/src/components/dashboard/ResponsiveDashboard.tsx
@@ -1,0 +1,628 @@
+import React from 'react';
+import {
+  Activity,
+  AlignLeft,
+  Clock,
+  Cpu,
+  Fan,
+  HardDrive,
+  HardDriveDownload,
+  LucideIcon,
+  MemoryStick,
+  Monitor,
+  Network,
+  Server,
+  Shield,
+  TerminalSquare,
+  Thermometer,
+  TrendingUp,
+  TriangleAlert
+} from 'lucide-react';
+
+import { NetworkAreaChart } from '@/components/charts/NetworkAreaChart';
+import { currentAlerts } from '@/components/dashboard/AlertBanner';
+import { Bar, Gauge, Sparkline } from '@/components/dashboard/primitives';
+import { DiskIoPoint } from '@/hooks/useSystemData';
+import { cn } from '@/lib/utils';
+import { NetworkHistoryEntry } from '@/types/system';
+import { DashboardData } from '@/utils/dashboardData';
+import {
+  formatBytes,
+  formatClock,
+  formatLinkSpeed,
+  formatRate,
+  formatRelativeTime,
+  formatShortDateTime,
+  shortKernel
+} from '@/utils/format';
+import { ALERT_LEVEL_COLORS, COLORS, loadCellColor, loadColor, statusColor, tempColor } from '@/utils/statusColors';
+
+// 키오스크 배치가 읽히지 않는 화면(휴대폰, 세로 태블릿, 좁은 창)을 위한 레이아웃.
+// 정보는 키오스크와 동일하고, 고정 캔버스 대신 세로로 흐르며 글자를 키운다.
+const TEMP_SCALE_MAX = 90;
+const TEMP_WARN = 65;
+const TEMP_CRITICAL = 74;
+const MAX_CORE_BARS = 16;
+const MAX_ALERTS = 8;
+const MAX_PROCESSES = 8;
+
+interface ResponsiveDashboardProps {
+  data: DashboardData;
+  connected: boolean;
+  lastUpdate: number | null;
+  now: number | null;
+  networkHistory: NetworkHistoryEntry[];
+  diskIoHistory: DiskIoPoint[];
+}
+
+export const ResponsiveDashboard: React.FC<ResponsiveDashboardProps> = ({
+  data,
+  connected,
+  lastUpdate,
+  now,
+  networkHistory,
+  diskIoHistory
+}) => (
+  <div className="min-h-screen bg-gray-900 pb-6 text-gray-100">
+    <Header data={data} connected={connected} lastUpdate={lastUpdate} now={now} />
+    <AlertRow data={data} />
+
+    <main className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-2 xl:grid-cols-3">
+      <GaugeRow data={data} />
+      <StatRow data={data} />
+      <NetworkCard data={data} history={networkHistory} />
+      <CpuCoresCard data={data} />
+      <CpuDayCard data={data} />
+      <LoadHistoryCard data={data} />
+      <SwapCard data={data} />
+      <DiskIoCard data={data} history={diskIoHistory} />
+      <InterfacesCard data={data} />
+      <BandwidthCard data={data} />
+      <AlertsCard data={data} now={now} />
+      <ProcessesCard data={data} />
+      <SshCard data={data} now={now} />
+      <TrafficCard data={data} />
+      <FirewallCard data={data} />
+    </main>
+  </div>
+);
+
+// --- 공통 조각 -------------------------------------------------------------
+
+interface CardProps {
+  icon: LucideIcon;
+  color: string;
+  title: string;
+  right?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const Card: React.FC<CardProps> = ({ icon: Icon, color, title, right, className, children }) => (
+  <section className={cn('rounded-lg border border-gray-700 bg-gray-800 p-3', className)}>
+    <div className="mb-2 flex items-center justify-between gap-2">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <Icon size={14} color={color} strokeWidth={2} className="shrink-0" />
+        <h2 className="truncate text-[11px] font-medium tracking-wide text-gray-300">{title}</h2>
+      </div>
+      {right}
+    </div>
+    {children}
+  </section>
+);
+
+const Empty: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <p className="text-xs text-gray-500">{children}</p>
+);
+
+// 카드 하나가 그리드 전체 폭을 차지해야 할 때.
+const fullWidth = 'sm:col-span-2 xl:col-span-3';
+
+// --- 헤더 / 경고 -----------------------------------------------------------
+
+const Header: React.FC<Omit<ResponsiveDashboardProps, 'networkHistory' | 'diskIoHistory'>> = ({
+  data,
+  connected,
+  lastUpdate,
+  now
+}) => {
+  const secondsAgo = now !== null && lastUpdate !== null ? Math.max(0, Math.round((now - lastUpdate) / 1000)) : 0;
+
+  return (
+    <header className="sticky top-0 z-10 border-b border-gray-700 bg-gray-800/95 backdrop-blur">
+      <div className="flex items-center justify-between gap-2 px-3 pb-1 pt-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Server size={18} color="#60a5fa" strokeWidth={2} className="shrink-0" />
+          <h1 className="truncate text-base font-bold">Server Monitor</h1>
+          <div className="h-2 w-2 shrink-0 animate-[pulseDot_2s_ease-in-out_infinite] rounded-full bg-green-400" />
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="font-mono text-xs text-gray-300">{now === null ? ' ' : formatClock(new Date(now))}</div>
+          <div className={cn('text-[10px]', connected ? 'text-gray-500' : 'text-red-400')}>
+            {connected ? `Live · ${secondsAgo}s ago` : 'Reconnecting…'}
+          </div>
+        </div>
+      </div>
+      {/* 좁은 화면에서는 호스트 이름까지 보여줄 여유가 있다. */}
+      <div className="truncate px-3 pb-2 font-mono text-[10px] text-gray-500">
+        {data.host.hostname} · {data.host.os} · {shortKernel(data.host.kernel)}
+      </div>
+    </header>
+  );
+};
+
+const AlertRow: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const alerts = currentAlerts(data);
+  const hasAlert = alerts.length > 0;
+  const color = hasAlert ? '#f87171' : '#4ade80';
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 border-b border-gray-700 px-3 py-2',
+        hasAlert && 'animate-[alertBlink_1.2s_ease-in-out_infinite]'
+      )}
+      style={{ background: hasAlert ? 'rgba(239,68,68,0.12)' : 'rgba(16,185,129,0.08)' }}
+    >
+      <TriangleAlert size={14} color={color} strokeWidth={2} className="shrink-0" />
+      <span className="text-xs" style={{ color }}>
+        {hasAlert ? `Warning: ${alerts.join(' · ')}` : 'All systems normal'}
+      </span>
+    </div>
+  );
+};
+
+// --- 게이지 / 요약 ---------------------------------------------------------
+
+interface GaugeTileProps {
+  icon: LucideIcon;
+  iconColor: string;
+  label: string;
+  percentage: number | null;
+  caption: string;
+}
+
+const GaugeTile: React.FC<GaugeTileProps> = ({ icon: Icon, iconColor, label, percentage, caption }) => {
+  const color = percentage === null ? COLORS.muted : statusColor(percentage);
+
+  return (
+    <div className="flex flex-col items-center rounded-lg border border-gray-700 bg-gray-800 p-3">
+      <div className="mb-2 flex w-full items-center gap-1.5">
+        <Icon size={14} color={iconColor} strokeWidth={2} />
+        <span className="text-[11px] text-gray-300">{label}</span>
+      </div>
+      <Gauge percentage={percentage ?? 0} color={color} size={68} strokeWidth={6} />
+      <div className="mt-2 text-lg font-bold" style={{ color }}>
+        {percentage === null ? 'N/A' : `${percentage.toFixed(1)}%`}
+      </div>
+      <div className="text-[11px] text-gray-400">{caption}</div>
+    </div>
+  );
+};
+
+const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const toGb = (mb: number) => (mb / 1024).toFixed(1);
+
+  return (
+    <div className={cn('grid grid-cols-2 gap-3 sm:grid-cols-4', fullWidth)}>
+      <GaugeTile icon={Cpu} iconColor="#60a5fa" label="CPU" percentage={data.cpu.usage} caption={`${data.cpu.cores} cores`} />
+      <GaugeTile
+        icon={Monitor}
+        iconColor="#c084fc"
+        label="GPU"
+        percentage={data.gpu.usage === 'N/A' ? null : data.gpu.usage}
+        caption={data.gpu.temperature === 'N/A' ? 'no sensor' : `${data.gpu.temperature.toFixed(1)}°C`}
+      />
+      <GaugeTile
+        icon={MemoryStick}
+        iconColor="#4ade80"
+        label="RAM"
+        percentage={data.memory.percentage}
+        caption={`${toGb(data.memory.used)}/${toGb(data.memory.total)}GB`}
+      />
+      <GaugeTile
+        icon={HardDrive}
+        iconColor="#facc15"
+        label="DISK"
+        percentage={data.disk.percentage}
+        caption={`${data.disk.used.toFixed(0)}/${data.disk.total.toFixed(0)}GB`}
+      />
+    </div>
+  );
+};
+
+const StatRow: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const { load, cpu, fan, host, uptime } = data;
+  const rpm = [fan.cpu, fan.case1, fan.case2].find(value => value > 0) ?? 0;
+  const temperature = cpu.temperature;
+  const temperatureColor = tempColor(temperature);
+
+  return (
+    <div className={cn('grid grid-cols-2 gap-3 sm:grid-cols-4', fullWidth)}>
+      <Card icon={Clock} color="#4ade80" title="UPTIME">
+        <div className="text-xl font-bold text-white">
+          {uptime.days}d {uptime.hours}h
+        </div>
+        <div className="text-xs text-gray-400">{uptime.minutes}m</div>
+        <div className="mt-2 border-t border-gray-700 pt-2 text-[10px] leading-relaxed text-gray-500">
+          Last reboot: {formatShortDateTime(host.bootTime)}
+          <br />
+          reason: {host.rebootReason ?? 'unknown'}
+        </div>
+      </Card>
+
+      <Card icon={Activity} color="#f472b6" title="LOAD AVG">
+        <div className="text-xl font-bold" style={{ color: loadColor(load.avg1, cpu.cores) }}>
+          {load.avg1.toFixed(2)}
+        </div>
+        <div className="text-xs text-gray-400">1 min</div>
+        <div className="mt-2 border-t border-gray-700 pt-2 text-[10px] leading-relaxed text-gray-500">
+          5m {load.avg5.toFixed(2)}
+          <br />
+          15m {load.avg15.toFixed(2)}
+        </div>
+      </Card>
+
+      <Card icon={Thermometer} color="#fb923c" title="CPU TEMP">
+        <div className="text-xl font-bold" style={{ color: temperatureColor }}>
+          {temperature === 'N/A' ? 'N/A' : `${temperature.toFixed(1)}°C`}
+        </div>
+        <Bar
+          percentage={temperature === 'N/A' ? 0 : Math.min(100, (temperature / TEMP_SCALE_MAX) * 100)}
+          color={temperatureColor}
+          className="mt-2 overflow-visible"
+        >
+          <div
+            className="absolute top-[-2px] h-[9px] w-px bg-yellow-400"
+            style={{ left: `${(TEMP_WARN / TEMP_SCALE_MAX) * 100}%` }}
+          />
+          <div
+            className="absolute top-[-2px] h-[9px] w-px bg-red-400"
+            style={{ left: `${(TEMP_CRITICAL / TEMP_SCALE_MAX) * 100}%` }}
+          />
+        </Bar>
+        <div className="mt-2 text-[10px] text-gray-500">
+          {temperature === 'N/A'
+            ? 'no sensor'
+            : temperature >= TEMP_CRITICAL
+              ? `${(temperature - TEMP_CRITICAL).toFixed(1)}° over alert threshold`
+              : `${(TEMP_CRITICAL - temperature).toFixed(1)}° to alert threshold`}
+        </div>
+      </Card>
+
+      <Card icon={Fan} color="#c084fc" title="FAN">
+        <div className="text-xl font-bold text-white">{rpm > 0 ? rpm.toLocaleString() : 'N/A'}</div>
+        <div className="text-xs text-gray-400">RPM</div>
+      </Card>
+    </div>
+  );
+};
+
+// --- 네트워크 --------------------------------------------------------------
+
+const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[] }> = ({ data, history }) => (
+  <Card
+    icon={Network}
+    color="#22d3ee"
+    title="NETWORK ACTIVITY"
+    className={cn('xl:col-span-2', 'sm:col-span-2')}
+    right={
+      <span className="shrink-0 whitespace-nowrap font-mono text-[11px]">
+        <span className="text-blue-400">↓ {formatRate(data.network.download)}</span>{' '}
+        <span className="text-emerald-400">↑ {formatRate(data.network.upload)}</span>
+      </span>
+    }
+  >
+    <div className="h-44 sm:h-56">
+      <NetworkAreaChart data={history} />
+    </div>
+    <div className="mt-2 grid grid-cols-2 gap-2 border-t border-gray-700 pt-2 sm:grid-cols-4">
+      <MiniStat value={data.network.ping.toFixed(1)} unit="ms ping" color="text-yellow-400" />
+      <MiniStat
+        value={`${data.network.errorRates.rx}/${data.network.errorRates.tx}%`}
+        unit="rx/tx err"
+        color="text-red-400"
+      />
+      <MiniStat value={String(data.network.connections)} unit="connections" color="text-green-400" />
+      <MiniStat value={String(data.network.listeningPorts)} unit="listening ports" color="text-sky-400" />
+    </div>
+  </Card>
+);
+
+const MiniStat: React.FC<{ value: string; unit: string; color: string }> = ({ value, unit, color }) => (
+  <div className="min-w-0">
+    <div className={cn('truncate font-mono text-sm', color)}>{value}</div>
+    <div className="truncate text-[10px] text-gray-500">{unit}</div>
+  </div>
+);
+
+const InterfacesCard: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Card icon={Network} color="#22d3ee" title="INTERFACES">
+    {data.network.interfaces.length === 0 && <Empty>no interfaces detected</Empty>}
+    <ul className="space-y-1.5">
+      {data.network.interfaces.map(entry => (
+        <li key={entry.name} className="flex items-center justify-between gap-2 text-xs">
+          <span className="min-w-0 truncate text-gray-300">
+            {entry.name} <span className="text-gray-500">{entry.ip ?? '—'}</span>
+          </span>
+          <span className={cn('shrink-0 font-mono', entry.state === 'up' ? 'text-green-400' : 'text-gray-500')}>
+            {entry.state !== 'up'
+              ? entry.state
+              : entry.speedMbps === null
+                ? 'up'
+                : entry.speedMbps >= 1000
+                  ? `${entry.speedMbps / 1000}Gbps`
+                  : `${entry.speedMbps}Mbps`}
+          </span>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+const BandwidthCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const percentage = data.network.bandwidthPercentage;
+  const color = statusColor(percentage);
+
+  return (
+    <Card
+      icon={TrendingUp}
+      color="#a78bfa"
+      title="BANDWIDTH"
+      right={
+        <span className="shrink-0 text-xs font-medium" style={{ color }}>
+          {data.network.linkSpeedMbps === null ? '—' : `${percentage.toFixed(1)}%`}
+        </span>
+      }
+    >
+      <Bar percentage={percentage} color={color} className="h-2" />
+      <p className="mt-2 text-[10px] text-gray-500">of {formatLinkSpeed(data.network.linkSpeedMbps)}</p>
+    </Card>
+  );
+};
+
+// --- CPU / 부하 ------------------------------------------------------------
+
+const CpuCoresCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const cores = data.cpu.perCore.slice(0, MAX_CORE_BARS);
+  const hidden = data.cpu.perCore.length - cores.length;
+
+  return (
+    <Card
+      icon={Cpu}
+      color="#60a5fa"
+      title="CPU CORES"
+      right={hidden > 0 ? <span className="text-[10px] text-gray-500">+{hidden} more</span> : undefined}
+    >
+      {cores.length === 0 && <Empty>per-core data unavailable</Empty>}
+      {/* 세로 막대는 좁은 화면에서 뭉개진다. 가로 막대로 눕히면 코어가 많아도 읽힌다. */}
+      <ul className="space-y-1.5">
+        {cores.map((usage, index) => (
+          <li key={index} className="flex items-center gap-2">
+            <span className="w-6 shrink-0 text-[10px] text-gray-500">C{index}</span>
+            <div className="h-2 min-w-0 flex-1 overflow-hidden rounded bg-gray-900">
+              <div className="h-full rounded" style={{ width: `${usage}%`, background: statusColor(usage) }} />
+            </div>
+            <span className="w-10 shrink-0 text-right text-[11px] text-gray-400">{usage.toFixed(0)}%</span>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+const CpuDayCard: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Card icon={Activity} color="#fb923c" title="CPU LOAD — LAST 24H">
+    {data.history.cpuHourly.length === 0 ? (
+      <Empty>collecting hourly averages…</Empty>
+    ) : (
+      <>
+        <div className="flex gap-[2px]">
+          {data.history.cpuHourly.map(sample => (
+            <div
+              key={sample.at}
+              className="h-7 flex-1 rounded-sm"
+              style={{ background: sample.usage === null ? COLORS.empty : statusColor(sample.usage) }}
+              title={
+                sample.usage === null
+                  ? `${new Date(sample.at).getHours()}:00 — no data`
+                  : `${new Date(sample.at).getHours()}:00 — ${sample.usage.toFixed(0)}%`
+              }
+            />
+          ))}
+        </div>
+        <div className="mt-1 flex justify-between text-[10px] text-gray-500">
+          <span>{new Date(data.history.cpuHourly[0].at).getHours()}:00</span>
+          <span>now</span>
+        </div>
+      </>
+    )}
+  </Card>
+);
+
+const LoadHistoryCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const cells = [...Array(Math.max(0, 48 - data.history.load.length)).fill(null), ...data.history.load.slice(-48)];
+
+  return (
+    <Card
+      icon={Activity}
+      color="#f472b6"
+      title="LOAD — LAST 12H"
+      right={<span className="text-[10px] text-gray-500">15 min per cell</span>}
+    >
+      <div className="grid grid-cols-12 gap-1">
+        {cells.map((cell, index) => (
+          <div
+            key={cell ? cell.at : `empty-${index}`}
+            className="aspect-square rounded-sm"
+            style={{ background: loadCellColor(cell?.avg1 ?? null, data.cpu.cores) }}
+            title={
+              cell?.avg1 != null ? `${formatShortDateTime(cell.at)} · load ${cell.avg1.toFixed(2)}` : 'no data'
+            }
+          />
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+// --- 메모리 / 디스크 -------------------------------------------------------
+
+const SwapCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const { swap } = data;
+  const color = statusColor(swap.percentage);
+
+  return (
+    <Card
+      icon={MemoryStick}
+      color="#38bdf8"
+      title="SWAP"
+      right={
+        <span className="shrink-0 text-xs font-medium" style={{ color }}>
+          {swap.total > 0 ? `${swap.percentage.toFixed(0)}%` : 'off'}
+        </span>
+      }
+    >
+      <Bar percentage={swap.percentage} color={color} className="h-2" />
+      <p className="mt-2 text-xs text-gray-400">
+        {swap.total > 0 ? `${swap.used.toFixed(2)} / ${swap.total.toFixed(1)} GB` : 'no swap configured'}
+      </p>
+    </Card>
+  );
+};
+
+const DiskIoCard: React.FC<{ data: DashboardData; history: DiskIoPoint[] }> = ({ data, history }) => (
+  <Card
+    icon={HardDriveDownload}
+    color="#38bdf8"
+    title="DISK I/O"
+    right={
+      <span className="shrink-0 whitespace-nowrap font-mono text-[11px]">
+        <span className="text-blue-400">R {data.diskIO.read.toFixed(1)}</span>{' '}
+        <span className="text-pink-400">W {data.diskIO.write.toFixed(1)}</span>{' '}
+        <span className="text-gray-500">MB/s</span>
+      </span>
+    }
+  >
+    <div className="h-16">
+      <Sparkline
+        series={[
+          { key: 'read', values: history.map(point => point.read), color: '#60a5fa' },
+          { key: 'write', values: history.map(point => point.write), color: '#f472b6' }
+        ]}
+      />
+    </div>
+  </Card>
+);
+
+// --- 로그 / 보안 -----------------------------------------------------------
+
+const AlertsCard: React.FC<{ data: DashboardData; now: number | null }> = ({ data, now }) => (
+  <Card icon={TriangleAlert} color="#f87171" title="ALERTS LOG">
+    {data.alerts.length === 0 && <Empty>no alerts recorded</Empty>}
+    <ul className="space-y-1.5">
+      {data.alerts.slice(0, MAX_ALERTS).map(alert => (
+        <li key={alert.id} className="flex items-start justify-between gap-2 text-xs">
+          <span className="flex min-w-0 items-start gap-1.5">
+            <span
+              className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full"
+              style={{ background: ALERT_LEVEL_COLORS[alert.level] ?? '#9ca3af' }}
+            />
+            <span style={{ color: ALERT_LEVEL_COLORS[alert.level] ?? '#9ca3af' }}>{alert.message}</span>
+          </span>
+          <span className="shrink-0 text-gray-500">{now === null ? '' : formatRelativeTime(alert.at, now)}</span>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+const ProcessesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const processes = data.processes.filter(p => p.cpu > 0 || p.memory > 0).slice(0, MAX_PROCESSES);
+
+  return (
+    <Card icon={AlignLeft} color="#fb923c" title="TOP PROCESSES">
+      <div className="mb-1 flex items-center justify-between text-[10px] text-gray-500">
+        <span>Name</span>
+        <div className="flex gap-3">
+          <span className="w-10 text-right text-yellow-400">CPU %</span>
+          <span className="w-10 text-right text-blue-400">RAM %</span>
+        </div>
+      </div>
+      {processes.length === 0 && <Empty>process list unavailable</Empty>}
+      <ul>
+        {processes.map(process => (
+          <li key={process.id} className="flex items-center justify-between gap-2 py-1 text-xs">
+            <span className="min-w-0 truncate text-gray-300" title={process.name}>
+              {process.name}
+            </span>
+            <div className="flex shrink-0 gap-3 font-mono">
+              <span className="w-10 text-right text-yellow-400">{process.cpu.toFixed(1)}</span>
+              <span className="w-10 text-right text-blue-400">{process.memory.toFixed(1)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+const SshCard: React.FC<{ data: DashboardData; now: number | null }> = ({ data, now }) => (
+  <Card icon={TerminalSquare} color="#38bdf8" title="SSH SESSIONS">
+    {data.security.sshSessions.length === 0 && <Empty>no remote sessions</Empty>}
+    <ul className="space-y-1.5">
+      {data.security.sshSessions.map(session => (
+        <li
+          key={`${session.user}@${session.ip}@${session.since}`}
+          className="flex items-center justify-between gap-2 text-xs"
+        >
+          <span className="min-w-0 truncate text-gray-300">
+            {session.user}@{session.ip}
+          </span>
+          <span className="shrink-0 text-gray-500">{now === null ? '' : formatRelativeTime(session.since, now)}</span>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+const TrafficCard: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Card icon={TrendingUp} color="#38bdf8" title="TOP TRAFFIC IPS">
+    {data.security.topTraffic.length === 0 && <Empty>no external connections</Empty>}
+    <ul className="space-y-1.5">
+      {data.security.topTraffic.map(peer => (
+        <li key={peer.ip} className="flex items-center justify-between gap-2 text-xs">
+          <span className="min-w-0 truncate font-mono text-gray-300">{peer.ip}</span>
+          <span className="shrink-0 font-mono text-sky-400">
+            {peer.bytes === null ? `${peer.connections} conn` : formatBytes(peer.bytes)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+const FirewallCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const { firewall } = data.security;
+  const color = firewall.status === 'active' ? '#4ade80' : firewall.status === 'inactive' ? '#f87171' : '#9ca3af';
+
+  return (
+    <Card
+      icon={Shield}
+      color={color}
+      title="FIREWALL"
+      right={
+        <span className="shrink-0 text-xs font-medium" style={{ color }}>
+          {firewall.backend ? `${firewall.backend} · ${firewall.status}` : firewall.status}
+        </span>
+      }
+    >
+      <p className="text-xs text-gray-400">
+        Blocked (24h):{' '}
+        <span className="font-mono text-red-400">
+          {firewall.blockedAttempts === null ? 'N/A' : firewall.blockedAttempts.toLocaleString()}
+        </span>
+      </p>
+    </Card>
+  );
+};

--- a/src/components/dashboard/RightColumn.tsx
+++ b/src/components/dashboard/RightColumn.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { AlignLeft, Shield, TerminalSquare, TrendingUp, TriangleAlert } from 'lucide-react';
+
+import { EmptyRow, Panel, PanelTitle } from '@/components/dashboard/primitives';
+import { DashboardData } from '@/utils/dashboardData';
+import { formatBytes, formatRelativeTime } from '@/utils/format';
+import { ALERT_LEVEL_COLORS } from '@/utils/statusColors';
+
+// 1024x600 캔버스에 세로로 다 들어가는 최대 개수. 늘리면 아래 카드가 잘린다.
+const MAX_ALERTS = 5;
+const MAX_PROCESSES = 5;
+const MAX_SESSIONS = 4;
+const MAX_PEERS = 4;
+
+interface RightColumnProps {
+  data: DashboardData;
+  now: number | null;
+}
+
+export const RightColumn: React.FC<RightColumnProps> = ({ data, now }) => (
+  <div className="mr-[2px] flex min-h-0 w-[282px] min-w-0 shrink-0 flex-col gap-1 overflow-hidden">
+    <AlertsLog data={data} now={now} />
+    <TopProcesses data={data} />
+    <SshSessions data={data} now={now} />
+    <TopTraffic data={data} />
+    <FirewallCard data={data} />
+  </div>
+);
+
+const AlertsLog: React.FC<RightColumnProps> = ({ data, now }) => (
+  <Panel className="flex w-full shrink-0 flex-col gap-[3px] overflow-hidden p-[7px]">
+    <PanelTitle icon={TriangleAlert} color="#f87171" label="ALERTS LOG" />
+    {data.alerts.length === 0 && <EmptyRow>no alerts recorded</EmptyRow>}
+    {data.alerts.slice(0, MAX_ALERTS).map(alert => (
+      <div key={alert.id} className="flex justify-between gap-1.5 text-[9.5px]">
+        <span className="truncate" style={{ color: ALERT_LEVEL_COLORS[alert.level] ?? '#9ca3af' }}>
+          {alert.message}
+        </span>
+        <span className="shrink-0 text-gray-500">
+          {now === null ? '' : formatRelativeTime(alert.at, now)}
+        </span>
+      </div>
+    ))}
+  </Panel>
+);
+
+const TopProcesses: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const processes = data.processes
+    .filter(process => process.cpu > 0 || process.memory > 0)
+    .slice(0, MAX_PROCESSES);
+
+  return (
+    <Panel className="flex w-full shrink-0 flex-col overflow-hidden p-[7px]">
+      <PanelTitle icon={AlignLeft} color="#fb923c" label="TOP PROCESSES" className="mb-1 shrink-0" />
+      <div className="mb-[2px] flex shrink-0 items-center justify-between text-[8.5px] text-gray-400">
+        <span>Name</span>
+        <div className="flex gap-[5px]">
+          <span className="w-[26px] text-right text-yellow-400">CPU</span>
+          <span className="w-[26px] text-right text-blue-400">RAM</span>
+        </div>
+      </div>
+      {processes.length === 0 && <EmptyRow>process list unavailable</EmptyRow>}
+      {processes.map(process => (
+        <div key={process.id} className="flex items-center justify-between py-px text-[9.5px]">
+          <span className="max-w-[62%] truncate text-gray-400" title={process.name}>
+            {process.name}
+          </span>
+          <div className="flex items-center gap-[5px]">
+            <span className="w-[26px] text-right text-yellow-400">{process.cpu.toFixed(1)}</span>
+            <span className="w-[26px] text-right text-blue-400">{process.memory.toFixed(1)}</span>
+          </div>
+        </div>
+      ))}
+    </Panel>
+  );
+};
+
+const SshSessions: React.FC<RightColumnProps> = ({ data, now }) => (
+  <Panel className="flex w-full shrink-0 flex-col gap-1 overflow-hidden p-[7px]">
+    <PanelTitle icon={TerminalSquare} color="#38bdf8" label="SSH SESSIONS" />
+    {data.security.sshSessions.length === 0 && <EmptyRow>no remote sessions</EmptyRow>}
+    {data.security.sshSessions.slice(0, MAX_SESSIONS).map(session => (
+      <div key={`${session.user}@${session.ip}@${session.since}`} className="truncate text-[10px] text-gray-400">
+        {session.user}@{session.ip}{' '}
+        <span className="text-gray-500">· {now === null ? '' : formatRelativeTime(session.since, now)}</span>
+      </div>
+    ))}
+  </Panel>
+);
+
+const TopTraffic: React.FC<{ data: DashboardData }> = ({ data }) => (
+  <Panel className="flex w-full shrink-0 flex-col gap-1 overflow-hidden p-[7px]">
+    <PanelTitle icon={TrendingUp} color="#38bdf8" label="TOP TRAFFIC IPS" />
+    {data.security.topTraffic.length === 0 && <EmptyRow>no external connections</EmptyRow>}
+    {data.security.topTraffic.slice(0, MAX_PEERS).map(peer => (
+      <div key={peer.ip} className="flex justify-between gap-2 text-[10px]">
+        <span className="truncate text-gray-400">{peer.ip}</span>
+        {/* conntrack 이 바이트를 세지 않는 커널에서는 연결 수만 알 수 있다. */}
+        <span className="shrink-0 font-mono text-sky-400">
+          {peer.bytes === null ? `${peer.connections} conn` : formatBytes(peer.bytes)}
+        </span>
+      </div>
+    ))}
+  </Panel>
+);
+
+const FirewallCard: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const { firewall } = data.security;
+  const color =
+    firewall.status === 'active' ? '#4ade80' : firewall.status === 'inactive' ? '#f87171' : '#9ca3af';
+
+  return (
+    <Panel className="flex w-full shrink-0 flex-col gap-1 overflow-hidden p-[7px]">
+      <PanelTitle
+        icon={Shield}
+        color={color}
+        label="FIREWALL"
+        right={
+          <span className="shrink-0 whitespace-nowrap text-[9px]" style={{ color }}>
+            {firewall.backend ? `${firewall.backend} · ${firewall.status}` : firewall.status}
+          </span>
+        }
+      />
+      <div className="text-[9.5px] text-gray-400">
+        Blocked (24h):{' '}
+        <span className="font-mono text-red-400">
+          {firewall.blockedAttempts === null ? 'N/A' : firewall.blockedAttempts.toLocaleString()}
+        </span>
+      </div>
+    </Panel>
+  );
+};

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+// 1024x600 캔버스에 맞춘 공통 조각들. 치수(7px 라운드, 9px 라벨 등)는
+// 디자인 시안 그대로다.
+
+interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export const Panel: React.FC<PanelProps> = ({ className, children, ...props }) => (
+  <div
+    className={cn('box-border rounded-[7px] border border-gray-700 bg-gray-800', className)}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+interface PanelTitleProps {
+  icon: LucideIcon;
+  color: string;
+  label: string;
+  right?: React.ReactNode;
+  className?: string;
+}
+
+export const PanelTitle: React.FC<PanelTitleProps> = ({ icon: Icon, color, label, right, className }) => (
+  <div className={cn('flex items-center justify-between gap-1.5', className)}>
+    <div className="flex min-w-0 items-center gap-[5px]">
+      <Icon size={12} color={color} strokeWidth={2} className="shrink-0" />
+      <span className="whitespace-nowrap text-[9px] tracking-[0.03em] text-gray-300">{label}</span>
+    </div>
+    {right}
+  </div>
+);
+
+interface GaugeProps {
+  percentage: number;
+  color: string;
+  size?: number;
+  strokeWidth?: number;
+}
+
+export const Gauge: React.FC<GaugeProps> = ({ percentage, color, size = 36, strokeWidth = 3.5 }) => {
+  const radius = size / 2 - strokeWidth / 2 - 1.25;
+  const circumference = 2 * Math.PI * radius;
+  const filled = Math.max(0, Math.min(100, percentage));
+
+  return (
+    <svg width={size} height={size} className="shrink-0 -rotate-90">
+      <circle cx={size / 2} cy={size / 2} r={radius} stroke="#374151" strokeWidth={strokeWidth} fill="transparent" />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - (filled / 100) * circumference}
+      />
+    </svg>
+  );
+};
+
+interface BarProps {
+  percentage: number;
+  color: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const Bar: React.FC<BarProps> = ({ percentage, color, className, children }) => (
+  <div className={cn('relative h-[5px] rounded-[3px] bg-gray-900', className)}>
+    <div
+      className="h-full rounded-[3px]"
+      style={{ width: `${Math.max(0, Math.min(100, percentage))}%`, background: color }}
+    />
+    {children}
+  </div>
+);
+
+interface SparklineSeries {
+  key: string;
+  values: number[];
+  color: string;
+}
+
+interface SparklineProps {
+  series: SparklineSeries[];
+  className?: string;
+  emptyLabel?: string;
+}
+
+// 축도 눈금도 없는 추세선. 세로 축은 표시된 구간의 최댓값에 맞춰 자동으로 늘어난다.
+export const Sparkline: React.FC<SparklineProps> = ({ series, className, emptyLabel = 'collecting…' }) => {
+  const width = 200;
+  const height = 34;
+  const length = Math.max(...series.map(entry => entry.values.length), 0);
+
+  if (length < 2) {
+    return (
+      <div className={cn('flex items-center justify-center text-[8px] text-gray-500', className)}>
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  const max = Math.max(1, ...series.flatMap(entry => entry.values)) * 1.2;
+
+  const path = (values: number[]) =>
+    values
+      .map((value, index) => {
+        const x = (index / (length - 1)) * width;
+        const y = height - (Math.max(0, Math.min(max, value)) / max) * height;
+        return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+      })
+      .join(' ');
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={cn('h-full w-full', className)}
+    >
+      {series.map(entry => (
+        <path key={entry.key} d={path(entry.values)} fill="none" stroke={entry.color} strokeWidth={1.5} />
+      ))}
+    </svg>
+  );
+};
+
+// 값이 없는 카드가 통째로 접히지 않도록 자리를 잡아주는 한 줄.
+export const EmptyRow: React.FC<{ children?: React.ReactNode }> = ({ children = 'no data' }) => (
+  <div className="text-[9.5px] text-gray-500">{children}</div>
+);

--- a/src/hooks/useNow.ts
+++ b/src/hooks/useNow.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// 서버 렌더 결과에 시각이 박히면 하이드레이션 불일치가 난다.
+// 마운트 전에는 null 을 돌려주고, 화면에서는 자리표시자를 그린다.
+export function useNow(intervalMs = 1000): number | null {
+  const [now, setNow] = useState<number | null>(null);
+
+  useEffect(() => {
+    setNow(Date.now());
+    const interval = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(interval);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/src/hooks/useSystemData.ts
+++ b/src/hooks/useSystemData.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { NetworkHistoryEntry, ServerData } from '@/types/system';
+import { DashboardData, toDashboardData } from '@/utils/dashboardData';
+
+const POLL_INTERVAL_MS = 1000;
+const REQUEST_TIMEOUT_MS = 4000;
+const MAX_POINTS = 60;
+
+// 이 필드들이 없으면 응답이 /api/system 의 것이 아니거나 심하게 망가진 것이다.
+const REQUIRED_FIELDS = ['cpu', 'memory', 'disk', 'network', 'uptime', 'temperature', 'fan', 'processes'] as const;
+
+export interface DiskIoPoint {
+  read: number;
+  write: number;
+}
+
+export interface SystemDataState {
+  data: DashboardData | null;
+  error: string | null;
+  connected: boolean;
+  lastUpdate: number | null;
+  networkHistory: NetworkHistoryEntry[];
+  diskIoHistory: DiskIoPoint[];
+}
+
+function assertServerData(payload: unknown): asserts payload is ServerData {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid data format received');
+  }
+
+  const record = payload as Record<string, unknown>;
+  const missing = REQUIRED_FIELDS.filter(field => !record[field]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required fields: ${missing.join(', ')}`);
+  }
+}
+
+export function useSystemData(): SystemDataState {
+  const [state, setState] = useState<SystemDataState>({
+    data: null,
+    error: null,
+    connected: false,
+    lastUpdate: null,
+    networkHistory: [],
+    diskIoHistory: []
+  });
+
+  // 응답이 폴링 간격보다 느려지면 요청이 겹쳐 쌓인다. 한 번에 하나만 보낸다.
+  const inflight = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      if (inflight.current) return;
+      inflight.current = true;
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+      try {
+        const response = await fetch('/api/system', { signal: controller.signal, cache: 'no-store' });
+        if (!response.ok) throw new Error(`Failed to fetch system data (${response.status})`);
+
+        const payload: unknown = await response.json();
+        assertServerData(payload);
+        if (cancelled) return;
+
+        const data = toDashboardData(payload);
+        const time = new Date().toLocaleTimeString('ko-KR', {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          hour12: false
+        });
+
+        setState(previous => ({
+          data,
+          error: null,
+          connected: true,
+          lastUpdate: Date.now(),
+          networkHistory: [
+            ...previous.networkHistory,
+            { time, download: data.network.download, upload: data.network.upload }
+          ].slice(-MAX_POINTS),
+          diskIoHistory: [
+            ...previous.diskIoHistory,
+            { read: data.diskIO.read, write: data.diskIO.write }
+          ].slice(-MAX_POINTS)
+        }));
+      } catch (error) {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : 'Unknown error occurred';
+        console.error('Error fetching system data:', error);
+
+        // 마지막으로 받은 값은 지우지 않는다. 잠깐 끊겼다고 화면이 비어버리면
+        // 벽에 걸어둔 대시보드로서는 오히려 정보가 줄어든다.
+        setState(previous => ({ ...previous, error: message, connected: false }));
+      } finally {
+        clearTimeout(timeout);
+        inflight.current = false;
+      }
+    };
+
+    fetchOnce();
+    const interval = setInterval(fetchOnce, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type ViewMode = 'kiosk' | 'responsive';
+
+// 키오스크 캔버스를 이 배율 밑으로 줄여야 들어간다면, 글자가 읽히지 않는다
+// (9px 라벨이 7px 아래로 내려간다). 그런 화면에는 반응형 레이아웃을 준다.
+// 0.8 => 가로 819px, 세로 480px 이상이면 고정 배치를 유지한다.
+// 대상인 7인치 패널(1024x600)은 배율 1.0 이라 항상 키오스크로 뜬다.
+const KIOSK_MIN_SCALE = 0.8;
+
+interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface ViewModeState {
+  // 측정 전(SSR/첫 페인트)에는 null. 잘못된 레이아웃을 한 프레임 보여주지 않기 위함이다.
+  mode: ViewMode | null;
+  scale: number;
+}
+
+// `?kiosk=1` 로 고정 배치를 강제하고, `?kiosk=0` 으로 반응형을 강제한다.
+// 키오스크 브라우저가 뷰포트를 이상하게 보고할 때 쓰는 탈출구.
+function readOverride(): ViewMode | null {
+  const value = new URLSearchParams(window.location.search).get('kiosk');
+  if (value === '1' || value === 'true') return 'kiosk';
+  if (value === '0' || value === 'false') return 'responsive';
+  return null;
+}
+
+export function useViewMode(designWidth: number, designHeight: number): ViewModeState {
+  const [viewport, setViewport] = useState<Viewport | null>(null);
+  const [override, setOverride] = useState<ViewMode | null>(null);
+
+  useEffect(() => {
+    // 래퍼 엘리먼트가 아니라 뷰포트를 잰다. 반응형 레이아웃은 세로로 스크롤되므로
+    // 래퍼 높이를 재면 "내용이 길다 -> 배율이 크다 -> 키오스크로 전환 -> 내용이 짧아진다"
+    // 로 모드가 진동한다.
+    const measure = () => setViewport({ width: window.innerWidth, height: window.innerHeight });
+
+    measure();
+    setOverride(readOverride());
+
+    window.addEventListener('resize', measure);
+    window.addEventListener('orientationchange', measure);
+    return () => {
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('orientationchange', measure);
+    };
+  }, []);
+
+  if (viewport === null) return { mode: null, scale: 1 };
+
+  const scale = Math.min(viewport.width / designWidth, viewport.height / designHeight);
+  return { mode: override ?? (scale >= KIOSK_MIN_SCALE ? 'kiosk' : 'responsive'), scale };
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,6 +19,17 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* 대시보드 상태 표시용. Tailwind 의 animate-[pulseDot_...] 에서 참조한다. */
+@keyframes pulseDot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+@keyframes alertBlink {
+  0%, 100% { background-color: rgba(239, 68, 68, 0.12); }
+  50% { background-color: rgba(239, 68, 68, 0.32); }
+}
+
 /* 7-inch screen optimization */
 @media screen and (max-width: 1024px) and (max-height: 600px) {
   html {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -35,11 +35,109 @@ export function isARMTemperatureInfo(temp: TemperatureInfo): temp is ARMTemperat
     return 'rp1' in temp && 'ssd' in temp;
 }
 
+// 호스트 식별 정보. 헤더의 "Ubuntu 22.04 · 5.15.0" 표기와 재부팅 이력에 쓰인다.
+export interface HostInfo {
+    hostname: string;
+    os: string;
+    kernel: string;
+    arch: string;
+    bootTime: string; // ISO 8601
+    // 마지막 재부팅이 정상 종료였는지. wtmp 를 못 읽으면 null.
+    rebootReason: string | null;
+}
+
+export interface LoadInfo {
+    avg1: number;
+    avg5: number;
+    avg15: number;
+}
+
+export interface SwapInfo {
+    used: number;  // GB
+    total: number; // GB
+    percentage: number;
+}
+
+export interface DiskIoInfo {
+    read: number;  // MB/s
+    write: number; // MB/s
+}
+
+export interface GpuInfo {
+    name: string | null;
+    usage: number | 'N/A';
+    temperature: TemperatureValue;
+}
+
+export interface NetworkInterfaceInfo {
+    name: string;
+    ip: string | null;
+    speedMbps: number | null;
+    state: 'up' | 'down' | 'unknown';
+    isDefault: boolean;
+}
+
+// 대역폭 상위 피어. nf_conntrack 의 바이트 계정이 꺼져 있으면 bytes 는 null 이고
+// 연결 수(connections)만 의미가 있다.
+export interface TrafficPeer {
+    ip: string;
+    bytes: number | null;
+    connections: number;
+}
+
+export interface SshSession {
+    user: string;
+    ip: string;
+    since: string; // ISO 8601
+}
+
+export interface FirewallInfo {
+    status: 'active' | 'inactive' | 'unknown';
+    backend: string | null;
+    // 커널 로그를 읽을 권한이 없으면 null.
+    blockedAttempts: number | null;
+}
+
+export interface SecurityInfo {
+    firewall: FirewallInfo;
+    sshSessions: SshSession[];
+    topTraffic: TrafficPeer[];
+}
+
+export type AlertLevel = 'ok' | 'info' | 'warning' | 'critical';
+
+export interface AlertEntry {
+    id: string;
+    level: AlertLevel;
+    message: string;
+    at: string; // ISO 8601
+}
+
+// 히스토리는 프로세스 메모리에만 쌓인다. 서버를 재시작하면 비고, UI 는 빈 구간을
+// "수집 중" 으로 표시한다.
+export interface LoadSample {
+    at: string; // ISO 8601, 15분 버킷의 시작
+    // 서버가 그 시간대에 켜져 있지 않았으면 null.
+    avg1: number | null;
+}
+
+export interface CpuHourSample {
+    at: string; // ISO 8601, 정시 버킷의 시작
+    usage: number | null;
+}
+
+export interface HistoryInfo {
+    load: LoadSample[];      // 최근 12시간, 15분 버킷
+    cpuHourly: CpuHourSample[]; // 최근 24시간, 1시간 버킷
+}
+
 export interface ServerData {
     cpu: {
         usage: number;
         cores: number;
         temperature: TemperatureValue;
+        // 코어별 사용률. /proc/stat 를 못 읽으면 빈 배열.
+        perCore?: number[];
     };
     memory: {
         used: number;
@@ -59,6 +157,11 @@ export interface ServerData {
             rx: string;
             tx: string;
         };
+        connections?: number;
+        listeningPorts?: number;
+        interfaces?: NetworkInterfaceInfo[];
+        linkSpeedMbps?: number | null;
+        bandwidthPercentage?: number;
     };
     uptime: {
         days: number;
@@ -72,6 +175,17 @@ export interface ServerData {
         case2: number;
     };
     processes: Process[];
+    // 아래 필드들은 1.3 에서 추가됐다. 구버전을 돌리는 클러스터 노드도 같은
+    // 대시보드로 읽을 수 있어야 하므로 전부 optional 이다.
+    host?: HostInfo;
+    load?: LoadInfo;
+    swap?: SwapInfo;
+    diskIO?: DiskIoInfo;
+    gpu?: GpuInfo;
+    security?: SecurityInfo;
+    history?: HistoryInfo;
+    alerts?: AlertEntry[];
+    timestamp?: string;
     // 일부 수집기만 실패했을 때 어떤 지표가 왜 비었는지 알려준다.
     // 헤드리스 서버에서 `curl localhost:3000/api/system` 만으로 진단할 수 있게 하는 용도.
     warnings?: string[];

--- a/src/utils/collectors/alerts.ts
+++ b/src/utils/collectors/alerts.ts
@@ -1,0 +1,128 @@
+import { AlertEntry, AlertLevel, FirewallInfo, SshSession, TemperatureValue } from '@/types/system';
+
+const MAX_ENTRIES = 30;
+
+// 임계값을 넘나드는 값 때문에 로그가 도배되지 않도록, 켜지는 값과 꺼지는 값을
+// 다르게 둔다(히스테리시스).
+interface Rule {
+  key: string;
+  level: AlertLevel;
+  enterAbove: number;
+  clearBelow: number;
+  onEnter: (value: number) => string;
+  onClear: (value: number) => string;
+}
+
+const RULES: Rule[] = [
+  {
+    key: 'cpu',
+    level: 'warning',
+    enterAbove: 90,
+    clearBelow: 80,
+    onEnter: value => `CPU usage ${value.toFixed(0)}%`,
+    onClear: () => 'CPU usage back to normal'
+  },
+  {
+    key: 'memory',
+    level: 'warning',
+    enterAbove: 90,
+    clearBelow: 80,
+    onEnter: value => `Memory usage ${value.toFixed(0)}%`,
+    onClear: () => 'Memory usage back to normal'
+  },
+  {
+    key: 'disk',
+    level: 'warning',
+    enterAbove: 85,
+    clearBelow: 80,
+    onEnter: value => `Disk usage crossed ${value.toFixed(0)}%`,
+    onClear: () => 'Disk usage back to normal'
+  },
+  {
+    key: 'temperature',
+    level: 'critical',
+    enterAbove: 74,
+    clearBelow: 70,
+    onEnter: value => `CPU temp ${value.toFixed(1)}°C`,
+    onClear: () => 'CPU temp back to normal'
+  },
+  {
+    key: 'swap',
+    level: 'warning',
+    enterAbove: 80,
+    clearBelow: 60,
+    onEnter: value => `Swap usage ${value.toFixed(0)}%`,
+    onClear: () => 'Swap usage back to normal'
+  }
+];
+
+const active = new Set<string>();
+const log: AlertEntry[] = [];
+let knownSessions: Set<string> | null = null;
+let knownFirewall: FirewallInfo['status'] | null = null;
+let sequence = 0;
+
+function push(level: AlertLevel, message: string, at: number): void {
+  sequence += 1;
+  log.unshift({ id: `${at}-${sequence}`, level, message, at: new Date(at).toISOString() });
+  if (log.length > MAX_ENTRIES) log.length = MAX_ENTRIES;
+}
+
+export interface AlertInput {
+  cpu: number;
+  memory: number;
+  disk: number;
+  swap: number;
+  temperature: TemperatureValue;
+  firewall: FirewallInfo['status'];
+  sshSessions: SshSession[];
+}
+
+export function evaluateAlerts(input: AlertInput, at: number = Date.now()): AlertEntry[] {
+  const values: Record<string, number | null> = {
+    cpu: input.cpu,
+    memory: input.memory,
+    disk: input.disk,
+    swap: input.swap,
+    temperature: input.temperature === 'N/A' ? null : input.temperature
+  };
+
+  for (const rule of RULES) {
+    const value = values[rule.key];
+    if (value === null || Number.isNaN(value)) continue;
+
+    if (!active.has(rule.key) && value > rule.enterAbove) {
+      active.add(rule.key);
+      push(rule.level, rule.onEnter(value), at);
+    } else if (active.has(rule.key) && value < rule.clearBelow) {
+      active.delete(rule.key);
+      push('ok', rule.onClear(value), at);
+    }
+  }
+
+  // 새로 생긴 SSH 세션만 기록한다. 첫 평가에서는 이미 붙어 있던 세션을
+  // 방금 로그인한 것처럼 쏟아내지 않도록 조용히 기억만 해둔다.
+  const sessionKeys = new Set(input.sshSessions.map(s => `${s.user}@${s.ip}@${s.since}`));
+  if (knownSessions === null) {
+    knownSessions = sessionKeys;
+  } else {
+    for (const session of input.sshSessions) {
+      const key = `${session.user}@${session.ip}@${session.since}`;
+      if (!knownSessions.has(key)) push('info', `SSH login: ${session.user}@${session.ip}`, at);
+    }
+    knownSessions = sessionKeys;
+  }
+
+  if (input.firewall !== 'unknown' && input.firewall !== knownFirewall) {
+    if (knownFirewall !== null) {
+      push(
+        input.firewall === 'active' ? 'ok' : 'critical',
+        `Firewall ${input.firewall}`,
+        at
+      );
+    }
+    knownFirewall = input.firewall;
+  }
+
+  return [...log];
+}

--- a/src/utils/collectors/cpu.ts
+++ b/src/utils/collectors/cpu.ts
@@ -1,0 +1,69 @@
+import { readFile } from 'fs/promises';
+
+import { clamp, round } from '@/utils/collectors/shell';
+
+interface CpuTimes {
+  idle: number;
+  total: number;
+}
+
+export interface CpuUsage {
+  total: number;
+  perCore: number[];
+}
+
+// `top -bn1` 의 첫 샘플은 부팅 이후 누적 평균이라 항상 0에 가깝게 나온다.
+// /proc/stat 를 두 번 읽어 그 사이의 변화량으로 계산한다.
+let previousSample: { total: CpuTimes; perCore: CpuTimes[] } | null = null;
+
+function parseCpuLine(line: string): CpuTimes {
+  const values = line.trim().split(/\s+/).slice(1).map(Number);
+  if (values.length < 4 || values.some(Number.isNaN)) {
+    throw new Error(`unparsable /proc/stat cpu line: ${line}`);
+  }
+
+  return {
+    idle: values[3] + (values[4] ?? 0), // idle + iowait
+    total: values.reduce((sum, value) => sum + value, 0)
+  };
+}
+
+async function readCpuStat(): Promise<{ total: CpuTimes; perCore: CpuTimes[] }> {
+  const contents = await readFile('/proc/stat', 'utf-8');
+  const lines = contents.split('\n');
+
+  const aggregate = lines.find(line => line.startsWith('cpu '));
+  if (!aggregate) throw new Error('no "cpu" line in /proc/stat');
+
+  // cpu0, cpu1, ... 은 논리 코어 순서대로 나온다.
+  const perCore = lines.filter(line => /^cpu\d+ /.test(line)).map(parseCpuLine);
+  return { total: parseCpuLine(aggregate), perCore };
+}
+
+function usageBetween(previous: CpuTimes, current: CpuTimes): number {
+  const totalDelta = current.total - previous.total;
+  const idleDelta = current.idle - previous.idle;
+  if (totalDelta <= 0) return 0;
+  return round(clamp((1 - idleDelta / totalDelta) * 100, 0, 100), 1);
+}
+
+export async function getCpuUsage(): Promise<CpuUsage> {
+  let previous = previousSample;
+
+  // 첫 호출이면 짧게 두 번 재서 0% 를 반환하지 않도록 한다.
+  if (!previous) {
+    previous = await readCpuStat();
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+
+  const current = await readCpuStat();
+  previousSample = current;
+
+  // 코어가 오프라인이 되면 개수가 달라질 수 있으므로 짧은 쪽에 맞춘다.
+  const coreCount = Math.min(previous.perCore.length, current.perCore.length);
+  const perCore = Array.from({ length: coreCount }, (_, index) =>
+    usageBetween(previous.perCore[index], current.perCore[index])
+  );
+
+  return { total: usageBetween(previous.total, current.total), perCore };
+}

--- a/src/utils/collectors/diskio.ts
+++ b/src/utils/collectors/diskio.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'fs/promises';
+
+import { DiskIoInfo } from '@/types/system';
+import { round } from '@/utils/collectors/shell';
+
+// 파티션(sda1, nvme0n1p2)까지 세면 같은 I/O 를 두 번 더하게 된다. 전체 디스크만 센다.
+const WHOLE_DISK_PATTERN = /^(sd[a-z]+|nvme\d+n\d+|mmcblk\d+|vd[a-z]+|xvd[a-z]+|hd[a-z]+)$/;
+
+// /proc/diskstats 의 섹터는 장치의 물리 섹터 크기와 무관하게 항상 512 바이트다.
+const SECTOR_BYTES = 512;
+
+let previousSample: { read: number; write: number; at: number } | null = null;
+
+async function readDiskTotals(): Promise<{ read: number; write: number }> {
+  const contents = await readFile('/proc/diskstats', 'utf-8');
+
+  let readSectors = 0;
+  let writeSectors = 0;
+  let matched = 0;
+
+  for (const line of contents.split('\n')) {
+    const fields = line.trim().split(/\s+/);
+    if (fields.length < 10) continue;
+
+    const name = fields[2];
+    if (!WHOLE_DISK_PATTERN.test(name)) continue;
+
+    const read = Number(fields[5]);  // sectors read
+    const written = Number(fields[9]); // sectors written
+    if (Number.isNaN(read) || Number.isNaN(written)) continue;
+
+    readSectors += read;
+    writeSectors += written;
+    matched += 1;
+  }
+
+  if (matched === 0) throw new Error('no whole-disk devices found in /proc/diskstats');
+  return { read: readSectors * SECTOR_BYTES, write: writeSectors * SECTOR_BYTES };
+}
+
+export async function getDiskIo(): Promise<DiskIoInfo> {
+  const totals = await readDiskTotals();
+  const now = Date.now();
+  const previous = previousSample;
+  previousSample = { ...totals, at: now };
+
+  // 첫 샘플은 비교 대상이 없다. 누적 바이트를 그대로 쓰면 수백 MB/s 로 보인다.
+  if (!previous) return { read: 0, write: 0 };
+
+  const elapsedSeconds = (now - previous.at) / 1000;
+  if (elapsedSeconds <= 0) return { read: 0, write: 0 };
+
+  const rate = (current: number, before: number) =>
+    round(Math.max(0, current - before) / 1024 / 1024 / elapsedSeconds, 1);
+
+  return { read: rate(totals.read, previous.read), write: rate(totals.write, previous.write) };
+}

--- a/src/utils/collectors/gpu.ts
+++ b/src/utils/collectors/gpu.ts
@@ -1,0 +1,81 @@
+import { readdir } from 'fs/promises';
+
+import { GpuInfo } from '@/types/system';
+import { clamp, readSys, round, run, withTtl } from '@/utils/collectors/shell';
+
+const UNAVAILABLE: GpuInfo = { name: null, usage: 'N/A', temperature: 'N/A' };
+
+// amdgpu 는 사용률을 sysfs 로 그대로 노출한다. 외부 명령이 필요 없다.
+async function readAmdGpu(): Promise<GpuInfo | null> {
+  let cards: string[];
+  try {
+    cards = (await readdir('/sys/class/drm')).filter(name => /^card\d+$/.test(name));
+  } catch {
+    return null;
+  }
+
+  for (const card of cards) {
+    const busy = await readSys(`/sys/class/drm/${card}/device/gpu_busy_percent`);
+    if (busy === null) continue;
+
+    const usage = parseInt(busy, 10);
+    if (Number.isNaN(usage)) continue;
+
+    return {
+      name: (await readSys(`/sys/class/drm/${card}/device/label`)) ?? 'amdgpu',
+      usage: clamp(usage, 0, 100),
+      temperature: await readAmdTemperature(card)
+    };
+  }
+
+  return null;
+}
+
+async function readAmdTemperature(card: string): Promise<number | 'N/A'> {
+  const base = `/sys/class/drm/${card}/device/hwmon`;
+  let hwmons: string[];
+  try {
+    hwmons = await readdir(base);
+  } catch {
+    return 'N/A';
+  }
+
+  for (const hwmon of hwmons) {
+    const raw = await readSys(`${base}/${hwmon}/temp1_input`);
+    if (raw === null) continue;
+    const milliCelsius = parseInt(raw, 10);
+    if (!Number.isNaN(milliCelsius)) return round(milliCelsius / 1000, 1);
+  }
+  return 'N/A';
+}
+
+// nvidia-smi 는 프로세스를 띄우고 200ms 가까이 걸린다. 매 초 호출하지 않는다.
+const readNvidiaGpu = withTtl(5000, async (): Promise<GpuInfo | null> => {
+  let output: string;
+  try {
+    output = await run(
+      'nvidia-smi --query-gpu=name,utilization.gpu,temperature.gpu --format=csv,noheader,nounits'
+    );
+  } catch {
+    return null; // 드라이버/도구 미설치
+  }
+
+  const [line] = output.split('\n');
+  if (!line) return null;
+
+  const [name, usage, temperature] = line.split(',').map(value => value.trim());
+  const usageValue = parseFloat(usage);
+  const temperatureValue = parseFloat(temperature);
+
+  return {
+    name: name || 'NVIDIA',
+    usage: Number.isNaN(usageValue) ? 'N/A' : clamp(usageValue, 0, 100),
+    temperature: Number.isNaN(temperatureValue) ? 'N/A' : temperatureValue
+  };
+});
+
+export async function getGpuInfo(): Promise<GpuInfo> {
+  // 인텔 내장 그래픽은 커널이 사용률을 퍼센트로 노출하지 않아
+  // (i915 는 perf 이벤트로만 얻을 수 있다) N/A 로 남는다.
+  return (await readAmdGpu()) ?? (await readNvidiaGpu()) ?? UNAVAILABLE;
+}

--- a/src/utils/collectors/history.ts
+++ b/src/utils/collectors/history.ts
@@ -1,0 +1,67 @@
+import { CpuHourSample, HistoryInfo, LoadSample } from '@/types/system';
+import { round } from '@/utils/collectors/shell';
+
+// 히스토리는 프로세스 메모리에만 있다. 서버를 재시작하면 비고, 그 구간은
+// UI 에서 "데이터 없음" 셀로 보인다. 영속화는 이 대시보드의 목적(현재 상태를
+// 벽에 띄우기)에 비해 과하다.
+const LOAD_BUCKET_MS = 15 * 60 * 1000;
+const LOAD_BUCKETS = 48; // 12시간
+const HOUR_BUCKET_MS = 60 * 60 * 1000;
+const HOUR_BUCKETS = 24;
+
+interface Bucket {
+  sum: number;
+  count: number;
+}
+
+const loadBuckets = new Map<number, Bucket>();
+const cpuBuckets = new Map<number, Bucket>();
+
+function add(buckets: Map<number, Bucket>, key: number, value: number): void {
+  const bucket = buckets.get(key);
+  if (bucket) {
+    bucket.sum += value;
+    bucket.count += 1;
+  } else {
+    buckets.set(key, { sum: value, count: 1 });
+  }
+}
+
+function prune(buckets: Map<number, Bucket>, oldestKey: number): void {
+  for (const key of buckets.keys()) {
+    if (key < oldestKey) buckets.delete(key);
+  }
+}
+
+export function recordSample(cpuUsage: number, load1: number, at: number = Date.now()): void {
+  const loadKey = Math.floor(at / LOAD_BUCKET_MS) * LOAD_BUCKET_MS;
+  const hourKey = Math.floor(at / HOUR_BUCKET_MS) * HOUR_BUCKET_MS;
+
+  add(loadBuckets, loadKey, load1);
+  add(cpuBuckets, hourKey, cpuUsage);
+
+  prune(loadBuckets, loadKey - (LOAD_BUCKETS - 1) * LOAD_BUCKET_MS);
+  prune(cpuBuckets, hourKey - (HOUR_BUCKETS - 1) * HOUR_BUCKET_MS);
+}
+
+function series(buckets: Map<number, Bucket>, bucketMs: number, count: number, now: number, digits: number) {
+  const newestKey = Math.floor(now / bucketMs) * bucketMs;
+  return Array.from({ length: count }, (_, index) => {
+    const key = newestKey - (count - 1 - index) * bucketMs;
+    const bucket = buckets.get(key);
+    return {
+      at: new Date(key).toISOString(),
+      value: bucket ? round(bucket.sum / bucket.count, digits) : null
+    };
+  });
+}
+
+export function getHistory(now: number = Date.now()): HistoryInfo {
+  const load: LoadSample[] = series(loadBuckets, LOAD_BUCKET_MS, LOAD_BUCKETS, now, 2).map(
+    ({ at, value }) => ({ at, avg1: value })
+  );
+  const cpuHourly: CpuHourSample[] = series(cpuBuckets, HOUR_BUCKET_MS, HOUR_BUCKETS, now, 1).map(
+    ({ at, value }) => ({ at, usage: value })
+  );
+  return { load, cpuHourly };
+}

--- a/src/utils/collectors/host.ts
+++ b/src/utils/collectors/host.ts
@@ -1,0 +1,58 @@
+import os from 'os';
+
+import { HostInfo } from '@/types/system';
+import { readSys, run, withTtl } from '@/utils/collectors/shell';
+
+function parseOsRelease(contents: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const line of contents.split('\n')) {
+    const match = line.match(/^([A-Z_]+)=(.*)$/);
+    if (!match) continue;
+    fields[match[1]] = match[2].replace(/^"(.*)"$/, '$1');
+  }
+  return fields;
+}
+
+// 배포판 이름은 부팅 중에 바뀌지 않는다. 한 번 읽으면 충분하다.
+const readDistro = withTtl(60 * 60 * 1000, async (): Promise<string> => {
+  const contents = (await readSys('/etc/os-release')) ?? (await readSys('/usr/lib/os-release'));
+  if (!contents) return `${os.type()} ${os.release()}`;
+
+  const fields = parseOsRelease(contents);
+  // PRETTY_NAME 은 "Ubuntu 22.04.4 LTS" 처럼 길어서 좁은 헤더에 안 들어간다.
+  // NAME + VERSION_ID 조합("Ubuntu 22.04")이 더 짧고 정보량은 같다.
+  if (fields.NAME && fields.VERSION_ID) return `${fields.NAME} ${fields.VERSION_ID}`;
+  return fields.PRETTY_NAME || fields.NAME || `${os.type()} ${os.release()}`;
+});
+
+// wtmp 를 뒤져 마지막 재부팅 직전에 정상 종료(shutdown) 기록이 있었는지 본다.
+// 있으면 계획된 재부팅, 없으면 커널 패닉/정전처럼 예기치 못한 종료다.
+const readRebootReason = withTtl(5 * 60 * 1000, async (): Promise<string | null> => {
+  let output: string;
+  try {
+    output = await run('last -x -F -n 20 reboot shutdown 2>/dev/null || true');
+  } catch {
+    return null; // last 미설치(busybox 등) 또는 wtmp 권한 없음
+  }
+
+  const lines = output.split('\n').map(line => line.trim()).filter(Boolean);
+  const rebootIndex = lines.findIndex(line => line.startsWith('reboot'));
+  if (rebootIndex === -1) return null;
+
+  const previous = lines[rebootIndex + 1];
+  if (!previous) return null;
+  return previous.startsWith('shutdown') ? 'clean shutdown' : 'unexpected shutdown';
+});
+
+export async function getHostInfo(): Promise<HostInfo> {
+  const [distro, rebootReason] = await Promise.all([readDistro(), readRebootReason()]);
+
+  return {
+    hostname: os.hostname(),
+    os: distro,
+    kernel: os.release(),
+    arch: os.arch(),
+    bootTime: new Date(Date.now() - os.uptime() * 1000).toISOString(),
+    rebootReason
+  };
+}

--- a/src/utils/collectors/load.ts
+++ b/src/utils/collectors/load.ts
@@ -1,0 +1,33 @@
+import os from 'os';
+import { readFile } from 'fs/promises';
+
+import { LoadInfo, SwapInfo } from '@/types/system';
+import { round } from '@/utils/collectors/shell';
+
+export function getLoadAverage(): LoadInfo {
+  // os.loadavg() 는 /proc/loadavg 를 읽는 것과 같지만 파싱이 필요 없다.
+  const [avg1, avg5, avg15] = os.loadavg();
+  return { avg1: round(avg1), avg5: round(avg5), avg15: round(avg15) };
+}
+
+export async function getSwapInfo(): Promise<SwapInfo> {
+  const contents = await readFile('/proc/meminfo', 'utf-8');
+  const field = (key: string) => {
+    const match = contents.match(new RegExp(`^${key}:\\s+(\\d+) kB`, 'm'));
+    return match ? parseInt(match[1], 10) : null;
+  };
+
+  const totalKb = field('SwapTotal');
+  if (totalKb === null) throw new Error('SwapTotal missing from /proc/meminfo');
+
+  const freeKb = field('SwapFree') ?? 0;
+  const usedKb = Math.max(0, totalKb - freeKb);
+  const toGb = (kb: number) => round(kb / 1024 / 1024);
+
+  return {
+    used: toGb(usedKb),
+    total: toGb(totalKb),
+    // 스왑이 없는 서버(총량 0)는 0% 로 둔다. 0/0 은 NaN 이 되어 UI 를 깨뜨린다.
+    percentage: totalKb > 0 ? round((usedKb / totalKb) * 100, 1) : 0
+  };
+}

--- a/src/utils/collectors/netstat.ts
+++ b/src/utils/collectors/netstat.ts
@@ -1,0 +1,265 @@
+import os from 'os';
+import { readFile, readdir } from 'fs/promises';
+
+import { NetworkInterfaceInfo, TrafficPeer } from '@/types/system';
+import { readSys } from '@/utils/collectors/shell';
+
+// Linux network interface names are restricted to this charset (see netdevice(7)).
+// Validating against it before touching sysfs paths keeps a value derived from
+// command output from ever being treated as a path traversal.
+export const INTERFACE_NAME_PATTERN = /^[a-zA-Z0-9@.:_-]+$/;
+
+const TCP_ESTABLISHED = '01';
+const TCP_LISTEN = '0A';
+
+// --- /proc/net/tcp 파싱 ---------------------------------------------------
+
+// sysfs 의 주소는 4바이트 워드 단위 리틀엔디언 16진수다. "0100007F" 는 127.0.0.1.
+function hexToIpv4(hex: string): string {
+  const bytes = hex.match(/../g);
+  if (!bytes || bytes.length !== 4) return '0.0.0.0';
+  return bytes.reverse().map(byte => parseInt(byte, 16)).join('.');
+}
+
+function hexToIpv6(hex: string): string {
+  const words = hex.match(/.{8}/g);
+  if (!words || words.length !== 4) return '::';
+
+  // 각 32비트 워드가 개별적으로 리틀엔디언이라 워드 안에서만 바이트를 뒤집는다.
+  const bytes = words.flatMap(word => (word.match(/../g) ?? []).reverse().map(b => parseInt(b, 16)));
+  if (bytes.length !== 16) return '::';
+
+  // IPv4-mapped(::ffff:a.b.c.d)는 IPv4 로 보여주는 편이 읽기 쉽다.
+  const isMapped = bytes.slice(0, 10).every(b => b === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
+  if (isMapped) return bytes.slice(12).join('.');
+
+  const groups: string[] = [];
+  for (let i = 0; i < 16; i += 2) {
+    groups.push(((bytes[i] << 8) | bytes[i + 1]).toString(16));
+  }
+
+  // 가장 긴 0 구간 하나를 "::" 로 줄인다 (RFC 5952).
+  let bestStart = -1;
+  let bestLength = 0;
+  let start = -1;
+  for (let i = 0; i <= groups.length; i += 1) {
+    if (i < groups.length && groups[i] === '0') {
+      if (start === -1) start = i;
+    } else if (start !== -1) {
+      if (i - start > bestLength) {
+        bestStart = start;
+        bestLength = i - start;
+      }
+      start = -1;
+    }
+  }
+
+  if (bestLength < 2) return groups.join(':');
+  return `${groups.slice(0, bestStart).join(':')}::${groups.slice(bestStart + bestLength).join(':')}`;
+}
+
+interface Socket {
+  localPort: number;
+  remoteIp: string;
+  state: string;
+}
+
+async function readSockets(path: string, ipv6: boolean): Promise<Socket[]> {
+  let contents: string;
+  try {
+    contents = await readFile(path, 'utf-8');
+  } catch {
+    return []; // tcp6 는 IPv6 가 꺼진 커널에 없다
+  }
+
+  const sockets: Socket[] = [];
+  for (const line of contents.split('\n').slice(1)) {
+    const fields = line.trim().split(/\s+/);
+    if (fields.length < 4) continue;
+
+    const [, localPortHex] = fields[1].split(':');
+    const [remoteHex] = fields[2].split(':');
+    if (!localPortHex || !remoteHex) continue;
+
+    sockets.push({
+      localPort: parseInt(localPortHex, 16),
+      remoteIp: ipv6 ? hexToIpv6(remoteHex) : hexToIpv4(remoteHex),
+      state: fields[3]
+    });
+  }
+  return sockets;
+}
+
+async function readAllSockets(): Promise<Socket[]> {
+  const [v4, v6] = await Promise.all([
+    readSockets('/proc/net/tcp', false),
+    readSockets('/proc/net/tcp6', true)
+  ]);
+  return [...v4, ...v6];
+}
+
+export interface SocketSummary {
+  connections: number;
+  listeningPorts: number;
+  peers: Map<string, number>;
+}
+
+export async function getSocketSummary(): Promise<SocketSummary> {
+  const sockets = await readAllSockets();
+
+  const listening = new Set<number>();
+  const peers = new Map<string, number>();
+  let connections = 0;
+
+  for (const socket of sockets) {
+    if (socket.state === TCP_LISTEN) {
+      listening.add(socket.localPort);
+      continue;
+    }
+    if (socket.state !== TCP_ESTABLISHED) continue;
+
+    connections += 1;
+    // 로컬 프로세스끼리의 연결(127.0.0.1)은 "누가 트래픽을 쓰는가" 관점에서 잡음이다.
+    if (isLoopback(socket.remoteIp)) continue;
+    peers.set(socket.remoteIp, (peers.get(socket.remoteIp) ?? 0) + 1);
+  }
+
+  return { connections, listeningPorts: listening.size, peers };
+}
+
+function isLoopback(ip: string): boolean {
+  return ip.startsWith('127.') || ip === '::1' || ip === '0.0.0.0' || ip === '::';
+}
+
+// --- 인터페이스 ------------------------------------------------------------
+
+// `ip route` 는 /usr/sbin 에 있어 서비스 PATH 에서 빠지기 쉽다.
+// /proc/net/route 를 직접 읽으면 외부 바이너리가 전혀 필요 없다.
+export async function getDefaultInterface(): Promise<string> {
+  const contents = await readFile('/proc/net/route', 'utf-8');
+  const lines = contents.split('\n').slice(1);
+
+  for (const line of lines) {
+    const [iface, destination] = line.trim().split(/\s+/);
+    if (destination === '00000000' && iface && INTERFACE_NAME_PATTERN.test(iface)) {
+      return iface;
+    }
+  }
+
+  // 기본 경로가 없으면(컨테이너 등) 트래픽이 가장 많은 물리 인터페이스로 대체한다.
+  const candidates = await listInterfaceNames();
+  let best = '';
+  let bestBytes = -1;
+  for (const name of candidates) {
+    const bytes = await readInterfaceStat(name, 'rx_bytes');
+    if (bytes > bestBytes) {
+      best = name;
+      bestBytes = bytes;
+    }
+  }
+
+  if (!best) throw new Error('no usable network interface found');
+  return best;
+}
+
+async function listInterfaceNames(): Promise<string[]> {
+  return (await readdir('/sys/class/net')).filter(
+    name => name !== 'lo' && INTERFACE_NAME_PATTERN.test(name)
+  );
+}
+
+export async function readInterfaceStat(interfaceName: string, stat: string): Promise<number> {
+  const contents = await readSys(`/sys/class/net/${interfaceName}/statistics/${stat}`);
+  const value = contents === null ? NaN : parseInt(contents, 10);
+  return Number.isNaN(value) ? 0 : value;
+}
+
+async function readLinkSpeed(interfaceName: string): Promise<number | null> {
+  // 가상/무선 장치는 speed 파일이 없거나 읽으면 EINVAL 이고, 링크가 내려가 있으면 -1 이다.
+  const raw = await readSys(`/sys/class/net/${interfaceName}/speed`);
+  if (raw === null) return null;
+  const speed = parseInt(raw, 10);
+  return Number.isNaN(speed) || speed <= 0 ? null : speed;
+}
+
+export async function getInterfaces(defaultInterface: string): Promise<NetworkInterfaceInfo[]> {
+  const names = await listInterfaceNames();
+  const addresses = os.networkInterfaces();
+
+  const interfaces = await Promise.all(
+    names.map(async (name): Promise<NetworkInterfaceInfo> => {
+      const operstate = (await readSys(`/sys/class/net/${name}/operstate`)) ?? 'unknown';
+      const ipv4 = addresses[name]?.find(entry => entry.family === 'IPv4' && !entry.internal);
+
+      return {
+        name,
+        ip: ipv4?.address ?? null,
+        speedMbps: await readLinkSpeed(name),
+        state: operstate === 'up' ? 'up' : operstate === 'down' ? 'down' : 'unknown',
+        isDefault: name === defaultInterface
+      };
+    })
+  );
+
+  // 기본 경로를 쓰는 인터페이스가 맨 위, 그다음 링크가 올라온 것들 순.
+  return interfaces.sort((a, b) => {
+    if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+    if ((a.state === 'up') !== (b.state === 'up')) return a.state === 'up' ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+// --- 상위 트래픽 피어 ------------------------------------------------------
+
+function localAddresses(): Set<string> {
+  const addresses = new Set<string>();
+  for (const entries of Object.values(os.networkInterfaces())) {
+    for (const entry of entries ?? []) addresses.add(entry.address);
+  }
+  return addresses;
+}
+
+// conntrack 은 커널이 이미 세고 있는 연결별 바이트 수를 준다.
+// 단 net.netfilter.nf_conntrack_acct=1 일 때만 bytes= 필드가 붙는다.
+async function readConntrackBytes(): Promise<Map<string, number> | null> {
+  let contents: string;
+  try {
+    contents = await readFile('/proc/net/nf_conntrack', 'utf-8');
+  } catch {
+    return null; // conntrack 모듈이 없거나 읽을 권한이 없다
+  }
+
+  const locals = localAddresses();
+  const totals = new Map<string, number>();
+
+  for (const line of contents.split('\n')) {
+    if (!line.includes('bytes=')) return null; // 바이트 계정이 꺼져 있다
+    const bytes = [...line.matchAll(/bytes=(\d+)/g)].reduce((sum, m) => sum + Number(m[1]), 0);
+    const addresses = [...line.matchAll(/(?:src|dst)=([0-9a-fA-F.:]+)/g)].map(m => m[1]);
+
+    // 튜플 양쪽 중 우리 주소가 아닌 쪽이 상대 피어다.
+    const peer = addresses.find(address => !locals.has(address) && !isLoopback(address));
+    if (!peer) continue;
+
+    totals.set(peer, (totals.get(peer) ?? 0) + bytes);
+  }
+
+  return totals.size > 0 ? totals : null;
+}
+
+export async function getTopTraffic(peers: Map<string, number>, limit = 4): Promise<TrafficPeer[]> {
+  const byBytes = await readConntrackBytes();
+
+  if (byBytes) {
+    return [...byBytes.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([ip, bytes]) => ({ ip, bytes, connections: peers.get(ip) ?? 0 }));
+  }
+
+  // conntrack 을 못 쓰면 열려 있는 연결 수로 순위를 매긴다. 바이트는 알 수 없다.
+  return [...peers.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([ip, connections]) => ({ ip, bytes: null, connections }));
+}

--- a/src/utils/collectors/security.ts
+++ b/src/utils/collectors/security.ts
@@ -1,0 +1,86 @@
+import { FirewallInfo, SshSession } from '@/types/system';
+import { readSys, run, withTtl } from '@/utils/collectors/shell';
+
+// --- SSH 세션 --------------------------------------------------------------
+
+// `who` 는 utmp 를 읽는다. 원격 로그인이면 마지막 괄호 안에 접속지가 붙는다.
+//   deploy   pts/1        2024-07-20 14:35 (192.168.0.5)
+const WHO_LINE = /^(\S+)\s+\S+\s+(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})(?::\d{2})?\s*(?:\((.*)\))?/;
+
+export const getSshSessions = withTtl(15_000, async (): Promise<SshSession[]> => {
+  const output = await run('who 2>/dev/null || true');
+  if (!output) return [];
+
+  const sessions: SshSession[] = [];
+  for (const line of output.split('\n')) {
+    const match = line.match(WHO_LINE);
+    if (!match) continue;
+
+    const [, user, date, time, host] = match;
+    // 접속지가 없으면 물리 콘솔/로컬 tty 라 SSH 세션이 아니다.
+    if (!host) continue;
+
+    const since = new Date(`${date}T${time}`);
+    sessions.push({
+      user,
+      ip: host,
+      since: Number.isNaN(since.getTime()) ? new Date().toISOString() : since.toISOString()
+    });
+  }
+
+  // 최근 접속이 위로.
+  return sessions.sort((a, b) => b.since.localeCompare(a.since));
+});
+
+// --- 방화벽 ----------------------------------------------------------------
+
+async function isServiceActive(name: string): Promise<boolean> {
+  // systemctl is-active 는 비활성일 때 종료 코드가 3 이라 `|| true` 가 필요하다.
+  const output = await run(`systemctl is-active ${name} 2>/dev/null || true`);
+  return output === 'active';
+}
+
+async function detectFirewall(): Promise<{ status: FirewallInfo['status']; backend: string | null }> {
+  // ufw status 는 root 를 요구하지만, 설정 파일은 보통 누구나 읽을 수 있다.
+  const ufwConf = await readSys('/etc/ufw/ufw.conf');
+  if (ufwConf !== null) {
+    const enabled = /^ENABLED=yes$/im.test(ufwConf);
+    return { status: enabled ? 'active' : 'inactive', backend: 'ufw' };
+  }
+
+  for (const service of ['firewalld', 'nftables', 'iptables']) {
+    try {
+      if (await isServiceActive(service)) return { status: 'active', backend: service };
+    } catch {
+      // systemctl 이 없는 환경(컨테이너 등). 다음 후보로 넘어간다.
+    }
+  }
+
+  return { status: 'unknown', backend: null };
+}
+
+// 커널 로그 한 번 훑는 비용이 크므로 1분에 한 번만 센다.
+const countBlockedAttempts = withTtl(60_000, async (): Promise<number | null> => {
+  let output: string;
+  try {
+    // NR 이 0 이면 저널을 읽을 권한이 없다는 뜻이라, "차단 0건" 과 구분한다.
+    output = await run(
+      `journalctl -k --since=-24h --no-pager 2>/dev/null | awk '/UFW BLOCK|nft.*drop|DPT=.*DROP/ {c++} END {print NR" "(c+0)}'`,
+      10_000
+    );
+  } catch {
+    return null;
+  }
+
+  const [lines, blocked] = output.split(/\s+/).map(Number);
+  if (!lines || Number.isNaN(blocked)) return null;
+  return blocked;
+});
+
+export const getFirewallInfo = withTtl(30_000, async (): Promise<FirewallInfo> => {
+  const [{ status, backend }, blockedAttempts] = await Promise.all([
+    detectFirewall(),
+    countBlockedAttempts()
+  ]);
+  return { status, backend, blockedAttempts };
+});

--- a/src/utils/collectors/shell.ts
+++ b/src/utils/collectors/shell.ts
@@ -1,0 +1,80 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { readFile } from 'fs/promises';
+
+const execAsync = promisify(exec);
+
+// `ip`, `sensors`, `ps` 등은 /usr/sbin, /sbin 에 설치되는 경우가 많은데
+// 비-root 사용자로 뜬 systemd/pm2 서비스의 PATH 에는 그 경로가 빠져 있다.
+// 그래서 명령이 "not found" 로 끝나고, 지표가 통째로 0 이 된다.
+export const EXEC_ENV = {
+  ...process.env,
+  PATH: [process.env.PATH, '/usr/local/sbin', '/usr/sbin', '/sbin'].filter(Boolean).join(':'),
+  LC_ALL: 'C', // 로케일에 따라 소수점이 ','가 되면 parseFloat가 잘라먹는다
+  LANG: 'C'
+};
+
+export async function run(command: string, timeout = 5000): Promise<string> {
+  const { stdout } = await execAsync(command, { env: EXEC_ENV, timeout });
+  return stdout.trim();
+}
+
+export async function readSys(filePath: string): Promise<string | null> {
+  try {
+    return (await readFile(filePath, 'utf-8')).trim();
+  } catch {
+    return null;
+  }
+}
+
+// 수집기 하나가 실패해도 나머지 지표는 살려 보낸다.
+export async function collect<T>(
+  name: string,
+  fn: () => Promise<T>,
+  fallback: T,
+  warnings: string[]
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`${name}: ${message}`);
+    console.warn(`[systemMonitor] ${name} failed:`, message);
+    return fallback;
+  }
+}
+
+// 대시보드는 1초마다 폴링한다. `who`, `last`, `nvidia-smi` 처럼 프로세스를
+// 띄우는 수집기까지 매 초 돌리면 측정 대상 서버가 더 바빠지므로,
+// 잘 변하지 않는 값은 TTL 동안 캐시해서 재사용한다.
+export function withTtl<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
+  let value: T;
+  let expiresAt = 0;
+  let inflight: Promise<T> | null = null;
+
+  return async () => {
+    if (expiresAt > Date.now()) return value;
+    // 같은 틱에 여러 수집기가 부르더라도 프로세스는 한 번만 띄운다.
+    if (inflight) return inflight;
+
+    inflight = fn()
+      .then(result => {
+        value = result;
+        expiresAt = Date.now() + ttlMs;
+        return result;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+
+    return inflight;
+  };
+}
+
+export function clamp(value: number, low: number, high: number): number {
+  return Math.max(low, Math.min(high, value));
+}
+
+export function round(value: number, digits = 2): number {
+  return parseFloat(value.toFixed(digits));
+}

--- a/src/utils/dashboardData.ts
+++ b/src/utils/dashboardData.ts
@@ -1,0 +1,106 @@
+import {
+  AlertEntry,
+  HistoryInfo,
+  HostInfo,
+  LoadInfo,
+  NetworkInterfaceInfo,
+  Process,
+  SecurityInfo,
+  ServerData,
+  SwapInfo,
+  DiskIoInfo,
+  GpuInfo,
+  TemperatureInfo,
+  TemperatureValue
+} from '@/types/system';
+
+// API 의 새 필드들은 전부 optional 이다(구버전 노드 호환). 컴포넌트마다
+// `?? 0` 을 흩뿌리는 대신, 화면에 넘기기 직전 한 번만 기본값을 채운다.
+export interface DashboardData {
+  cpu: {
+    usage: number;
+    cores: number;
+    temperature: TemperatureValue;
+    perCore: number[];
+  };
+  memory: { used: number; total: number; percentage: number };
+  disk: { used: number; total: number; percentage: number };
+  swap: SwapInfo;
+  diskIO: DiskIoInfo;
+  gpu: GpuInfo;
+  network: {
+    download: number;
+    upload: number;
+    ping: number;
+    errorRates: { rx: string; tx: string };
+    connections: number;
+    listeningPorts: number;
+    interfaces: NetworkInterfaceInfo[];
+    linkSpeedMbps: number | null;
+    bandwidthPercentage: number;
+  };
+  uptime: { days: number; hours: number; minutes: number };
+  temperature: TemperatureInfo;
+  fan: { cpu: number; case1: number; case2: number };
+  processes: Process[];
+  host: HostInfo;
+  load: LoadInfo;
+  security: SecurityInfo;
+  history: HistoryInfo;
+  alerts: AlertEntry[];
+  timestamp: string;
+  warnings: string[];
+}
+
+const EMPTY_HISTORY: HistoryInfo = { load: [], cpuHourly: [] };
+
+const EMPTY_SECURITY: SecurityInfo = {
+  firewall: { status: 'unknown', backend: null, blockedAttempts: null },
+  sshSessions: [],
+  topTraffic: []
+};
+
+export function toDashboardData(raw: ServerData): DashboardData {
+  return {
+    cpu: {
+      usage: raw.cpu.usage,
+      cores: raw.cpu.cores,
+      temperature: raw.cpu.temperature,
+      perCore: raw.cpu.perCore ?? []
+    },
+    memory: raw.memory,
+    disk: raw.disk,
+    swap: raw.swap ?? { used: 0, total: 0, percentage: 0 },
+    diskIO: raw.diskIO ?? { read: 0, write: 0 },
+    gpu: raw.gpu ?? { name: null, usage: 'N/A', temperature: 'N/A' },
+    network: {
+      download: raw.network.download,
+      upload: raw.network.upload,
+      ping: raw.network.ping,
+      errorRates: raw.network.errorRates,
+      connections: raw.network.connections ?? 0,
+      listeningPorts: raw.network.listeningPorts ?? 0,
+      interfaces: raw.network.interfaces ?? [],
+      linkSpeedMbps: raw.network.linkSpeedMbps ?? null,
+      bandwidthPercentage: raw.network.bandwidthPercentage ?? 0
+    },
+    uptime: raw.uptime,
+    temperature: raw.temperature,
+    fan: raw.fan,
+    processes: raw.processes,
+    host: raw.host ?? {
+      hostname: '—',
+      os: 'unknown',
+      kernel: '—',
+      arch: '—',
+      bootTime: new Date().toISOString(),
+      rebootReason: null
+    },
+    load: raw.load ?? { avg1: 0, avg5: 0, avg15: 0 },
+    security: raw.security ?? EMPTY_SECURITY,
+    history: raw.history ?? EMPTY_HISTORY,
+    alerts: raw.alerts ?? [],
+    timestamp: raw.timestamp ?? new Date().toISOString(),
+    warnings: raw.warnings ?? []
+  };
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,70 @@
+// 대시보드 표기 전용 포맷터. 수집기는 항상 같은 단위(네트워크는 KB/s, 디스크는 GB)로
+// 보내고, 사람이 읽기 좋은 단위 변환은 전부 여기서 한다.
+
+export function formatRate(kbPerSecond: number): string {
+  if (!Number.isFinite(kbPerSecond)) return '0 KB/s';
+  if (kbPerSecond >= 1024) return `${(kbPerSecond / 1024).toFixed(2)} MB/s`;
+  return `${kbPerSecond.toFixed(kbPerSecond >= 10 ? 0 : 1)} KB/s`;
+}
+
+// 축 눈금처럼 단위를 따로 붙여야 할 때 쓴다.
+export function rateUnit(maxKbPerSecond: number): { unit: string; divisor: number } {
+  return maxKbPerSecond >= 1024 ? { unit: 'MB/s', divisor: 1024 } : { unit: 'KB/s', divisor: 1 };
+}
+
+export function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value.toFixed(value >= 100 || index === 0 ? 0 : 1)}${units[index]}`;
+}
+
+export function formatRelativeTime(iso: string, now: number): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '—';
+
+  const seconds = Math.max(0, Math.round((now - then) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+export function formatClock(date: Date): string {
+  const day = date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  const time = date.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  });
+  return `${day} ${time}`;
+}
+
+// "07-20 14:32" — 좁은 카드에 넣기 위해 연도는 뺀다.
+export function formatShortDateTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+// 커널 릴리스는 "5.15.0-101-generic" 처럼 길다. 헤더에는 버전만 남긴다.
+export function shortKernel(release: string): string {
+  return release.split('-')[0];
+}
+
+export function formatLinkSpeed(mbps: number | null): string {
+  if (mbps === null) return 'unknown link speed';
+  return mbps >= 1000 ? `${mbps / 1000}Gbps link` : `${mbps}Mbps link`;
+}

--- a/src/utils/statusColors.ts
+++ b/src/utils/statusColors.ts
@@ -1,0 +1,49 @@
+// 대시보드 전체가 같은 기준으로 색을 고르도록 한곳에 모아둔다.
+
+export const COLORS = {
+  ok: '#10b981',
+  warn: '#f59e0b',
+  critical: '#ef4444',
+  idle: '#374151',
+  empty: '#111827',
+  muted: '#6b7280'
+} as const;
+
+export function statusColor(percentage: number): string {
+  if (percentage < 50) return COLORS.ok;
+  if (percentage < 80) return COLORS.warn;
+  return COLORS.critical;
+}
+
+export function tempColor(temperature: number | 'N/A'): string {
+  if (temperature === 'N/A') return '#9ca3af';
+  if (temperature <= 50) return '#4ade80';
+  if (temperature <= 65) return '#facc15';
+  if (temperature <= 74) return '#fb923c';
+  return '#f87171';
+}
+
+// 로드는 코어 수로 나눠야 의미가 있다. 4코어의 4.0 과 1코어의 4.0 은 다르다.
+export function loadColor(load: number, cores: number): string {
+  const perCore = cores > 0 ? load / cores : load;
+  if (perCore < 0.7) return '#4ade80';
+  if (perCore < 1) return '#facc15';
+  return '#f87171';
+}
+
+// GitHub 잔디와 같은 4단계. 값이 없는 구간은 배경색으로 비워 둔다.
+export function loadCellColor(load: number | null, cores: number): string {
+  if (load === null) return COLORS.empty;
+  const perCore = cores > 0 ? load / cores : load;
+  if (perCore < 0.3) return '#0e4429';
+  if (perCore < 0.6) return '#006d32';
+  if (perCore < 0.9) return '#26a641';
+  return '#39d353';
+}
+
+export const ALERT_LEVEL_COLORS: Record<string, string> = {
+  ok: '#4ade80',
+  info: '#60a5fa',
+  warning: '#facc15',
+  critical: '#f87171'
+};

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -1,56 +1,43 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import os from 'os';
 import { readFile, readdir } from 'fs/promises';
 
-import { ServerData, Process, X86TemperatureInfo, ARMTemperatureInfo, TemperatureInfo, TemperatureValue } from '@/types/system';
-
-const execFile = promisify(exec);
+import {
+  ServerData,
+  Process,
+  X86TemperatureInfo,
+  ARMTemperatureInfo,
+  TemperatureInfo,
+  TemperatureValue,
+  SecurityInfo
+} from '@/types/system';
+import { collect, readSys, round, run } from '@/utils/collectors/shell';
+import { getCpuUsage } from '@/utils/collectors/cpu';
+import { getHostInfo } from '@/utils/collectors/host';
+import { getLoadAverage, getSwapInfo } from '@/utils/collectors/load';
+import { getDiskIo } from '@/utils/collectors/diskio';
+import { getGpuInfo } from '@/utils/collectors/gpu';
+import {
+  getDefaultInterface,
+  getInterfaces,
+  getSocketSummary,
+  getTopTraffic,
+  readInterfaceStat,
+  SocketSummary
+} from '@/utils/collectors/netstat';
+import { getFirewallInfo, getSshSessions } from '@/utils/collectors/security';
+import { getHistory, recordSample } from '@/utils/collectors/history';
+import { evaluateAlerts } from '@/utils/collectors/alerts';
 
 // 캐시된 시스템 정보
 let cachedData: ServerData | null = null;
 let lastUpdateTime = 0;
 const UPDATE_INTERVAL = 1000; // 1초마다 업데이트
 
-// `ip`, `sensors`, `ps` 등은 /usr/sbin, /sbin 에 설치되는 경우가 많은데
-// 비-root 사용자로 뜬 systemd/pm2 서비스의 PATH 에는 그 경로가 빠져 있다.
-// 그래서 명령이 "not found" 로 끝나고, 지표가 통째로 0 이 된다.
-const EXEC_ENV = {
-  ...process.env,
-  PATH: [process.env.PATH, '/usr/local/sbin', '/usr/sbin', '/sbin'].filter(Boolean).join(':'),
-  LC_ALL: 'C', // 로케일에 따라 소수점이 ','가 되면 parseFloat가 잘라먹는다
-  LANG: 'C'
-};
-
-async function run(command: string): Promise<string> {
-  const { stdout } = await execFile(command, { env: EXEC_ENV, timeout: 5000 });
-  return stdout.trim();
-}
-
-async function readSys(filePath: string): Promise<string | null> {
-  try {
-    return (await readFile(filePath, 'utf-8')).trim();
-  } catch {
-    return null;
-  }
-}
-
-// 수집기 하나가 실패해도 나머지 지표는 살려 보낸다.
-async function collect<T>(name: string, fn: () => Promise<T>, fallback: T, warnings: string[]): Promise<T> {
-  try {
-    return await fn();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    warnings.push(`${name}: ${message}`);
-    console.warn(`[systemMonitor] ${name} failed:`, message);
-    return fallback;
-  }
-}
-
 interface CpuInfo {
   usage: number;
   cores: number;
   temperature: number | 'N/A';
+  perCore: number[];
 }
 
 interface MemoryInfo {
@@ -73,6 +60,11 @@ interface NetworkInfo {
     rx: string;
     tx: string;
   };
+  connections: number;
+  listeningPorts: number;
+  interfaces: ServerData['network']['interfaces'];
+  linkSpeedMbps: number | null;
+  bandwidthPercentage: number;
 }
 
 interface FanInfo {
@@ -96,52 +88,13 @@ function getArchitecture(): 'x86' | 'arm' | 'unknown' {
 
 // --- CPU ---------------------------------------------------------------
 
-// `top -bn1` 의 첫 샘플은 부팅 이후 누적 평균이라 항상 0에 가깝게 나온다.
-// /proc/stat 를 두 번 읽어 그 사이의 변화량으로 계산한다.
-let prevCpuStat: { idle: number; total: number } | null = null;
-
-async function readCpuStat(): Promise<{ idle: number; total: number }> {
-  const contents = await readFile('/proc/stat', 'utf-8');
-  const line = contents.split('\n').find(l => l.startsWith('cpu '));
-  if (!line) throw new Error('no "cpu" line in /proc/stat');
-
-  const values = line.trim().split(/\s+/).slice(1).map(Number);
-  if (values.length < 4 || values.some(Number.isNaN)) {
-    throw new Error(`unparsable /proc/stat cpu line: ${line}`);
-  }
-
-  const idle = values[3] + (values[4] ?? 0); // idle + iowait
-  const total = values.reduce((sum, value) => sum + value, 0);
-  return { idle, total };
-}
-
-async function getCpuUsage(): Promise<number> {
-  let previous = prevCpuStat;
-
-  // 첫 호출이면 짧게 두 번 재서 0% 를 반환하지 않도록 한다.
-  if (!previous) {
-    previous = await readCpuStat();
-    await new Promise(resolve => setTimeout(resolve, 200));
-  }
-
-  const current = await readCpuStat();
-  prevCpuStat = current;
-
-  const totalDelta = current.total - previous.total;
-  const idleDelta = current.idle - previous.idle;
-  if (totalDelta <= 0) return 0;
-
-  const usage = (1 - idleDelta / totalDelta) * 100;
-  return parseFloat(Math.min(100, Math.max(0, usage)).toFixed(1));
-}
-
 async function getCpuInfo(warnings: string[]): Promise<CpuInfo> {
   const [usage, temperature] = await Promise.all([
-    collect('cpu.usage', getCpuUsage, 0, warnings),
+    collect('cpu.usage', getCpuUsage, { total: 0, perCore: [] }, warnings),
     collect<number | 'N/A'>('cpu.temperature', getCpuTemperature, 'N/A', warnings)
   ]);
 
-  return { usage, cores: os.cpus().length, temperature };
+  return { usage: usage.total, perCore: usage.perCore, cores: os.cpus().length, temperature };
 }
 
 // --- Memory ------------------------------------------------------------
@@ -164,7 +117,7 @@ async function getMemoryInfo(): Promise<MemoryInfo> {
   return {
     used: Math.round(usedKb / 1024),
     total: Math.round(totalKb / 1024),
-    percentage: parseFloat(((usedKb / totalKb) * 100).toFixed(1))
+    percentage: round((usedKb / totalKb) * 100, 1)
   };
 }
 
@@ -183,59 +136,17 @@ async function getDiskInfo(): Promise<DiskInfo> {
     throw new Error(`unparsable df output: ${line}`);
   }
 
-  const toGb = (kb: number) => parseFloat((kb / 1024 / 1024).toFixed(2));
+  const toGb = (kb: number) => round(kb / 1024 / 1024);
   return {
     used: toGb(used),
     total: toGb(total),
-    percentage: parseInt(percentage.replace('%', ''), 10) || parseFloat(((used / total) * 100).toFixed(1))
+    percentage: parseInt(percentage.replace('%', ''), 10) || round((used / total) * 100, 1)
   };
 }
 
 // --- Network -----------------------------------------------------------
 
-// Linux network interface names are restricted to this charset (see netdevice(7)).
-// Validating against it before touching sysfs paths keeps a value derived from
-// command output from ever being treated as a path traversal.
-const INTERFACE_NAME_PATTERN = /^[a-zA-Z0-9@.:_-]+$/;
-
 let prevNetSample: { rx: number; tx: number; at: number } | null = null;
-
-async function readInterfaceStat(interfaceName: string, stat: string): Promise<number> {
-  const contents = await readSys(`/sys/class/net/${interfaceName}/statistics/${stat}`);
-  const value = contents === null ? NaN : parseInt(contents, 10);
-  return Number.isNaN(value) ? 0 : value;
-}
-
-// `ip route` 는 /usr/sbin 에 있어 서비스 PATH 에서 빠지기 쉽다.
-// /proc/net/route 를 직접 읽으면 외부 바이너리가 전혀 필요 없다.
-async function getDefaultInterface(): Promise<string> {
-  const contents = await readFile('/proc/net/route', 'utf-8');
-  const lines = contents.split('\n').slice(1);
-
-  for (const line of lines) {
-    const [iface, destination] = line.trim().split(/\s+/);
-    if (destination === '00000000' && iface && INTERFACE_NAME_PATTERN.test(iface)) {
-      return iface;
-    }
-  }
-
-  // 기본 경로가 없으면(컨테이너 등) 트래픽이 가장 많은 물리 인터페이스로 대체한다.
-  const candidates = (await readdir('/sys/class/net')).filter(
-    name => name !== 'lo' && INTERFACE_NAME_PATTERN.test(name)
-  );
-  let best = '';
-  let bestBytes = -1;
-  for (const name of candidates) {
-    const bytes = await readInterfaceStat(name, 'rx_bytes');
-    if (bytes > bestBytes) {
-      best = name;
-      bestBytes = bytes;
-    }
-  }
-
-  if (!best) throw new Error('no usable network interface found');
-  return best;
-}
 
 async function getPing(): Promise<number> {
   const host = process.env.PING_HOST || '8.8.8.8';
@@ -249,7 +160,7 @@ async function getPing(): Promise<number> {
   return match ? parseFloat(match[1]) : 0;
 }
 
-async function getNetworkInfo(warnings: string[]): Promise<NetworkInfo> {
+async function getNetworkInfo(warnings: string[], sockets: SocketSummary): Promise<NetworkInfo> {
   const interfaceName = await getDefaultInterface();
 
   const [rxBytes, txBytes, rxErrors, txErrors, rxPackets, txPackets] = await Promise.all([
@@ -281,16 +192,29 @@ async function getNetworkInfo(warnings: string[]): Promise<NetworkInfo> {
   // 에러율은 바이트가 아니라 패킷 대비로 계산해야 의미가 있다.
   const rate = (errors: number, packets: number) => (packets > 0 ? ((errors / packets) * 100).toFixed(2) : '0.00');
 
-  const ping = await collect('network.ping', getPing, 0, warnings);
+  const [ping, interfaces] = await Promise.all([
+    collect('network.ping', getPing, 0, warnings),
+    collect('network.interfaces', () => getInterfaces(interfaceName), [], warnings)
+  ]);
+
+  const linkSpeedMbps = interfaces.find(entry => entry.isDefault)?.speedMbps ?? null;
+  // 링크 속도(Mbps)를 KB/s 로 바꿔 현재 처리량과 같은 단위로 비교한다.
+  const linkCapacityKbps = linkSpeedMbps === null ? null : (linkSpeedMbps * 1000) / 8;
 
   return {
-    download: parseFloat(download.toFixed(2)),
-    upload: parseFloat(upload.toFixed(2)),
+    download: round(download),
+    upload: round(upload),
     ping,
     errorRates: {
       rx: rate(rxErrors, rxPackets),
       tx: rate(txErrors, txPackets)
-    }
+    },
+    connections: sockets.connections,
+    listeningPorts: sockets.listeningPorts,
+    interfaces,
+    linkSpeedMbps,
+    bandwidthPercentage:
+      linkCapacityKbps === null ? 0 : round(Math.min(100, ((download + upload) / linkCapacityKbps) * 100), 1)
   };
 }
 
@@ -319,7 +243,7 @@ async function readThermalZone(): Promise<number | 'N/A'> {
     const milliCelsius = parseInt(raw, 10);
     if (Number.isNaN(milliCelsius)) continue;
 
-    const celsius = parseFloat((milliCelsius / 1000).toFixed(1));
+    const celsius = round(milliCelsius / 1000, 1);
     const type = (await readSys(`/sys/class/thermal/${zone}/type`)) ?? '';
     if (preferred.includes(type)) return celsius;
     if (fallback === 'N/A') fallback = celsius;
@@ -464,6 +388,26 @@ async function getUptime(): Promise<UptimeInfo> {
   };
 }
 
+// --- Security ----------------------------------------------------------
+
+async function getSecurityInfo(
+  peers: Map<string, number>,
+  warnings: string[]
+): Promise<SecurityInfo> {
+  const [firewall, sshSessions, topTraffic] = await Promise.all([
+    collect(
+      'security.firewall',
+      getFirewallInfo,
+      { status: 'unknown' as const, backend: null, blockedAttempts: null },
+      warnings
+    ),
+    collect('security.sshSessions', getSshSessions, [], warnings),
+    collect('security.topTraffic', () => getTopTraffic(peers), [], warnings)
+  ]);
+
+  return { firewall, sshSessions, topTraffic };
+}
+
 // --- Public API --------------------------------------------------------
 
 function emptyTemperature(): TemperatureInfo {
@@ -481,23 +425,82 @@ export async function getSystemInfo(): Promise<ServerData> {
 
   const warnings: string[] = [];
 
+  // 연결 수, 열린 포트, 상위 트래픽 피어는 모두 같은 소켓 목록에서 나온다.
+  // 한 번만 읽어 네트워크/보안 수집기가 나눠 쓴다.
+  const sockets = await collect(
+    'network.sockets',
+    getSocketSummary,
+    { connections: 0, listeningPorts: 0, peers: new Map<string, number>() },
+    warnings
+  );
+
   // Promise.all 이 아니라 개별 fallback 으로 감싼다. 예전에는 수집기 하나만
   // 실패해도 전체 응답이 0으로 떨어졌다.
-  const [cpu, memory, disk, network, temperature, fan, processes, uptime] = await Promise.all([
-    getCpuInfo(warnings),
-    collect('memory', getMemoryInfo, { used: 0, total: 0, percentage: 0 }, warnings),
-    collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0 }, warnings),
-    collect(
-      'network',
-      () => getNetworkInfo(warnings),
-      { download: 0, upload: 0, ping: 0, errorRates: { rx: '0.00', tx: '0.00' } },
-      warnings
-    ),
-    collect('temperature', getTemperature, emptyTemperature(), warnings),
-    collect('fan', getFanSpeed, { cpu: 0, case1: 0, case2: 0 }, warnings),
-    collect<Process[]>('processes', getProcesses, [], warnings),
-    collect('uptime', getUptime, { days: 0, hours: 0, minutes: 0 }, warnings)
-  ]);
+  const [cpu, memory, disk, network, temperature, fan, processes, uptime, host, swap, diskIO, gpu] =
+    await Promise.all([
+      getCpuInfo(warnings),
+      collect('memory', getMemoryInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+      collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+      collect(
+        'network',
+        () => getNetworkInfo(warnings, sockets),
+        {
+          download: 0,
+          upload: 0,
+          ping: 0,
+          errorRates: { rx: '0.00', tx: '0.00' },
+          connections: 0,
+          listeningPorts: 0,
+          interfaces: [],
+          linkSpeedMbps: null,
+          bandwidthPercentage: 0
+        },
+        warnings
+      ),
+      collect('temperature', getTemperature, emptyTemperature(), warnings),
+      collect('fan', getFanSpeed, { cpu: 0, case1: 0, case2: 0 }, warnings),
+      collect<Process[]>('processes', getProcesses, [], warnings),
+      collect('uptime', getUptime, { days: 0, hours: 0, minutes: 0 }, warnings),
+      collect(
+        'host',
+        getHostInfo,
+        {
+          hostname: os.hostname(),
+          os: `${os.type()} ${os.release()}`,
+          kernel: os.release(),
+          arch: os.arch(),
+          bootTime: new Date(Date.now() - os.uptime() * 1000).toISOString(),
+          rebootReason: null
+        },
+        warnings
+      ),
+      collect('swap', getSwapInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+      collect('diskIO', getDiskIo, { read: 0, write: 0 }, warnings),
+      collect(
+        'gpu',
+        getGpuInfo,
+        { name: null, usage: 'N/A' as const, temperature: 'N/A' as const },
+        warnings
+      )
+    ]);
+
+  const load = getLoadAverage();
+  const security = await getSecurityInfo(sockets.peers, warnings);
+
+  recordSample(cpu.usage, load.avg1, now);
+
+  const alerts = evaluateAlerts(
+    {
+      cpu: cpu.usage,
+      memory: memory.percentage,
+      disk: disk.percentage,
+      swap: swap.percentage,
+      temperature: cpu.temperature,
+      firewall: security.firewall.status,
+      sshSessions: security.sshSessions
+    },
+    now
+  );
 
   const data: ServerData = {
     cpu,
@@ -508,6 +511,15 @@ export async function getSystemInfo(): Promise<ServerData> {
     fan,
     processes,
     uptime,
+    host,
+    load,
+    swap,
+    diskIO,
+    gpu,
+    security,
+    history: getHistory(now),
+    alerts,
+    timestamp: new Date(now).toISOString(),
     ...(warnings.length > 0 ? { warnings } : {})
   };
 


### PR DESCRIPTION
## What

Implements the updated design mock (`ServerMonitor.dc.html`) and the metrics it introduced, then adds a responsive layout alongside it.

### Collectors — `src/utils/collectors/*`

The mock showed a dozen panels the API had no data for. Split the collection out of `systemMonitor.ts` into focused modules:

| Module | Adds | Source |
| --- | --- | --- |
| `cpu.ts` | per-core usage | `/proc/stat` `cpu0..N` deltas |
| `load.ts` | load average, swap | `os.loadavg()`, `/proc/meminfo` |
| `diskio.ts` | read/write MB/s | `/proc/diskstats`, whole disks only so partitions aren't double counted |
| `gpu.ts` | GPU usage/temp | amdgpu sysfs, else `nvidia-smi` |
| `netstat.ts` | connections, listening ports, interfaces, top traffic peers | `/proc/net/tcp{,6}`, `nf_conntrack` |
| `host.ts` | distro/kernel, boot time, reboot reason | `/etc/os-release`, `last -x` |
| `security.ts` | SSH sessions, firewall, blocked attempts | `who`, ufw config, kernel journal |
| `history.ts` | 12h load grid, 24h CPU heatmap | in-memory ring buffers |
| `alerts.ts` | alert log | threshold state machine with hysteresis |

Notes for review:

- Every panel degrades to `N/A`, never to a fake zero — same policy as the existing collectors.
- The poll runs at 1 Hz, so anything that spawns a process (`who`, `last`, `nvidia-smi`, `journalctl`) is behind a TTL cache, and the socket list is read once and shared by the network and security collectors.
- New `ServerData` fields are **optional**, so a cluster node running an older build still parses. `toDashboardData()` fills the defaults once at the client boundary.

### UI

- **Kiosk layout** (`KioskDashboard`) reproduces the 1024x600 mock and scales the whole canvas to whatever display it lands on.
- **Responsive layout** (`ResponsiveDashboard`) carries the same panels into a scrolling 1/2/3-column grid with larger type and horizontal per-core bars, plus the host name in the header and current ↓/↑ rates on the network card (the kiosk only shows the chart).
- `useViewMode` picks between them from the viewport: kiosk if the canvas fits at ≥ 0.8 scale (≥ 819x480 CSS px), responsive otherwise. The 7-inch panel renders at scale 1.0. `?kiosk=1` / `?kiosk=0` overrides it if a kiosk browser misreports its viewport.
- A failed poll no longer blanks the screen — the last values stay up and the header switches to `Reconnecting…`.

### Incidental fix

The network chart labelled its axis `MB/s` while the API sends KB/s. Rates now pick their unit from the value (`formatRate`).

## Testing

- `tsc --noEmit`, `eslint src` (0 errors, no new warnings), `next build` all pass.
- Layouts checked at 320, 390, 768, 1024x600, 1024x768 and desktop widths against a synthetic full-data payload injected in the browser. No horizontal overflow at 320px; all three kiosk columns fit 1024x600 with 14–17px headroom.
- Kiosk layout was rendered before and after the responsive work and compared — the card markup is untouched, only the canvas wrapper moved out of `page.tsx`.

## Not verified here

Development was on macOS, which has no `/proc`, so the Linux parsing paths never executed — the graceful-degradation path did (`warnings` correctly named each unavailable collector). **The parsers for `/proc/diskstats`, `/proc/net/tcp`, `who` and `last` should get one run on a real host.** `curl localhost:3000/api/system | jq .warnings` reports any collector that failed.

Panels that depend on host configuration and may read `N/A` are documented in the README: GPU (Intel iGPUs expose no percentage), traffic bytes (needs `nf_conntrack_acct=1`, otherwise ranks peers by connection count), and blocked attempts (needs journal read access).

The 12h/24h histories live in process memory, so they start empty after a restart and fill in over time.

## Note

`.claude/` is left untracked — it holds machine-local settings plus a `launch.json` I added for the dev server. Worth adding `.claude/settings.local.json` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
