### PR TITLE
security: harden system API and add response security headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,26 @@ NEXT_PUBLIC_CLUSTER_PROTOCOL=https
 
 # --- API CORS allow-list (src/app/api/system/route.ts) ---------------------
 # Comma-separated list of origins allowed to call /api/system.
+# NOTE: CORS only restricts cross-origin reads from *browsers*. It does NOT
+# stop curl/scripts from reading the endpoint directly. /api/system exposes
+# sensitive host recon (SSH source IPs, listening ports, top traffic peers,
+# firewall state). Treat the endpoint as UNAUTHENTICATED and restrict it at the
+# network level: bind to localhost, put it behind a VPN, or front it with a
+# reverse proxy that requires auth. See README "Securing the API".
 ALLOWED_ORIGINS=http://localhost:4000,http://192.168.0.100:4000,http://192.168.0.101:4000,http://192.168.0.102:4000,http://192.168.0.103:4000,https://status.example.com
+
+# --- Optional API token gate (src/proxy.ts) --------------------------------
+# If set, every /api/system* request must present this token, either as
+#   Authorization: Bearer <token>
+# or a cookie named `api_auth_token` (useful when a reverse proxy injects it).
+# Leave UNSET to keep the endpoint open (default). Generate a long random value,
+# e.g. `openssl rand -hex 32`.
+#
+# WARNING: enabling this breaks the built-in browser dashboard, which calls
+# /api/system/stream from the browser and can't attach a secret token. Use this
+# mode only for machine-to-machine polling or when a reverse proxy in front of
+# the app injects the token/cookie for you.
+# API_AUTH_TOKEN=
 
 # --- History persistence (src/utils/collectors/history.ts) -----------------
 # The load (12h) and CPU (24h) history charts are persisted to disk so a

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ read on the server.
 | `NEXT_PUBLIC_CLUSTER_SERVERS` | `src/config/clusterConfig.ts` | JSON array of `{ "name", "ip", "type" }` objects rendered on `/cluster`. `type` is `"intel"` or `"rpi"` and controls which sensors are read. |
 | `NEXT_PUBLIC_CLUSTER_PORT` | `src/config/clusterConfig.ts` | Port each cluster node's `/api/system` listens on (default `3000`). |
 | `NEXT_PUBLIC_CLUSTER_PROTOCOL` | `src/config/clusterConfig.ts` | Scheme (`http`/`https`) used to reach cluster nodes from the browser (default `http`). |
-| `ALLOWED_ORIGINS` | `src/app/api/system/route.ts` | Comma-separated list of origins allowed to call `/api/system` (CORS allow-list). |
+| `ALLOWED_ORIGINS` | `src/app/api/system/route.ts` | Comma-separated list of origins allowed to call `/api/system` (CORS allow-list). CORS only limits cross-origin browser reads — it does not authenticate. See [Securing the API](#securing-the-api). |
+| `API_AUTH_TOKEN` | `src/proxy.ts` | Optional shared secret. When set, every `/api/system*` request must present it as `Authorization: Bearer <token>` or an `api_auth_token` cookie. Unset by default. Enabling it breaks the built-in browser dashboard — see [Securing the API](#securing-the-api). |
 | `NEXT_PUBLIC_SITE_URL` | `src/config/siteConfig.ts` | Canonical site URL used for metadata, Open Graph tags, `robots.txt` and `sitemap.xml`. |
 | `NEXT_PUBLIC_SITE_NAME` | `src/config/siteConfig.ts` | Full site/app name shown in page titles and metadata. |
 | `NEXT_PUBLIC_SITE_SHORT_NAME` | `src/config/siteConfig.ts` | Short name used in the title template and mobile web app title. |
@@ -177,6 +178,33 @@ Adding, removing, or repointing a cluster node is now a one-line edit in
   mode, reading `KIOSK_USER`/`KIOSK_URL` from `.env` if present.
 - `scripts/monitor.sh` — standalone JSON dump of the same metrics. Not used by
   the API route; kept for shelling out from other tooling.
+
+## Securing the API
+
+`/api/system` and `/api/system/stream` return sensitive host reconnaissance:
+SSH session source IPs and usernames, listening ports, top traffic peer IPs,
+firewall state, and the running process list. **The endpoint is unauthenticated
+by default**, and the `ALLOWED_ORIGINS` CORS list only restricts cross-origin
+reads from browsers — it does nothing against `curl` or any script. Anyone who
+can reach the port can read everything.
+
+Pick at least one of these, in rough order of preference:
+
+1. **Network isolation (recommended).** Bind the app to `localhost` and expose
+   it only through a reverse proxy (nginx/Caddy/Traefik) that terminates TLS and
+   enforces auth (Basic auth, mTLS, OAuth2 proxy), or keep it reachable only
+   over a VPN / private network. This keeps the browser dashboard fully working.
+2. **Optional token gate.** Set `API_AUTH_TOKEN` (e.g. `openssl rand -hex 32`).
+   Every `/api/system*` request then needs `Authorization: Bearer <token>` or an
+   `api_auth_token` cookie. This suits machine-to-machine polling or a reverse
+   proxy that injects the token. Note it disables the built-in browser dashboard,
+   which cannot carry a secret token from the browser.
+
+The app also sends hardening response headers (`X-Frame-Options: DENY`,
+`X-Content-Type-Options: nosniff`, a `frame-ancestors 'none'` CSP,
+`Referrer-Policy`, `Permissions-Policy`, HSTS) from `next.config.ts`, and the
+process list reports executable names only (never full command lines) so
+secrets passed as CLI arguments are never exposed.
 
 ## Deploying a cluster
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,43 @@
 import type { NextConfig } from "next";
 
+// 보안 응답 헤더. 대시보드는 임베드될 이유가 없으므로 클릭재킹을 원천 차단하고,
+// MIME 스니핑/플러그인 주입/base 태그 하이재킹을 막는다.
+//
+// CSP 는 script/style/connect 를 제약하지 않는 최소 구성이다. 그 세 가지를
+// 좁히면 Next 의 인라인 부트스트랩, Tailwind/Recharts 의 인라인 스타일,
+// /cluster 의 교차-노드 fetch 가 깨지기 쉬워, 여기서는 확실히 안전한
+// frame-ancestors/object-src/base-uri 만 강제한다. 더 엄격한 CSP 가 필요하면
+// 배포 환경에 맞춰 script-src/connect-src 를 추가하라(README 참고).
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+  },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // 이 대시보드는 카메라/마이크/위치정보 등을 쓰지 않는다. 전부 끈다.
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+  },
+  // HTTPS 응답에서만 브라우저가 적용한다. HTTP 로 서빙 중이면 무시되므로 안전.
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains"
+  }
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  poweredByHeader: false, // "X-Powered-By: Next.js" 로 스택/버전을 광고하지 않는다
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders
+      }
+    ];
+  }
 };
 
 export default nextConfig;

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -13,8 +13,9 @@ const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
     .filter(Boolean);
 
 function getCorsHeaders(origin: string | undefined) {
+    // 이 라우트는 GET/OPTIONS 만 구현한다. 쓰지도 않는 메서드/헤더를 광고하지 않는다.
     const headers: Record<string, string> = {
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type, Authorization',
         'Content-Type': 'application/json'
     };
@@ -43,9 +44,10 @@ export async function GET(request: Request) {
             headers: getCorsHeaders(origin)
         });
     } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
