### PR TITLE
style: terminal-themed dashboard UI

### DIFF
--- a/src/components/charts/NetworkAreaChart.tsx
+++ b/src/components/charts/NetworkAreaChart.tsx
@@ -68,19 +68,19 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
         </linearGradient>
       </defs>
 
-      <line x1={PAD_LEFT} y1={PAD_TOP} x2={PAD_LEFT} y2={PAD_TOP + innerHeight} stroke="#374151" strokeWidth={1} />
+      <line x1={PAD_LEFT} y1={PAD_TOP} x2={PAD_LEFT} y2={PAD_TOP + innerHeight} stroke="rgba(255,255,255,0.10)" strokeWidth={1} />
       <line
         x1={PAD_LEFT}
         y1={PAD_TOP + innerHeight}
         x2={PAD_LEFT + innerWidth}
         y2={PAD_TOP + innerHeight}
-        stroke="#374151"
+        stroke="rgba(255,255,255,0.10)"
         strokeWidth={1}
       />
 
       {ticks.map(tick => (
         <g key={tick}>
-          <line x1={PAD_LEFT - 4} y1={y(tick * divisor)} x2={PAD_LEFT} y2={y(tick * divisor)} stroke="#4b5563" strokeWidth={1} />
+          <line x1={PAD_LEFT - 4} y1={y(tick * divisor)} x2={PAD_LEFT} y2={y(tick * divisor)} stroke="rgba(255,255,255,0.14)" strokeWidth={1} />
           <text x={PAD_LEFT - 8} y={y(tick * divisor) + 3} fontSize={9} fill="#9ca3af" textAnchor="end">
             {`${tick.toFixed(tick < 2 ? 1 : 0)} ${unit}`}
           </text>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -70,7 +70,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
   networkHistory,
   diskIoHistory
 }) => (
-  <div className="min-h-screen bg-gray-900 text-gray-100">
+  <div className="terminal-bg min-h-screen text-gray-100">
+    <TerminalTitleBar data={data} />
     <Header data={data} connected={connected} lastUpdate={lastUpdate} now={now} />
     <AlertBar data={data} />
 
@@ -126,7 +127,7 @@ const Card: React.FC<CardProps> = ({ icon: Icon, color, title, right, children }
     <div className="dash-card-head flex items-center justify-between gap-2">
       <div className="flex min-w-0 items-center gap-1.5">
         <Icon className="dash-icon shrink-0" color={color} strokeWidth={2} />
-        <h2 className="t-label truncate tracking-wide text-gray-300">{title}</h2>
+        <h2 className="t-label truncate uppercase tracking-[0.08em] text-gray-300">{title}</h2>
       </div>
       {right}
     </div>
@@ -156,6 +157,28 @@ function currentAlerts(data: DashboardData): string[] {
   return alerts;
 }
 
+// 터미널 윈도우 크롬. 신호등 + 경로만 얹어 대시보드를 "터미널 창"처럼 감싼다.
+// 배치나 정보는 건드리지 않는, 순수 장식용 상단 바다.
+const TerminalTitleBar: React.FC<{ data: DashboardData }> = ({ data }) => {
+  const host = data.host.hostname || 'server';
+
+  return (
+    <div className="term-titlebar">
+      <div className="flex shrink-0 items-center gap-[7px]">
+        <span className="term-dot" style={{ background: '#ff5f56' }} />
+        <span className="term-dot" style={{ background: '#ffbd2e' }} />
+        <span className="term-dot" style={{ background: '#27c93f' }} />
+      </div>
+      <span className="min-w-0 flex-1 truncate text-center font-mono">
+        <span style={{ color: '#34d399' }}>root@{host}</span>
+        <span style={{ color: '#5c6478' }}> — ~/monitor — </span>
+        <span style={{ color: '#8b93a7' }}>zsh</span>
+      </span>
+      <span className="shrink-0 font-mono text-gray-500">⎇ main</span>
+    </div>
+  );
+};
+
 type HeaderProps = Omit<DashboardProps, 'networkHistory' | 'diskIoHistory'>;
 
 const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => {
@@ -164,7 +187,8 @@ const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => 
   return (
     <header className="dash-head sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-gray-700 bg-gray-800/95 backdrop-blur">
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <Server size={16} color="#60a5fa" strokeWidth={2} className="shrink-0" />
+        <Server size={16} color="#38bdf8" strokeWidth={2} className="shrink-0" />
+        <span className="t-value shrink-0 font-bold text-emerald-400 select-none">❯</span>
         <h1 className="t-value truncate font-bold">Server Monitor</h1>
         <div className="h-[7px] w-[7px] shrink-0 animate-[pulseDot_2s_ease-in-out_infinite] rounded-full bg-green-400" />
       </div>
@@ -236,7 +260,7 @@ const GaugeCard: React.FC<GaugeTileProps> = ({ icon: Icon, iconColor, label, per
   const color = percentage === null ? COLORS.muted : statusColor(percentage);
 
   return (
-    <section className="dash-card flex min-w-0 flex-col items-center rounded-lg border border-gray-700 bg-gray-800">
+    <section className="gauge-card dash-card flex min-w-0 flex-col items-center rounded-lg border border-gray-700 bg-gray-800">
       <div className="flex w-full items-center gap-1">
         <Icon className="dash-icon shrink-0" color={iconColor} strokeWidth={2} />
         <span className="t-micro truncate text-gray-300">{label}</span>

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -27,7 +27,7 @@ export const Gauge: React.FC<GaugeProps> = ({ percentage, color, className }) =>
         cx={GAUGE_BOX / 2}
         cy={GAUGE_BOX / 2}
         r={GAUGE_RADIUS}
-        stroke="#374151"
+        stroke="#242b3a"
         strokeWidth={GAUGE_STROKE}
         fill="transparent"
       />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,22 +1,127 @@
 @import "tailwindcss";
 
+/* ---------------------------------------------------------------------------
+   터미널 팔레트
+
+   포트폴리오(github.com/Ruthgyeul)의 터미널 감성을 그대로 옮겨 왔다.
+   대시보드 곳곳의 gray-* 유틸리티를 손대지 않고 색만 바꾸기 위해, Tailwind 의
+   회색 계열 토큰을 통째로 이 팔레트로 재정의한다. 카드/보더/글자 색이 한 번에
+   따라오므로 타일 배치나 정보는 건드리지 않는다.
+--------------------------------------------------------------------------- */
+@theme {
+  --color-gray-50:  #f4f6fb;
+  --color-gray-100: #e6e8ee; /* 본문 */
+  --color-gray-200: #d5dae4;
+  --color-gray-300: #c3c8d4; /* 흐린 본문 */
+  --color-gray-400: #8b93a7; /* 라벨 */
+  --color-gray-500: #5c6478; /* 캡션 */
+  --color-gray-600: #454d5e;
+  --color-gray-700: rgba(255, 255, 255, 0.08); /* 카드 보더 */
+  --color-gray-800: #111621; /* 카드 배경 */
+  --color-gray-900: #0a0d13; /* 페이지 / 인셋 */
+}
+
 :root {
-  --background: #111827;
-  --foreground: #ffffff;
+  --background: #0a0d13;
+  --foreground: #e6e8ee;
   --screen-saver-timeout: 0;
+
+  --term-bg: #0a0d13;
+  --term-panel: #111621;
+  --term-inset: #0d1119;
+  --term-border: rgba(255, 255, 255, 0.08);
+  --term-accent: #38bdf8;
+  --term-green: #34d399;
+  --term-faint: #5c6478;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #111827;
-    --foreground: #ffffff;
+    --background: #0a0d13;
+    --foreground: #e6e8ee;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-mono), ui-monospace, "SF Mono", "SFMono-Regular", Menlo, monospace;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: rgba(52, 211, 153, 0.3);
+}
+
+/* 스크롤바 — 포트폴리오와 동일한 얇은 터미널 스타일 */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: var(--term-bg);
+}
+::-webkit-scrollbar-thumb {
+  background: #242b3a;
+  border-radius: 5px;
+  border: 2px solid var(--term-bg);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--term-accent);
+}
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #242b3a var(--term-bg);
+}
+
+/* ---------------------------------------------------------------------------
+   터미널 배경 — 은은한 스캔라인 격자 + 상단 글로우.
+   대시보드 루트에 얹혀 검은 바탕에 CRT 결을 준다.
+--------------------------------------------------------------------------- */
+.terminal-bg {
+  background-color: var(--term-bg);
+  background-image:
+    radial-gradient(1200px 600px at 15% -10%, rgba(56, 189, 248, 0.06), transparent),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 24px
+    );
+}
+
+/* 터미널 윈도우 크롬(신호등 + 경로)을 얹는 얇은 바 */
+.term-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--term-border);
+  background: rgba(10, 13, 19, 0.92);
+  backdrop-filter: blur(6px);
+  font-size: 11px;
+  color: var(--term-faint);
+  letter-spacing: 0.02em;
+}
+.term-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  flex: none;
+}
+
+/* 카드 호버 리프트 — 포트폴리오의 .card 와 동일 결 */
+.dash-card,
+.gauge-card {
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.dash-card:hover,
+.gauge-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(56, 189, 248, 0.35);
+  border-color: rgba(56, 189, 248, 0.35);
 }
 
 /* 대시보드 상태 표시용. Tailwind 의 animate-[pulseDot_...] 에서 참조한다. */


### PR DESCRIPTION
## What

Reskins the monitoring dashboard with a terminal aesthetic ported from the portfolio site (github.com/Ruthgyeul). **No tile positions, order, or data changed — this is purely a visual reskin.**

## Why

Requested to give ServerMonitor the same terminal-console look and feel as the portfolio landing page.

## Changes

- **Palette remap** (`globals.css`): redefine Tailwind `gray-*` tokens to a terminal palette so every existing gray utility shifts at once — page `#0a0d13`, cards `#111621`, translucent-white borders, mono text. Avoids touching dozens of individual classNames.
- **Terminal texture**: monospace body font, subtle scanline grid + accent glow background, thin scrollbars, green selection color.
- **Window chrome**: a titlebar with traffic-light dots and `root@host — ~/monitor — zsh`, plus a green `❯` prompt glyph on the header title (decorative only).
- **Hover glow**: cyan lift on cards and gauge tiles.
- **Cohesion**: gauge track and network-chart axis colors aligned to the palette.

## Notes for reviewers

- The gray-token remap in `@theme` also restyles secondary pages (`/cluster`) and legacy `stats/*` components consistently — intentional.
- `tsc --noEmit` passes; no console errors in preview.
- Verified the 3-column desktop layout and the responsive single-column collapse both preserve the original tile order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)