### PR TITLE
Push system data over SSE instead of per-second polling

### DIFF
--- a/src/app/api/system/stream/route.ts
+++ b/src/app/api/system/stream/route.ts
@@ -1,0 +1,80 @@
+import { ServerData } from '@/types/system';
+import { subscribe } from '@/utils/systemStream';
+
+// 이 라우트는 연결을 열어둔 채 서버가 데이터를 밀어주는 SSE 스트림이다.
+// 폴링과 달리 클라이언트당 연결 1개만 유지되고, 실제 수집은 systemStream 의
+// 단일 루프가 담당한다(초당 1회 고정).
+
+// 장기 연결 + Node 전용 수집(fs/os/child_process)이므로 정적 최적화를 끈다.
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
+    .split(',')
+    .map((origin) => origin.trim().replace(/\/+$/, ''))
+    .filter(Boolean);
+
+// 유휴 연결이 프록시/방화벽에 끊기지 않도록 주기적으로 보내는 keep-alive.
+const KEEPALIVE_MS = 15000;
+
+export async function GET(request: Request) {
+    const origin = request.headers.get('origin') || undefined;
+    const encoder = new TextEncoder();
+
+    let unsubscribe: () => void = () => {};
+    let keepAlive: ReturnType<typeof setInterval> | null = null;
+
+    const stream = new ReadableStream({
+        start(controller) {
+            const push = (chunk: string) => {
+                try {
+                    controller.enqueue(encoder.encode(chunk));
+                } catch {
+                    // 컨트롤러가 이미 닫힘(클라이언트 종료). 정리는 abort/cancel 이 맡는다.
+                }
+            };
+
+            const send = (data: ServerData) => push(`data: ${JSON.stringify(data)}\n\n`);
+
+            unsubscribe = subscribe(send);
+
+            // ": " 로 시작하는 줄은 SSE 코멘트라 클라이언트가 무시한다. 연결 유지용.
+            keepAlive = setInterval(() => push(': ping\n\n'), KEEPALIVE_MS);
+
+            const cleanup = () => {
+                unsubscribe();
+                if (keepAlive) {
+                    clearInterval(keepAlive);
+                    keepAlive = null;
+                }
+                try {
+                    controller.close();
+                } catch {
+                    // 이미 닫힌 경우 무시.
+                }
+            };
+
+            request.signal.addEventListener('abort', cleanup);
+        },
+        cancel() {
+            unsubscribe();
+            if (keepAlive) {
+                clearInterval(keepAlive);
+                keepAlive = null;
+            }
+        }
+    });
+
+    const headers: Record<string, string> = {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        // nginx 리버스 프록시가 응답을 버퍼링해 실시간성이 깨지는 것을 막는다.
+        'X-Accel-Buffering': 'no'
+    };
+    if (origin && allowedOrigins.includes(origin)) {
+        headers['Access-Control-Allow-Origin'] = origin;
+    }
+
+    return new Response(stream, { headers });
+}

--- a/src/hooks/useSystemData.ts
+++ b/src/hooks/useSystemData.ts
@@ -1,12 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { NetworkHistoryEntry, ServerData } from '@/types/system';
 import { DashboardData, toDashboardData } from '@/utils/dashboardData';
 
-const POLL_INTERVAL_MS = 1000;
-const REQUEST_TIMEOUT_MS = 4000;
 const MAX_POINTS = 60;
 
 // 이 필드들이 없으면 응답이 /api/system 의 것이 아니거나 심하게 망가진 것이다.
@@ -48,26 +46,19 @@ export function useSystemData(): SystemDataState {
     diskIoHistory: []
   });
 