+        // 원인(파일 경로/명령 실패 메시지 등)은 서버 로그에만 남기고, 클라이언트에는
+        // 내부 구조를 드러내지 않는 일반 메시지만 돌려준다.
         console.error('Error fetching system data:', error);
-        return new NextResponse(JSON.stringify({ error: `Failed to collect system data: ${message}` }), {
+        return new NextResponse(JSON.stringify({ error: 'Failed to collect system data' }), {
             status: 500,
             headers: getCorsHeaders(origin)
         });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// /api/system* 는 SSH 접속 IP/사용자명, 전체 프로세스 목록, 열린 포트, 트래픽
+// 상대 IP, 방화벽 상태 같은 민감한 정찰 정보를 돌려준다. CORS 는 브라우저의
+// 교차 출처 "읽기"만 막을 뿐, curl 같은 비-브라우저 클라이언트는 그대로 읽는다.
+//
+// 그래서 선택적 공유 토큰 게이트를 둔다. API_AUTH_TOKEN 이 설정돼 있으면 모든
+// /api/system* 요청은 그 토큰을 제시해야 한다. 설정돼 있지 않으면(기본값)
+// 동작은 이전과 완전히 동일하다 — 대신 네트워크 레벨(로컬바인딩/VPN/리버스
+// 프록시)로 보호해야 한다(README 참고).
+//
+// 주의: 토큰을 켜면 브라우저 내장 대시보드(같은 오리진에서 /api/system/stream 을
+// 부른다)는 토큰을 실을 수 없어 동작하지 않는다. 이 모드는 리버스 프록시가
+// 토큰을 주입하거나, 머신-투-머신 폴링을 하는 배포를 위한 것이다.
+
+const AUTH_TOKEN = process.env.API_AUTH_TOKEN;
+
+// 길이가 다르거나 값이 다를 때 걸리는 시간을 최대한 균일하게 만들어
+// 타이밍 사이드채널로 토큰을 한 글자씩 알아내는 것을 어렵게 한다.
+function timingSafeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  // 길이가 달라도 동일한 바이트 수를 비교하도록 긴 쪽 기준으로 순회한다.
+  const length = Math.max(aBytes.length, bBytes.length);
+  let mismatch = aBytes.length ^ bBytes.length;
+  for (let i = 0; i < length; i += 1) {
+    mismatch |= (aBytes[i] ?? 0) ^ (bBytes[i] ?? 0);
+  }
+  return mismatch === 0;
+}
+
+function presentedToken(request: NextRequest): string | null {
+  const header = request.headers.get('authorization');
+  if (header && header.startsWith('Bearer ')) {
+    return header.slice('Bearer '.length).trim();
+  }
+  // EventSource 는 커스텀 헤더를 못 붙이므로 쿠키 경로도 허용한다(프록시가 주입).
+  const cookie = request.cookies.get('api_auth_token')?.value;
+  return cookie ?? null;
+}
+
+export function proxy(request: NextRequest) {
+  // 토큰이 설정돼 있지 않으면 게이트를 열어둔다(기존 동작 유지).
+  if (!AUTH_TOKEN) return NextResponse.next();
+
+  // preflight 는 인증 대상이 아니다. 실제 요청에서 검사한다.
+  if (request.method === 'OPTIONS') return NextResponse.next();
+
+  const token = presentedToken(request);
+  if (token && timingSafeEqual(token, AUTH_TOKEN)) {
+    return NextResponse.next();
+  }
+
+  return new NextResponse(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': 'Bearer'
+    }
+  });
+}
+
+export const config = {
+  matcher: ['/api/system', '/api/system/:path*']
+};

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -344,9 +344,12 @@ async function getFanSpeed(): Promise<FanInfo> {
 // --- Processes / Uptime ------------------------------------------------
 
 async function getProcesses(): Promise<Process[]> {
+  // `args`(전체 명령줄) 대신 `comm`(실행 파일명)만 읽는다. 명령줄 인자에는
+  // 비밀번호/토큰이 그대로 노출되는 경우가 많은데(예: `mysql -pSECRET`,
+  // `--api-key=...`), 이 목록은 API 로도 나가므로 실행 파일명이면 충분하고 안전하다.
   // 파이프라인의 종료 코드는 head 의 것이라 ps 가 실패해도 0 이 된다.
   // 빈 출력을 그대로 넘기면 원인 없이 목록만 비므로 여기서 에러로 올린다.
-  const stdout = await run('ps -eo pid,pcpu,pmem,stat,args --sort=-pcpu | head -n 21');
+  const stdout = await run('ps -eo pid,pcpu,pmem,stat,comm --sort=-pcpu | head -n 21');
   const lines = stdout.split('\n').slice(1); // 헤더 제거
   if (lines.length === 0) {
     throw new Error('ps returned no rows (does this ps support --sort?)');


### PR DESCRIPTION
## What & why

`/api/system` and `/api/system/stream` expose sensitive host reconnaissance — SSH source IPs/usernames, listening ports, top traffic peer IPs, firewall state, and the process list — with **no authentication**. The `ALLOWED_ORIGINS` CORS list only limits cross-origin reads from browsers; it does nothing against `curl` or scripts. This PR reduces the exposed surface and adds defense-in-depth. No severe vulns (command injection / XSS / path traversal / committed secrets) were found — the collectors are already written defensively.

## Changes

- **`next.config.ts`** — security response headers: CSP `frame-ancestors 'none'; object-src 'none'; base-uri 'self'`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, HSTS. Also disables the `X-Powered-By` stack banner. CSP intentionally leaves script/style/connect unconstrained so the dashboard and cross-node `/cluster` fetches keep working.
- **`src/proxy.ts`** (new) — optional shared-token gate for `/api/system*`. When `API_AUTH_TOKEN` is set, requests must present it via `Authorization: Bearer <token>` or an `api_auth_token` cookie, compared in constant time. **Unset by default → existing behavior unchanged.** Uses the Next 16 `proxy` convention (replaces deprecated `middleware`).
- **`src/app/api/system/route.ts`** — stop echoing raw error messages to clients (log server-side, return a generic message); narrow advertised CORS methods to what's implemented (`GET, OPTIONS`).
- **`src/utils/systemMonitor.ts`** — collect process executable names (`ps comm`) instead of full command lines (`ps args`), so secrets passed as CLI arguments (e.g. `mysql -pSECRET`, `--api-key=...`) are never exposed via UI or API.
- **`.env.example` / `README.md`** — document `API_AUTH_TOKEN` and add a "Securing the API" section stressing network-level isolation (localhost bind / VPN / authenticating reverse proxy) as the primary control.

## Reviewer notes

- **Enabling `API_AUTH_TOKEN` disables the built-in browser dashboard**, which calls `/api/system/stream` from the browser and can't carry a secret token. That mode is for machine-to-machine polling or a reverse proxy that injects the token/cookie. For a browser dashboard, prefer network-level isolation. This is documented.
- The `warnings[]` diagnostic array is still surfaced to clients (intentional, for the dashboard). Left as-is; network isolation is the mitigation.
- **Out of scope:** `npm audit` reports 2 high (sharp/libvips via Next 16). The only `audit fix` path downgrades Next to 14 (breaking), so it's not included here — track via Dependabot / a patched Next release.

## Verification

- `tsc --noEmit` clean; changed files lint clean; `next build` succeeds (no deprecation warnings).
- Runtime smoke test: security headers served on `/api/system`; token gate returns 401 (no/wrong token) and 200 (correct Bearer **and** cookie); non-API routes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)