### PR TITLE
Treat cluster node ip as a base URL, hardcode only the path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,18 @@
 # "type" must be "intel" or "rpi" (controls which sensors are read/displayed).
 # Keep this on ONE line: dotenv only reads the first line of an unquoted value,
 # so a multi-line array parses as just "[" and the page renders no servers.
-NEXT_PUBLIC_CLUSTER_SERVERS=[{"name":"Cluster1","ip":"192.168.0.100","type":"intel"},{"name":"Cluster2","ip":"192.168.0.101","type":"intel"},{"name":"Cluster3","ip":"192.168.0.102","type":"rpi"},{"name":"Cluster4","ip":"192.168.0.103","type":"rpi"}]
+#
+# "ip" is the base URL the dashboard appends "/api/system" to. Two forms:
+#   - Full base URL, scheme included, e.g. "https://status.example.com". Used
+#     as-is; the scheme/port live in the URL, so CLUSTER_PORT / CLUSTER_PROTOCOL
+#     below are IGNORED for that node. Prefer this when nodes sit behind a
+#     reverse proxy / share one hostname.
+#   - Bare host/IP, e.g. "192.168.0.100". Expanded to
+#     "<CLUSTER_PROTOCOL>://<ip>:<CLUSTER_PORT>/api/system".
+NEXT_PUBLIC_CLUSTER_SERVERS=[{"name":"Cluster1","ip":"https://status.example.com","type":"intel"},{"name":"Cluster2","ip":"192.168.0.101","type":"intel"},{"name":"Cluster3","ip":"192.168.0.102","type":"rpi"},{"name":"Cluster4","ip":"192.168.0.103","type":"rpi"}]
 
+# Port/scheme applied ONLY to bare-host "ip" entries above (nodes whose "ip"
+# already includes http(s):// ignore both).
 # Port each cluster node's /api/system endpoint listens on.
 NEXT_PUBLIC_CLUSTER_PORT=4000
 

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ read on the server.
 
 | Variable | Used in | Description |
 | --- | --- | --- |