-  // 응답이 폴링 간격보다 느려지면 요청이 겹쳐 쌓인다. 한 번에 하나만 보낸다.
-  const inflight = useRef(false);
-
   useEffect(() => {
-    let cancelled = false;
+    // 폴링(초당 GET) 대신 연결 하나를 열어두고 서버가 밀어주는 SSE 를 구독한다.
+    // EventSource 는 연결이 끊기면 자동으로 재연결하므로 별도 백오프가 필요 없다.
+    const source = new EventSource('/api/system/stream');
 
-    const fetchOnce = async () => {
-      if (inflight.current) return;
-      inflight.current = true;
+    source.onopen = () => {
+      setState(previous => ({ ...previous, connected: true, error: null }));
+    };
 
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-
+    source.onmessage = (event: MessageEvent<string>) => {
       try {
-        const response = await fetch('/api/system', { signal: controller.signal, cache: 'no-store' });
-        if (!response.ok) throw new Error(`Failed to fetch system data (${response.status})`);
-
-        const payload: unknown = await response.json();
+        const payload: unknown = JSON.parse(event.data);
         assertServerData(payload);
-        if (cancelled) return;
 
         const data = toDashboardData(payload);
         const time = new Date().toLocaleTimeString('ko-KR', {
@@ -92,25 +83,22 @@ export function useSystemData(): SystemDataState {
           ].slice(-MAX_POINTS)
         }));
       } catch (error) {
-        if (cancelled) return;
         const message = error instanceof Error ? error.message : 'Unknown error occurred';
-        console.error('Error fetching system data:', error);
-
-        // 마지막으로 받은 값은 지우지 않는다. 잠깐 끊겼다고 화면이 비어버리면
-        // 벽에 걸어둔 대시보드로서는 오히려 정보가 줄어든다.
-        setState(previous => ({ ...previous, error: message, connected: false }));
-      } finally {
-        clearTimeout(timeout);
-        inflight.current = false;
+        console.error('Error parsing system data:', error);
+        // 파싱 실패는 연결 문제가 아니다. 마지막 값은 유지하고 에러만 표시한다.
+        setState(previous => ({ ...previous, error: message }));
       }
     };
 
-    fetchOnce();
-    const interval = setInterval(fetchOnce, POLL_INTERVAL_MS);
+    source.onerror = () => {
+      // 연결이 끊긴 상태. 마지막으로 받은 값은 지우지 않는다. 잠깐 끊겼다고
+      // 화면이 비어버리면 벽에 걸어둔 대시보드로서는 오히려 정보가 줄어든다.
+      // EventSource 가 알아서 재연결을 시도하며, 성공하면 onopen 이 복구한다.
+      setState(previous => ({ ...previous, connected: false }));
+    };
 
     return () => {
-      cancelled = true;
-      clearInterval(interval);
+      source.close();
     };
   }, []);
 

