### PR TITLE
Scale card contents with the viewport

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -360,11 +360,13 @@ const CoresCard: React.FC<{ data: DashboardData }> = ({ data }) => {
       <ul className={cn('dash-corelist', cores.length > CORE_SPLIT_THRESHOLD && 'dash-corelist--split')}>
         {cores.map((usage, index) => (
           <li key={index} className="flex items-center gap-1.5">
-            <span className="t-micro w-5 shrink-0 text-gray-500">C{index}</span>
+            {/* 폭을 ch 로 잡아야 글자 배율(--dash-scale)을 따라 같이 넓어진다.
+                px 로 고정하면 큰 화면에서 숫자가 칸을 넘어 서로 붙는다. */}
+            <span className="t-micro w-[3ch] shrink-0 text-gray-500">C{index}</span>
             <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded bg-gray-900">
               <div className="h-full rounded" style={{ width: `${usage}%`, background: statusColor(usage) }} />
             </div>
-            <span className="t-micro w-7 shrink-0 text-right text-gray-400">{usage.toFixed(0)}%</span>
+            <span className="t-micro w-[4ch] shrink-0 text-right text-gray-400">{usage.toFixed(0)}%</span>
           </li>
         ))}
       </ul>
@@ -625,8 +627,8 @@ const ProcessesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
       <div className="t-micro mb-0.5 flex items-center justify-between text-gray-500">
         <span>Name</span>
         <div className="flex gap-2">
-          <span className="w-8 text-right text-yellow-400">CPU</span>
-          <span className="w-8 text-right text-blue-400">RAM</span>
+          <span className="w-[5ch] text-right text-yellow-400">CPU</span>
+          <span className="w-[5ch] text-right text-blue-400">RAM</span>
         </div>
       </div>
       {processes.length === 0 && <Empty>process list unavailable</Empty>}
@@ -637,8 +639,8 @@ const ProcessesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
               {process.name}
             </span>
             <div className="flex shrink-0 gap-2 font-mono">
-              <span className="w-8 text-right text-yellow-400">{process.cpu.toFixed(1)}</span>
-              <span className="w-8 text-right text-blue-400">{process.memory.toFixed(1)}</span>
+              <span className="w-[5ch] text-right text-yellow-400">{process.cpu.toFixed(1)}</span>
+              <span className="w-[5ch] text-right text-blue-400">{process.memory.toFixed(1)}</span>
             </div>
           </li>
         ))}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,14 +40,28 @@ body {
    1024px 은 시안이 그려진 폭이라, 그 이상에서는 238:472:282 라는 시안의 열 비율을
    그대로 유지한다. 더 좁아지면 열이 통째로 아래로 접히고, 각 열 안의 순서는
    그대로 남는다.
+
+   카드 안의 치수는 --dash-scale 하나가 통째로 배율을 잡는다. 화면이 넓어지면
+   열도 그만큼 넓어지므로, 같은 글자 크기를 유지하면 큰 모니터에서 휴대폰 화면을
+   늘려 놓은 꼴이 된다. 배율을 올려 카드가 열 폭을 제대로 쓰게 한다.
 --------------------------------------------------------------------------- */
+
+:root { --dash-scale: 1; }
+
+/* 휴대폰: 카드 하나가 가로를 통째로 쓰니 조금 키워도 넘치지 않는다. */
+@media (max-width: 639px) { :root { --dash-scale: 1.08; } }
+
+/* 넓어질수록 열이 넓어진다. 그만큼 카드 속 내용도 키운다. */
+@media (min-width: 1280px) { :root { --dash-scale: 1.15; } }
+@media (min-width: 1600px) { :root { --dash-scale: 1.3; } }
+@media (min-width: 2000px) { :root { --dash-scale: 1.5; } }
 
 .dash-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   align-items: start;
-  gap: 12px;
-  padding: 12px;
+  gap: calc(12px * var(--dash-scale));
+  padding: calc(12px * var(--dash-scale));
 }
 
 @media (min-width: 640px) {
@@ -64,45 +78,61 @@ body {
 .dash-col {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: calc(12px * var(--dash-scale));
   min-width: 0;
 }
 
-/* 시안에서 나란히 놓인 두 카드(FAN+TEMP, INTERFACES+BANDWIDTH). */
+/* 시안에서 나란히 놓인 두 카드(FAN+TEMP, INTERFACES+BANDWIDTH).
+   휴대폰 폭에서는 반쪽이 170px 남짓이라 "eth0 192.168.0.14 · 1Gbps" 같은 줄이
+   잘린다. 그 구간에서만 위아래로 푼다. */
 .dash-subgrid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: calc(12px * var(--dash-scale));
 }
 
-.dash-card { padding: 12px; }
+@media (min-width: 640px) {
+  .dash-subgrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
 
-.dash-head { padding: 8px 12px; }
-.dash-alertbar { padding: 8px 12px; }
+.dash-card { padding: calc(12px * var(--dash-scale)); }
 
-.t-micro { font-size: 10px; }
-.t-label { font-size: 11px; }
-.t-body  { font-size: 12px; }
-.t-value { font-size: 15px; }
-.t-hero  { font-size: 20px; }
+.dash-head { padding: calc(8px * var(--dash-scale)) calc(12px * var(--dash-scale)); }
+.dash-alertbar { padding: calc(8px * var(--dash-scale)) calc(12px * var(--dash-scale)); }
 
-.dash-icon { width: 14px; height: 14px; }
-.dash-card-head { margin-bottom: 6px; }
-.dash-rows > * + * { margin-top: 6px; }
+.t-micro { font-size: calc(10px * var(--dash-scale)); }
+.t-label { font-size: calc(11px * var(--dash-scale)); }
+.t-body  { font-size: calc(12px * var(--dash-scale)); }
+.t-value { font-size: calc(15px * var(--dash-scale)); }
+.t-hero  { font-size: calc(20px * var(--dash-scale)); }
+
+.dash-icon {
+  width: calc(14px * var(--dash-scale));
+  height: calc(14px * var(--dash-scale));
+}
+.dash-card-head { margin-bottom: calc(6px * var(--dash-scale)); }
+.dash-rows > * + * { margin-top: calc(6px * var(--dash-scale)); }
 
 /* 코어가 많으면 한 줄에 하나씩 쌓기엔 너무 길어진다. 두 줄로 접는다.
    단 휴대폰에서는 세로가 넉넉하고 가로가 없으니 한 줄로 둔다. */
-.dash-corelist { display: grid; grid-template-columns: 1fr; gap: 6px 10px; }
+.dash-corelist {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: calc(6px * var(--dash-scale)) calc(10px * var(--dash-scale));
+}
 
 @media (min-width: 640px) {
   .dash-corelist--split { grid-template-columns: 1fr 1fr; }
 }
 
-.dash-gauge { width: 64px; height: 64px; }
-.dash-chart { height: 176px; }
-.dash-spark { height: 64px; }
-.dash-heat  { height: 28px; }
-.dash-loadgrid { gap: 4px; }
+.dash-gauge {
+  width: calc(64px * var(--dash-scale));
+  height: calc(64px * var(--dash-scale));
+}
+.dash-chart { height: calc(176px * var(--dash-scale)); }
+.dash-spark { height: calc(64px * var(--dash-scale)); }
+.dash-heat  { height: calc(28px * var(--dash-scale)); }
+.dash-loadgrid { gap: calc(4px * var(--dash-scale)); }
 .dash-loadcell { aspect-ratio: 1; }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Outside the kiosk breakpoint, every viewport rendered the cards at one fixed size. On a 2560px monitor that meant phone-sized type sitting in columns three times as wide — mostly empty card with a little text in the corner.

## What

Card dimensions now go through a single `--dash-scale` multiplier that steps up with the viewport. Type, padding, gaps, gauge diameter and chart heights all derive from it, so a card grows with the column it sits in.

| Viewport width | Scale | Label | Gauge | Columns |
| --- | --- | --- | --- | --- |
| < 640px | 1.08 | 11.9px | 69px | 1 |
| 640–1279px | 1.0 | 11px | 64px | 2–3 |
| ≥ 1280px | 1.15 | 12.7px | 74px | 3 |
| ≥ 1600px | 1.3 | 14.3px | 83px | 3 |
| ≥ 2000px | 1.5 | 16.5px | 96px | 3 |
| **1024x600 (kiosk)** | **n/a** | **9px** | **36px** | **3** |

The sub-640 bump is deliberate: there one column owns the full screen width, so the type can afford to be larger than on a tablet where two columns share it.

## The kiosk is untouched

Its media query sets the same tokens in explicit px and comes last in the file, so it wins regardless of the multiplier. Re-measured after the change, with the same worst-case payload used in [#21](https://github.com/Ruthgyeul/ServerMonitor/pull/21) (16 cores, six interfaces, every list full):

| | Before | After |
| --- | --- | --- |
| Label / padding / gauge | 9px / 6px / 36px | 9px / 6px / 36px |
| Vertical overflow | 0 | 0 |
| Spare per column | 27.7 / 27.5 / 32.8px | 27.7 / 27.5 / 32.8px |

## Two bugs the scaling exposed

Both were latent before this PR and would have surfaced on any large display:

- **Numeric columns did not follow the type.** `TOP PROCESSES` and `CPU CORES` used fixed `w-8` / `w-5` / `w-7`, so at 2560 the CPU and RAM figures collided — `13.7 1.4` rendered as `13.71.4`. They are `ch`-based now, so they widen with the text.
- **The design's paired cards overflowed on phones.** `INTERFACES+BANDWIDTH` and `FAN+TEMP` sit two-up per the mock; at 375px each half is ~170px and `eth0 192.168.0.14 · 1Gbps` ran past its box. They stack below 640px now — the same treatment the gauge row already had. On real screens the pairing is unchanged.

## Testing

Checked at 375, 820, 1024x600, 1440, 1920 and 2560 with a synthetic worst-case payload: no row-level overlap (measured by comparing sibling bounding boxes, ignoring nested spans), no horizontal overflow at any width, kiosk still fits without scrolling. `tsc --noEmit`, `eslint src` (0 errors, no new warnings) and `next build` all pass.

## Note

Column count and card order are unchanged — this only affects dimensions inside the cards. Vertical scrolling at non-kiosk sizes is expected and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