-| `NEXT_PUBLIC_CLUSTER_SERVERS` | `src/config/clusterConfig.ts` | JSON array of `{ "name", "ip", "type" }` objects rendered on `/cluster`. `type` is `"intel"` or `"rpi"` and controls which sensors are read. |
-| `NEXT_PUBLIC_CLUSTER_PORT` | `src/config/clusterConfig.ts` | Port each cluster node's `/api/system` listens on (default `3000`). |
-| `NEXT_PUBLIC_CLUSTER_PROTOCOL` | `src/config/clusterConfig.ts` | Scheme (`http`/`https`) used to reach cluster nodes from the browser (default `http`). |
+| `NEXT_PUBLIC_CLUSTER_SERVERS` | `src/config/clusterConfig.ts` | JSON array of `{ "name", "ip", "type" }` objects rendered on `/cluster`. `type` is `"intel"` or `"rpi"` and controls which sensors are read. `ip` is a base URL the dashboard appends `/api/system` to: a full URL with scheme (e.g. `https://status.example.com`, used as-is) or a bare host/IP (expanded with `NEXT_PUBLIC_CLUSTER_PROTOCOL`/`NEXT_PUBLIC_CLUSTER_PORT`). |
+| `NEXT_PUBLIC_CLUSTER_PORT` | `src/config/clusterConfig.ts` | Port for **bare-host** cluster nodes' `/api/system` (default `3000`). Ignored for `ip` entries that already include a scheme. |
+| `NEXT_PUBLIC_CLUSTER_PROTOCOL` | `src/config/clusterConfig.ts` | Scheme (`http`/`https`) for **bare-host** cluster nodes (default `http`). Ignored for `ip` entries that already include a scheme. |
 | `ALLOWED_ORIGINS` | `src/app/api/system/route.ts` | Comma-separated list of origins allowed to call `/api/system` (CORS allow-list). CORS only limits cross-origin browser reads — it does not authenticate. See [Securing the API](#securing-the-api). |
 | `API_AUTH_TOKEN` | `src/proxy.ts` | Optional shared secret. When set, every `/api/system*` request must present it as `Authorization: Bearer <token>` or an `api_auth_token` cookie. Unset by default. Enabling it breaks the built-in browser dashboard — see [Securing the API](#securing-the-api). |
 | `NEXT_PUBLIC_SITE_URL` | `src/config/siteConfig.ts` | Canonical site URL used for metadata, Open Graph tags, `robots.txt` and `sitemap.xml`. |
@@ -224,9 +224,12 @@ secrets passed as CLI arguments are never exposed.
 ## Deploying a cluster
 
 Each node in `NEXT_PUBLIC_CLUSTER_SERVERS` should run its own instance of
-this app (so its `/api/system` endpoint is reachable at
-`http://<ip>:<NEXT_PUBLIC_CLUSTER_PORT>`), and each node's `ALLOWED_ORIGINS`
-should include the origin of whichever instance is displaying `/cluster`.
+this app so its `/api/system` endpoint is reachable at the node's base URL.
+Give each node either a full base URL (`"ip": "https://status.example.com"`,
+appended with `/api/system` as-is) or a bare host/IP (`"ip": "192.168.0.100"`,
+reached at `<NEXT_PUBLIC_CLUSTER_PROTOCOL>://<ip>:<NEXT_PUBLIC_CLUSTER_PORT>`).
+Each node's `ALLOWED_ORIGINS` should include the origin of whichever instance
+is displaying `/cluster`.
 
 ## Learn more
 

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -19,10 +19,10 @@ import { Gauge, Sparkline } from '@/components/dashboard/primitives';
 import { useNow } from '@/hooks/useNow';
 import { cn } from '@/lib/utils';
 import {
-  CLUSTER_PORT,
-  CLUSTER_PROTOCOL,
   ClusterServer,
-  getClusterServers
+  getClusterHost,
+  getClusterServers,
+  getClusterUrl
 } from '@/config/clusterConfig';
 import { NetworkHistoryEntry, ServerData } from '@/types/system';
 import { formatClock, formatRate } from '@/utils/format';
@@ -46,7 +46,7 @@ type ServerResult =
 
 // 노드 하나를 가져온다. 컴포넌트 상태에 기대지 않는 순수 함수라 모듈 스코프에 둔다.
 async function fetchServer(server: ClusterServer): Promise<[string, ServerResult]> {
-  const url = `${CLUSTER_PROTOCOL}://${server.ip}:${CLUSTER_PORT}/api/system`;
+  const url = getClusterUrl(server, '/api/system');
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
@@ -334,7 +334,7 @@ const ServerShell: React.FC<{
             status === 'connecting' && 'bg-gray-500'
           )}
         />
-        <span className="t-micro font-mono text-gray-500">{server.ip.split(':')[0]}</span>
+        <span className="t-micro font-mono text-gray-500">{getClusterHost(server)}</span>
       </span>
     </div>
     {children}

--- a/src/config/clusterConfig.ts
+++ b/src/config/clusterConfig.ts
@@ -13,6 +13,43 @@ export const CLUSTER_PORT = process.env.NEXT_PUBLIC_CLUSTER_PORT || '3000';
 // terminate TLS, avoiding mixed-content blocks on an all-http default.
 export const CLUSTER_PROTOCOL = process.env.NEXT_PUBLIC_CLUSTER_PROTOCOL || 'http';
 
+// A node's `ip` may be a full base URL (e.g. "https://status.example.com",
+// possibly behind a reverse proxy) or a bare host/IP. Only the former carries
+// its own scheme.
+function hasScheme(value: string): boolean {
+    return /^https?:\/\//i.test(value);
+}
+
+// Base URL for a node, without a trailing slash. If `ip` already includes a
+// scheme it is taken as-is (the port lives in the URL, not CLUSTER_PORT); a
+// bare host is expanded with the configured protocol and port.
+export function getClusterBaseUrl(server: ClusterServer): string {
+    const base = hasScheme(server.ip)
+        ? server.ip
+        : `${CLUSTER_PROTOCOL}://${server.ip}:${CLUSTER_PORT}`;
+    return base.replace(/\/+$/, '');
+}
+
+// Full URL for one of a node's endpoints. Callers hardcode only the path
+// (e.g. "/api/system"); the host/scheme/port come from the node's `ip`.
+export function getClusterUrl(server: ClusterServer, path: string): string {
+    const suffix = path.startsWith('/') ? path : `/${path}`;
+    return `${getClusterBaseUrl(server)}${suffix}`;
+}
+
+// Host shown on the node card. For a full URL this is the hostname (dropping
+// scheme/port/path); for a bare host it's the value up to any ":port".
+export function getClusterHost(server: ClusterServer): string {
+    if (hasScheme(server.ip)) {
+        try {
+            return new URL(server.ip).hostname;
+        } catch {
+            return server.ip;
+        }
+    }
+    return server.ip.split(':')[0];
+}
+
 function isClusterServer(value: unknown): value is ClusterServer {
     if (!value || typeof value !== 'object') return false;
     const server = value as Record<string, unknown>;


### PR DESCRIPTION
## Summary

The `/cluster` page hardcoded the full node endpoint as `${CLUSTER_PROTOCOL}://${ip}:${CLUSTER_PORT}/api/system`, which made it impossible to point a node at a reverse-proxied hostname like `https://status.example.com` (you'd get `https://https://...:4000/api/system`).

Now a node's `ip` is treated as a **base URL** and the code hardcodes only the path (`/api/system`):

- **Full URL with scheme** (`"ip": "https://status.example.com"`) → used as-is, becoming `https://status.example.com/api/system`. `NEXT_PUBLIC_CLUSTER_PROTOCOL` / `NEXT_PUBLIC_CLUSTER_PORT` are ignored for that node.
- **Bare host/IP** (`"ip": "192.168.0.100"`) → still expands to `<protocol>://<ip>:<port>/api/system` for backward compatibility.

## Changes

- `src/config/clusterConfig.ts`: add `getClusterBaseUrl` / `getClusterUrl` / `getClusterHost` helpers that build the URL from a node's `ip`, appending only the caller-supplied path.
- `src/app/cluster/page.tsx`: use `getClusterUrl(server, '/api/system')` for the fetch, and `getClusterHost(server)` for the card's host label (correctly shows the hostname for full URLs instead of `https`).
- `.env.example` and `README.md`: document both `ip` forms and that protocol/port apply only to bare-host entries.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017oJsEZztvR3mvTbXjc3Tz7)_