--- a/src/utils/systemStream.ts
+++ b/src/utils/systemStream.ts
@@ -1,0 +1,82 @@
+import { ServerData } from '@/types/system';
+import { getSystemInfo } from '@/utils/systemMonitor';
+
+// 요청마다 수집기를 돌리는 대신, 프로세스 안에서 딱 하나의 루프만 돌린다.
+// 접속자가 몇 명이든 쉘 프로세스 spawn(sensors/ping/ps/df ...)은 초당 1회로
+// 고정되고, 각 SSE 연결은 그 결과를 나눠 받기만 한다.
+//
+// 구독자가 0명이 되면 루프를 멈춘다. 아무도 안 보는데 서버를 계속 두드릴
+// 이유가 없다. 첫 구독자가 붙으면 즉시 다시 시작한다.
+
+type Listener = (data: ServerData) => void;
+
+const TICK_MS = 1000;
+
+const listeners = new Set<Listener>();
+let active = false;
+let handle: ReturnType<typeof setTimeout> | null = null;
+let lastData: ServerData | null = null;
+
+async function tick(): Promise<void> {
+  try {
+    const data = await getSystemInfo();
+    lastData = data;
+    for (const listener of listeners) {
+      // 한 구독자의 예외가 다른 구독자에게 번지지 않게 격리한다.
+      try {
+        listener(data);
+      } catch (error) {
+        console.error('SSE listener threw:', error);
+      }
+    }
+  } catch (error) {
+    // 수집 자체가 실패해도 루프는 살려둔다. 이번 틱만 건너뛰고,
+    // 구독자는 마지막으로 받은 값을 그대로 들고 있는다.
+    console.error('system collection loop failed:', error);
+  }
+}
+
+// setInterval 대신 "완료 후 다음 예약" 방식이라, 수집이 1초보다 오래 걸려도
+// 요청이 겹쳐 쌓이지 않는다.
+async function loop(): Promise<void> {
+  if (!active) return;
+  await tick();
+  if (active) handle = setTimeout(() => void loop(), TICK_MS);
+}
+
+function start(): void {
+  if (active) return;
+  active = true;
+  void loop();
+}
+
+function stop(): void {
+  active = false;
+  if (handle) {
+    clearTimeout(handle);
+    handle = null;
+  }
+}
+
+/**
+ * 시스템 데이터 갱신을 구독한다. 구독 즉시(값이 있으면) 마지막 스냅샷을 한 번
+ * 전달하므로, 새 연결이 다음 틱까지 최대 1초를 기다리지 않는다.
+ * 반환된 함수를 호출하면 구독이 해제된다.
+ */
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  if (listeners.size === 1) start();
+
+  if (lastData) {
+    try {
+      listener(lastData);
+    } catch (error) {
+      console.error('SSE listener threw on initial push:', error);
+    }
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) stop();
+  };
+}


### PR DESCRIPTION
## What

Replaces the dashboard's per-second `GET /api/system` polling with a **Server-Sent Events (SSE)** stream that the server pushes to.

## Why

Each connected client was firing a full HTTP request/response round-trip every second. The concern was server load as clients (or a wall-mounted dashboard left open) accumulate. With SSE, each client holds a single long-lived connection and the server pushes updates — no per-second round-trips — and the actual shell collectors run **once per second total**, independent of how many clients are watching.

## Changes

- **`src/utils/systemStream.ts`** (new) — a single collection loop per process feeds all subscribers. Shell collectors (`sensors`/`ping`/`ps`/`df`) run once per second regardless of client count. The loop stops when the last subscriber disconnects and restarts on the next connection. New subscribers get the last snapshot immediately (no up-to-1s wait). Uses "await tick, then schedule next" so a slow collection never overlaps.
- **`src/app/api/system/stream/route.ts`** (new) — SSE endpoint (`nodejs` runtime, `force-dynamic`). Sends keep-alive comment pings every 15s so idle connections survive proxies/firewalls, and sets `X-Accel-Buffering: no` so nginx doesn't buffer the stream. Cleans up subscription + keep-alive on client disconnect. Mirrors the existing `ALLOWED_ORIGINS` CORS handling.
- **`src/hooks/useSystemData.ts`** — swaps `setInterval` + `fetch` for `EventSource`. Gains automatic reconnect for free. History accumulation and the "keep last values on disconnect" behavior are preserved.
- **`GET /api/system`** — left unchanged as a single-shot / fallback endpoint.

## Deployment note (Ubuntu + systemd `next start`)

No serverless constraints — the long-lived connection and background loop work as-is. If nginx is in front, disable buffering on the stream path:

```nginx
location /api/system/stream {
    proxy_pass http://127.0.0.1:3000;
    proxy_http_version 1.1;
    proxy_set_header Connection '';
    proxy_buffering off;
    proxy_cache off;
    proxy_read_timeout 3600s;
}
```

## Verification

- `tsc --noEmit` and `eslint` on changed files: pass.
- Ran the dev server: `/api/system/stream` returns `200`, subscriber gets an immediate snapshot (~278ms) then steady ~1s pushes; full `ServerData` payload (~4.7KB); no console errors. Dashboard header shows a live "updated 0s ago" indicator ticking. (Verified on macOS, so collector values fall back to 0/N-A; the SSE transport itself is fully exercised.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)