### PR TITLE
Fix NetworkChart Tooltip formatter type to unblock build

### DIFF
--- a/src/components/charts/NetworkChart.tsx
+++ b/src/components/charts/NetworkChart.tsx
@@ -65,7 +65,7 @@ export const NetworkChart: React.FC<NetworkChartProps> = ({ data, minimal }) => 
                             hide={false}
                         />
                         <Tooltip 
-                            formatter={(value: number) => [`${formatNumber(value)} MB/s`, '']}
+                            formatter={(value) => [`${formatNumber(Number(value))} MB/s`, '']}
                             labelFormatter={(label) => `Time: ${label}`}
                             contentStyle={{ 
                                 backgroundColor: '#1f2937',


### PR DESCRIPTION
## Summary

`npm run build` was failing at the TypeScript type-check step on `src/components/charts/NetworkChart.tsx:68`. This is a pre-existing error (present before the recent history/SSH work) that blocked the production build from completing.

## Root cause

Recharts 3 types the `<Tooltip>` `formatter` callback's value as `ValueType | undefined`, but the callback hard-declared `value: number` — an incompatible narrower type.

## Fix

- Drop the explicit `number` annotation so `value` is inferred as Recharts' `ValueType`.
- Coerce with `Number(value)` before passing to `formatNumber`, which expects a `number`.

```diff
- formatter={(value: number) => [`${formatNumber(value)} MB/s`, '']}
+ formatter={(value) => [`${formatNumber(Number(value))} MB/s`, '']}
```

## Verification

`npm run build` now completes end-to-end: all 7 routes compile and the type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)