### PR TITLE
fix: 모바일에서 사용자 확대/축소 잠금

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,10 +20,13 @@ const geistMono = Geist_Mono({
 });
 
 // 모바일에서 CSS 픽셀이 기기 폭을 따라가야 반응형 레이아웃이 의도대로 접힌다.
-// 키오스크 배치는 자체 배율로 맞추므로 확대/축소는 막지 않는다.
+// 사용자가 핀치/더블탭으로 화면을 확대·축소하지 못하도록 배율을 1로 고정한다.
 export const viewport: Viewport = {
     width: "device-width",
     initialScale: 1,
+    maximumScale: 1,
+    minimumScale: 1,
+    userScalable: false,
     themeColor: "#0a0d13"
 };
 


### PR DESCRIPTION
## 요약

모바일에서 사용자가 핀치 줌·더블탭 줌으로 사이트를 자유롭게 확대/축소할 수 있던 동작을 막고 배율을 1로 고정합니다.

## 변경 내용

`src/app/layout.tsx` 의 `viewport` 설정에 다음을 추가:

- `maximumScale: 1`
- `minimumScale: 1`
- `userScalable: false`

`width: "device-width"` 와 `initialScale: 1` 은 그대로 유지되어 반응형 레이아웃은 영향을 받지 않습니다.

## 참고

iOS Safari(10 이상)는 접근성 정책상 `user-scalable=no` 를 무시할 수 있어, iOS에서 핀치 줌을 완전히 차단하려면 추가로 CSS `touch-action` / JS 제스처 차단이 필요할 수 있습니다. 이 PR은 Android/Chrome 등 표준 동작 기기에서의 확대/축소를 잠급니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FqJeqw3TL73oBUtbMHsaf)_