### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "server-monitor",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "server-monitor",
-      "version": "1.2.1",
+      "version": "2.0.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.2",
         "lucide-react": "^0.511.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-monitor",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Version bump only: `1.2.1` → `2.0.0` in `package.json` and `package-lock.json`. No source changes.

## Why major

The two PRs since 1.2.1 changed both the API surface and the UI wholesale:

- [#20](https://github.com/Ruthgyeul/ServerMonitor/pull/20) added a large set of fields to `/api/system` — `host`, `load`, `swap`, `diskIO`, `gpu`, `security`, `history`, `alerts`, per-core CPU, and network connections/ports/interfaces/bandwidth — behind new collectors in `src/utils/collectors/`, and rebuilt the dashboard from the design mock.
- [#21](https://github.com/Ruthgyeul/ServerMonitor/pull/21) collapsed the resulting two layouts into one responsive layout and deleted eight components.

## For the reviewer

**Mixed-version clusters are safe in both directions, so nodes do not have to be upgraded together.** Every field added in #20 is optional on `ServerData`, and the client fills defaults once at the boundary in `toDashboardData()`. A 1.2.1 node still parses against the new dashboard (missing panels read `N/A`), and a 2.0.0 node still parses against a 1.2.1 dashboard, which just ignores the extra keys.

Tagging was left out deliberately — `npm version` was run with `--no-git-tag-version`, so this branch carries no `v2.0.0` tag. Tag after merging if you want one:

```bash
git tag v2.0.0 && git push origin v2.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
