### PR TITLE
feat: LOAD AVG 48시간 확대 + 부하 색상 초록→빨강 그라데이션

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -35,7 +35,15 @@ import {
   formatShortDateTime,
   shortKernel
 } from '@/utils/format';
-import { ALERT_LEVEL_COLORS, COLORS, loadCellColor, loadColor, statusColor, tempColor } from '@/utils/statusColors';
+import {
+  ALERT_LEVEL_COLORS,
+  COLORS,
+  heatColor,
+  loadCellColor,
+  loadColor,
+  statusColor,
+  tempColor
+} from '@/utils/statusColors';
 
 // 카드는 멀티컬럼(.dash-grid)으로 흘러 화면 폭에 따라 1/2/3열이 된다.
 // 열 수와 치수는 전부 src/styles/globals.css 가 정한다.
@@ -332,7 +340,8 @@ const UptimeCard: React.FC<{ data: DashboardData }> = ({ data }) => (
 const LoadCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   const { load, cpu, history } = data;
 
-  // 히스토리가 아직 48칸을 못 채웠으면 앞쪽을 빈 칸으로 메워 격자 모양을 유지한다.
+  // 한 칸이 1시간이라 48칸이면 48시간이다. 아직 다 못 채웠으면 앞쪽을 빈 칸으로
+  // 메워 격자 모양을 유지한다.
   const cells = [
     ...Array(Math.max(0, LOAD_CELLS - history.load.length)).fill(null),
     ...history.load.slice(-LOAD_CELLS)
@@ -350,7 +359,7 @@ const LoadCard: React.FC<{ data: DashboardData }> = ({ data }) => {
       }
     >
       <div className="t-micro mb-1 flex items-center justify-between gap-2 text-gray-500">
-        <span>Last 12h</span>
+        <span>Last 48h</span>
         <span className="truncate">
           5m {load.avg5.toFixed(2)} · 15m {load.avg15.toFixed(2)}
         </span>
@@ -456,7 +465,7 @@ const CpuDayCard: React.FC<{ data: DashboardData }> = ({ data }) => (
             <div
               key={sample.at}
               className="dash-heat flex-1 rounded-[2px]"
-              style={{ background: sample.usage === null ? COLORS.empty : statusColor(sample.usage) }}
+              style={{ background: sample.usage === null ? COLORS.empty : heatColor(sample.usage / 100) }}
               title={
                 sample.usage === null
                   ? `${new Date(sample.at).getHours()}:00 — no data`

--- a/src/utils/collectors/history.ts
+++ b/src/utils/collectors/history.ts
@@ -5,11 +5,12 @@ import { CpuHourSample, HistoryInfo, LoadSample } from '@/types/system';
 import { round } from '@/utils/collectors/shell';
 
 // 히스토리 버킷은 프로세스 메모리에 두되, 디스크에도 영속화한다. 그래야
-// 배포(git pull) 후 재시작이나 크래시로 서버가 다시 떠도 최근 12/24시간 그래프가
+// 배포(git pull) 후 재시작이나 크래시로 서버가 다시 떠도 최근 48/24시간 그래프가
 // 리셋되지 않는다. 저장 파일은 gitignore 된 data 디렉터리에 있어 pull/build 가
 // 건드리지 않는다.
-const LOAD_BUCKET_MS = 15 * 60 * 1000;
-const LOAD_BUCKETS = 48; // 12시간
+// 로드는 칸 수(48)를 유지한 채 버킷을 1시간으로 넓혀 48시간을 덮는다.
+const LOAD_BUCKET_MS = 60 * 60 * 1000;
+const LOAD_BUCKETS = 48; // 48시간
 const HOUR_BUCKET_MS = 60 * 60 * 1000;
 const HOUR_BUCKETS = 24;
 

--- a/src/utils/statusColors.ts
+++ b/src/utils/statusColors.ts
@@ -24,21 +24,47 @@ export function tempColor(temperature: number | 'N/A'): string {
 }
 
 // 로드는 코어 수로 나눠야 의미가 있다. 4코어의 4.0 과 1코어의 4.0 은 다르다.
+// 격자와 같은 그라데이션을 쓰되, 글자라서 어두운 쪽 끝은 잘라 가독성을 지킨다.
 export function loadColor(load: number, cores: number): string {
   const perCore = cores > 0 ? load / cores : load;
-  if (perCore < 0.7) return '#4ade80';
-  if (perCore < 1) return '#facc15';
-  return '#f87171';
+  return heatColor(Math.max(TEXT_HEAT_FLOOR, perCore));
 }
 
-// GitHub 잔디와 같은 4단계. 값이 없는 구간은 배경색으로 비워 둔다.
+// 부하가 낮으면 초록, 높아질수록 노랑 → 주황 → 빨강으로 이어지는 연속 그라데이션.
+// 단계식으로 끊으면 0.59 와 0.61 이 완전히 다른 색이 되어 추세가 안 보인다.
+const HEAT_STOPS: ReadonlyArray<readonly [number, readonly [number, number, number]]> = [
+  [0, [14, 68, 41]], // 거의 유휴 — 어두운 초록
+  [0.35, [38, 166, 65]],
+  [0.6, [250, 204, 21]],
+  [0.8, [249, 115, 22]],
+  [1, [239, 68, 68]] // 포화 — 빨강
+];
+
+// 어두운 배경 위 글자에는 그라데이션의 제일 어두운 초록이 너무 안 읽힌다.
+const TEXT_HEAT_FLOOR = 0.35;
+
+// ratio 는 0(유휴)~1(포화)로 정규화된 부하. 범위를 벗어나면 양 끝 색으로 고정된다.
+export function heatColor(ratio: number): string {
+  // NaN 이 들어오면 clamp 를 통과해 rgb(NaN,…) 가 되므로 먼저 막는다.
+  if (!Number.isFinite(ratio)) return COLORS.muted;
+  const t = Math.min(1, Math.max(0, ratio));
+  for (let i = 1; i < HEAT_STOPS.length; i++) {
+    const [prevAt, prev] = HEAT_STOPS[i - 1];
+    const [nextAt, next] = HEAT_STOPS[i];
+    if (t > nextAt) continue;
+    const span = nextAt - prevAt;
+    const k = span > 0 ? (t - prevAt) / span : 0;
+    const channels = prev.map((value, index) => Math.round(value + (next[index] - value) * k));
+    return `rgb(${channels.join(', ')})`;
+  }
+  return COLORS.critical;
+}
+
+// 값이 없는 구간은 배경색으로 비워 둔다. 코어당 로드 1.0 을 포화로 본다.
 export function loadCellColor(load: number | null, cores: number): string {
   if (load === null) return COLORS.empty;
   const perCore = cores > 0 ? load / cores : load;
-  if (perCore < 0.3) return '#0e4429';
-  if (perCore < 0.6) return '#006d32';
-  if (perCore < 0.9) return '#26a641';
-  return '#39d353';
+  return heatColor(perCore);
 }
 
 export const ALERT_LEVEL_COLORS: Record<string, string> = {


### PR DESCRIPTION
## 무엇을 바꿨나

### 1. LOAD AVG 격자를 48시간으로
`src/utils/collectors/history.ts` 의 로드 버킷을 15분 → 1시간으로 넓혔습니다. 칸 수(`LOAD_BUCKETS = 48`)는 그대로라 12열 × 4행 격자 레이아웃은 변하지 않고, 덮는 구간만 12h → 48h가 됩니다. 카드 라벨도 `Last 12h` → `Last 48h`.

### 2. 부하 색상을 초록 → 빨강 그라데이션으로
`src/utils/statusColors.ts` 에 `heatColor(ratio)` 를 추가했습니다. 0(유휴)~1(포화)을 어두운 초록 → 밝은 초록 → 노랑 → 주황 → 빨강으로 연속 보간합니다.

- **`loadCellColor`** (LOAD AVG 격자): 기존 GitHub 잔디식 초록 4단계는 부하가 높을수록 *더 밝은 초록* 이라 심각도가 읽히지 않았습니다. 코어당 로드 1.0을 포화로 보고 `heatColor` 로 교체.
- **CPU LOAD — LAST 24H 히트맵**: `statusColor` → `heatColor(usage / 100)`.
- **`loadColor`** (카드 우상단 `1m x.xx` 글자): 같은 그라데이션을 쓰되, 그라데이션 제일 어두운 초록이 다크 배경에서 안 읽혀 하한(0.35)을 뒀습니다.

단계식 대신 보간을 쓴 이유는 경계값 근처에서 색이 튀는 문제 때문입니다 — 기존 방식에선 0.59와 0.61이 완전히 다른 색이 되어 추세가 끊겨 보였습니다.

메모리/디스크 바 등 다른 곳의 `statusColor` 는 손대지 않았습니다.

## 리뷰어가 알아야 할 것

**배포 직후 로드 격자가 잠깐 비어 보입니다.** 기존 `data/history.json` 에 저장된 15분 정렬 버킷 키가 새 1시간 키와 맞지 않아, 정시(:00)에 정렬됐던 일부만 살아남습니다. 새 샘플이 쌓이면서 자연히 채워지고(같은 키에 누적되므로 자가 보정됨), 어긋난 옛 버킷은 48시간 안에 `prune` 으로 사라집니다.

저장 포맷 버전(`STORE_VERSION`)은 일부러 올리지 않았습니다. 올리면 파일 전체를 버려서 관련 없는 CPU 24시간 히스토리까지 같이 날아가기 때문입니다.

`heatColor` 는 non-finite 입력에서 `rgb(NaN, …)` 이 나오지 않도록 앞에서 막고 회색을 반환합니다.

## 검증

- `npm run build` 통과 (TypeScript 포함)
- `npx eslint` 변경 파일 clean
- 그라데이션 출력값을 0 / 0.35 / 0.6 / 0.8 / 1 및 범위 밖(-1, 1.5, NaN)에서 직접 확인

이 저장소에는 테스트 스위트가 없어 실행하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)