### PR TITLE
fix: single-line cluster env and silence Turbopack NFT trace warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,12 +13,9 @@
 # --- Cluster dashboard (src/app/cluster) -----------------------------------
 # JSON array of servers shown on the /cluster page.
 # "type" must be "intel" or "rpi" (controls which sensors are read/displayed).
-NEXT_PUBLIC_CLUSTER_SERVERS=[
-    {"name":"Cluster1","ip":"192.168.0.100","type":"intel"},
-    {"name":"Cluster2","ip":"192.168.0.101","type":"intel"},
-    {"name":"Cluster3","ip":"192.168.0.102","type":"rpi"},
-    {"name":"Cluster4","ip":"192.168.0.103","type":"rpi"}
-]
+# Keep this on ONE line: dotenv only reads the first line of an unquoted value,
+# so a multi-line array parses as just "[" and the page renders no servers.
+NEXT_PUBLIC_CLUSTER_SERVERS=[{"name":"Cluster1","ip":"192.168.0.100","type":"intel"},{"name":"Cluster2","ip":"192.168.0.101","type":"intel"},{"name":"Cluster3","ip":"192.168.0.102","type":"rpi"},{"name":"Cluster4","ip":"192.168.0.103","type":"rpi"}]
 
 # Port each cluster node's /api/system endpoint listens on.
 NEXT_PUBLIC_CLUSTER_PORT=4000

--- a/src/utils/collectors/history.ts
+++ b/src/utils/collectors/history.ts
@@ -17,7 +17,10 @@ const HOUR_BUCKETS = 24;
 // 손실되는 최악의 구간도 이 간격만큼뿐이다.
 const SAVE_INTERVAL_MS = 30 * 1000;
 
-const DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), 'data');
+// process.cwd() resolves to the project root at runtime; without this ignore,
+// Turbopack's file tracer can't statically scope it and traces the entire
+// project into the output bundle (the "unexpected file in NFT list" warning).
+const DATA_DIR = process.env.DATA_DIR || path.join(/*turbopackIgnore: true*/ process.cwd(), 'data');
 const STORE_FILE = process.env.HISTORY_FILE || path.join(DATA_DIR, 'history.json');
 const STORE_VERSION = 1;
 
@@ -79,7 +82,7 @@ function ensureLoaded(): void {
   if (loaded) return;
   loaded = true;
   try {
-    const raw = fs.readFileSync(STORE_FILE, 'utf-8');
+    const raw = fs.readFileSync(/*turbopackIgnore: true*/ STORE_FILE, 'utf-8');
     const parsed = JSON.parse(raw) as StoreShape;
     if (parsed && parsed.v === STORE_VERSION) {
       hydrate(loadBuckets, parsed.loadBuckets, LOAD_BUCKET_MS, LOAD_BUCKETS);


### PR DESCRIPTION
## What changed

- **`.env.example`**: collapse `NEXT_PUBLIC_CLUSTER_SERVERS` onto a single line (with a note explaining why).
- **`src/utils/collectors/history.ts`**: add `/*turbopackIgnore: true*/` to the `process.cwd()` and `fs.readFileSync(STORE_FILE)` calls.

## Why

**Cluster page silently showed no servers (real bug).** The example advertised a multi-line JSON array for `NEXT_PUBLIC_CLUSTER_SERVERS`. dotenv only reads the *first line* of an unquoted value, so the app received just `[`. `JSON.parse('[')` throws `Unexpected end of JSON input`, the `try/catch` in `clusterConfig.ts` swallows it and returns `[]`, and `/cluster` renders zero servers. This showed up in the build log as an `Invalid NEXT_PUBLIC_CLUSTER_SERVERS value` error.

**Turbopack "unexpected file in NFT list" warnings (x2).** `history.ts` uses `process.cwd()` and a dynamic `fs.readFileSync(STORE_FILE)`. Turbopack's file tracer can't statically scope these, so it traced the entire project into the output bundle. The build warning explicitly recommends the `turbopackIgnore` comment used here.

## Reviewer notes

- Runtime behavior of `history.ts` is unchanged — the comments only tell the bundler's tracer to skip those calls; the data file is still created/read at runtime.
- Verified locally: `npm run build` now compiles with **0 warnings** (was 2).
- ⚠️ The `.env.example` change does not affect a running deployment. Anyone with an existing multi-line `NEXT_PUBLIC_CLUSTER_SERVERS` in their real `.env` must collapse it to one line for `/cluster` to populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)