### PR TITLE
Project-wide improvements: alerting, deployment, cluster aggregation, new metrics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+out
+build
+data
+.git
+.github
+.env
+.env.*
+!.env.example
+npm-debug.log*
+*.tsbuildinfo
+.DS_Store
+coverage
+README.md

--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,37 @@ ALLOWED_ORIGINS=http://localhost:4000,http://192.168.0.100:4000,http://192.168.0
 # the app injects the token/cookie for you.
 # API_AUTH_TOKEN=
 
+# --- Alerts (src/utils/collectors/alerts.ts, notify.ts) --------------------
+# Alerts are always shown in the dashboard's alert card and persisted to
+# data/alerts.json (so they survive a restart). Optionally, push each new
+# alert transition to an external webhook.
+#
+# Webhook URL to POST alerts to. Leave UNSET to disable outbound notifications
+# (dashboard + on-disk log still work). e.g. a Slack/Discord incoming webhook.
+# ALERT_WEBHOOK_URL=
+# Payload shape: "json" (raw AlertEntry, default), "slack" ({text}), or
+# "discord" ({content}). Match this to your webhook provider.
+# ALERT_WEBHOOK_FORMAT=json
+# Re-notify (webhook only, not the on-screen log) every N minutes while a
+# threshold stays breached. 0 (default) disables re-notification.
+# ALERT_RENOTIFY_MINUTES=0
+#
+# Threshold overrides. Each rule enters when the value rises ABOVE _ENTER and
+# clears when it falls BELOW _CLEAR (hysteresis avoids log spam). Unset = the
+# built-in defaults shown here.
+# ALERT_CPU_ENTER=90
+# ALERT_CPU_CLEAR=80
+# ALERT_MEM_ENTER=90
+# ALERT_MEM_CLEAR=80
+# ALERT_DISK_ENTER=85
+# ALERT_DISK_CLEAR=80
+# ALERT_TEMP_ENTER=74
+# ALERT_TEMP_CLEAR=70
+# ALERT_SWAP_ENTER=80
+# ALERT_SWAP_CLEAR=60
+
 # --- History persistence (src/utils/collectors/history.ts) -----------------
-# The load (12h) and CPU (24h) history charts are persisted to disk so a
+# The load (48h) and CPU (24h) history charts are persisted to disk so a
 # redeploy/restart (e.g. `git pull` + rebuild) doesn't reset them. Files live
 # in DATA_DIR, which is gitignored. Override only if you want them elsewhere
 # (e.g. a volume mount).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # 마이너/패치는 한 PR로 묶어 노이즈를 줄인다. major 는 회귀 위험이 있어
+      # 개별 PR 로 받아 따로 검토한다(예: Next/React).
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# 같은 브랜치에 새 커밋이 밀리면 진행 중인 실행을 취소한다.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Prettier
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.next
+node_modules
+out
+build
+coverage
+data
+package-lock.json
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 110,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thanks for your interest in improving ServerMonitor.
+
+## Development
+
+```bash
+npm install
+npm run dev        # http://localhost:3000  (and /cluster)
+```
+
+The app reads live metrics from the host it runs on, so most panels only show
+real numbers on a Linux machine (metrics come from `/proc`, `/sys`, and a few
+shell tools). On macOS/Windows the Linux-only collectors degrade to `N/A`; the
+pure logic is still covered by the tests.
+
+## Before opening a pull request
+
+Run the same checks CI runs, and make sure they pass:
+
+```bash
+npm run format:check   # Prettier
+npm run lint           # ESLint
+npm run typecheck      # tsc --noEmit
+npm test               # Vitest
+```
+
+`npm run format` fixes formatting in place.
+
+## Guidelines
+
+- **Metrics degrade to `N/A`, never to a fake `0`.** When a source is missing,
+  return `N/A` and push a reason onto the `warnings` array (see
+  `collect()` in `src/utils/collectors/shell.ts`) — don't invent a value.
+- **New API fields are optional.** Cluster nodes may run older versions, so add
+  new `ServerData` fields as optional and fill defaults in
+  `src/utils/dashboardData.ts`.
+- **Don't leak secrets.** The process list reports executable names only
+  (`comm`, never full command lines). Keep it that way.
+- **Mind the kiosk layout.** The dashboard is tuned to fit a 1024×600 panel;
+  see the **Layout** section of the README before changing card contents or
+  the per-panel row caps.
+- Add a test when you touch pure logic (parsers, formatters, alert rules).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+
+# ServerMonitor 멀티스테이지 이미지. 런타임에는 next standalone 출력만 담아
+# 이미지를 작게 유지한다. 지표 수집이 읽는 sensors/ping/ps/df/last/who 등은
+# 호스트의 바이너리와 /proc·/sys 를 쓰므로 이미지에 넣지 않는다 —
+# docker-compose.yml 의 마운트/네임스페이스 설정을 참고하라.
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+# 락파일 기준 재현 가능한 설치. package*.json 만 먼저 복사해 레이어 캐시를 살린다.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+# NEXT_PUBLIC_* 는 빌드 시 번들에 인라인된다. 클러스터/사이트 메타데이터를 바꾸려면
+# --build-arg 로 넘기거나, 배포 후 런타임 값만 쓰는 서버 전용 변수를 사용하라.
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# 지표 수집기가 shell out 하는 호스트 도구를 넣는다. busybox 의 ps 는
+# `-eo ... --sort` 를 지원하지 않으므로 GNU procps 가 필요하다. sensors/ping 도
+# 마찬가지다. journalctl/systemctl/who/last(systemd·utmp)는 컨테이너에서 얻기
+# 어렵지만, 수집기가 이미 N/A 로 우아하게 degrade 하므로 넣지 않는다.
+# pid:host + /proc·/sys 마운트(docker-compose.yml)와 함께 써야 호스트를 읽는다.
+RUN apk add --no-cache procps lm-sensors iputils
+
+# 루트로 실행하지 않는다. standalone 서버 구동에 필요한 파일만 복사한다.
+RUN addgroup -g 1001 -S nodejs && adduser -u 1001 -S nextjs -G nodejs
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# 히스토리/알림 영속화 위치(gitignored data/). 볼륨으로 마운트해 재시작에도 유지.
+RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
+VOLUME /app/data
+
+USER nextjs
+EXPOSE 3000
+
+# 무거운 /api/system 이 아니라 경량 /api/health 로 헬스체크한다.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1
+
+CMD ["node", "server.js"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ruthgyeul
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ that aggregates several nodes on one screen.
   - alert log, top processes, SSH sessions, top traffic peers, firewall state
   - keeps the last known values on screen when the stream drops, and says so
     in the header instead of blanking the display
-- **Cluster view** (`/cluster`) — a compact grid that polls multiple
+- **Cluster view** (`/cluster`) — a compact grid that shows multiple
   ServerMonitor instances (e.g. an x86 server plus several Raspberry Pi
-  nodes) and shows their status side by side.
+  nodes) side by side. The browser polls a single same-origin endpoint
+  (`/api/cluster`); the server fans out to each node, so node IPs stay
+  server-side and nodes no longer need to CORS-allow the dashboard origin.
 - **JSON API** (`/api/system`) — returns the current metrics for the host,
   with a configurable CORS allow-list for cross-node requests.
 - **Kiosk launch script** — boots the dashboard full-screen in Firefox for
@@ -228,8 +230,13 @@ this app so its `/api/system` endpoint is reachable at the node's base URL.
 Give each node either a full base URL (`"ip": "https://status.example.com"`,
 appended with `/api/system` as-is) or a bare host/IP (`"ip": "192.168.0.100"`,
 reached at `<NEXT_PUBLIC_CLUSTER_PROTOCOL>://<ip>:<NEXT_PUBLIC_CLUSTER_PORT>`).
-Each node's `ALLOWED_ORIGINS` should include the origin of whichever instance
-is displaying `/cluster`.
+
+The `/cluster` page fetches a single same-origin endpoint (`/api/cluster`),
+and the dashboard **server** fetches each node's `/api/system`. Because those
+node requests are server-to-server, nodes no longer need to CORS-allow the
+dashboard origin for the cluster view, and node IPs never reach the browser.
+If a node has `API_AUTH_TOKEN` set, the dashboard forwards its own
+`API_AUTH_TOKEN` as the bearer token when polling that node.
 
 ## Learn more
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## The API is sensitive and unauthenticated by default
+
+`/api/system` and `/api/system/stream` return host reconnaissance: SSH session
+source IPs and usernames, listening ports, top traffic peer IPs, firewall
+state, and the running process list. **The endpoint is unauthenticated by
+default**, and the `ALLOWED_ORIGINS` CORS list only restricts cross-origin
+reads from browsers — it does nothing against `curl` or any script.
+
+Before exposing this anywhere untrusted, read the **Securing the API** section
+of the [README](README.md#securing-the-api). In short, pick at least one of:
+
+1. **Network isolation (recommended)** — bind to localhost / a private network
+   / a VPN, and front it with a reverse proxy that terminates TLS and enforces
+   auth.
+2. **Token gate** — set `API_AUTH_TOKEN` so every `/api/system*` request must
+   present a bearer token or cookie.
+
+`/api/health` and `/api/metrics` deliberately expose only non-sensitive data
+(liveness and numeric metrics), so they can sit outside the token gate for
+orchestration and Prometheus scraping.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via GitHub Security Advisories
+("Report a vulnerability" on the repository's **Security** tab) rather than a
+public issue. Include reproduction steps and the affected version. You can
+expect an initial acknowledgement within a few days.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# ServerMonitor — self-hosted, reads live host metrics.
+#
+# A monitor is only useful if it can see the HOST, not just its own container.
+# The settings below give the container that visibility:
+#
+#   pid: host          → the container's own /proc becomes the host's, so
+#                        /proc/stat, /proc/meminfo and the /proc/<pid> scans
+#                        (CPU, memory, SSH sessions, process list) read the
+#                        host. No /proc mount is needed with this.
+#   network_mode: host → interface stats, listening ports and connections are
+#                        the host's; the app is reachable on the host's :3000.
+#   /sys (ro)          → temperature/fan/cpufreq/power_supply/net link speed.
+#   /var/log (ro)      → optional; lets `last` read wtmp for the reboot reason.
+#   ./data             → history.json / alerts.json persist across restarts.
+#
+# This is a lot of host access by design — it is the point of a host monitor.
+# Keep the endpoint off the public internet (see README "Securing the API").
+
+services:
+  servermonitor:
+    build: .
+    # Or pull a prebuilt image instead of building:
+    # image: ghcr.io/ruthgyeul/servermonitor:latest
+    container_name: servermonitor
+    restart: unless-stopped
+    pid: host
+    network_mode: host
+    env_file:
+      - .env
+    volumes:
+      - /sys:/sys:ro
+      - /var/log:/var/log:ro
+      - ./data:/app/data
+    # network_mode: host means PORT from .env (default 3000) is the host port.
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3000/api/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,10 @@
 // eslint-config-next 16 은 플랫 config 를 그대로 내보낸다. FlatCompat 로 감싸면
 // 설정 객체에 순환 참조가 생겨 검증 단계에서 터지므로, 직접 펼쳐 쓴다.
-import coreWebVitals from "eslint-config-next/core-web-vitals";
-import typescript from "eslint-config-next/typescript";
+import coreWebVitals from 'eslint-config-next/core-web-vitals';
+import typescript from 'eslint-config-next/typescript';
 
 const eslintConfig = [
-  { ignores: [".next/**", "node_modules/**", "next-env.d.ts"] },
+  { ignores: ['.next/**', 'node_modules/**', 'next-env.d.ts'] },
   ...coreWebVitals,
   ...typescript
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 // 보안 응답 헤더. 대시보드는 임베드될 이유가 없으므로 클릭재킹을 원천 차단하고,
 // MIME 스니핑/플러그인 주입/base 태그 하이재킹을 막는다.
@@ -10,30 +10,32 @@ import type { NextConfig } from "next";
 // 배포 환경에 맞춰 script-src/connect-src 를 추가하라(README 참고).
 const securityHeaders = [
   {
-    key: "Content-Security-Policy",
+    key: 'Content-Security-Policy',
     value: "frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
   },
-  { key: "X-Frame-Options", value: "DENY" },
-  { key: "X-Content-Type-Options", value: "nosniff" },
-  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   // 이 대시보드는 카메라/마이크/위치정보 등을 쓰지 않는다. 전부 끈다.
   {
-    key: "Permissions-Policy",
-    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()'
   },
   // HTTPS 응답에서만 브라우저가 적용한다. HTTP 로 서빙 중이면 무시되므로 안전.
   {
-    key: "Strict-Transport-Security",
-    value: "max-age=31536000; includeSubDomains"
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains'
   }
 ];
 
 const nextConfig: NextConfig = {
   poweredByHeader: false, // "X-Powered-By: Next.js" 로 스택/버전을 광고하지 않는다
+  // Docker 이미지를 최소화한다: 서버 실행에 필요한 파일만 .next/standalone 로 추린다.
+  output: 'standalone',
   async headers() {
     return [
       {
-        source: "/:path*",
+        source: '/:path*',
         headers: securityHeaders
       }
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.11",
         "postcss": "^8.5.16",
+        "prettier": "^3.4.2",
         "tailwindcss": "^4.3.2",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10"
@@ -6295,6 +6296,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -29,6 +32,7 @@
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.11",
     "postcss": "^8.5.16",
+    "prettier": "^3.4.2",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss']
 };
 
 export default config;

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -40,10 +40,7 @@
       "purpose": "any maskable"
     }
   ],
-  "categories": [
-    "utilities",
-    "productivity"
-  ],
+  "categories": ["utilities", "productivity"],
   "lang": "en-US",
   "dir": "ltr",
   "prefer_related_applications": false,

--- a/src/app/api/cluster/route.ts
+++ b/src/app/api/cluster/route.ts
@@ -1,7 +1,6 @@
-import { NextResponse } from 'next/server';
-
 import { ServerData } from '@/types/system';
 import { ClusterServer, getClusterHost, getClusterServers, getClusterUrl } from '@/config/clusterConfig';
+import { jsonResponse } from '@/utils/http';
 
 // 클러스터 뷰는 지금까지 브라우저에서 각 노드의 /api/system 을 직접 폴링했다.
 // 그래서 (a) 모든 노드가 대시보드 오리진을 CORS 로 허용해야 하고, (b) 노드 IP 가
@@ -59,11 +58,13 @@ async function fetchNode(server: ClusterServer): Promise<ClusterNode> {
   }
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   const servers = getClusterServers();
   const nodes = await Promise.all(servers.map(fetchNode));
 
-  return NextResponse.json(
+  // 노드 전체 데이터를 모은 큰 페이로드라 gzip 을 받으면 압축해 보낸다.
+  return jsonResponse(
+    request,
     { nodes, timestamp: new Date().toISOString() },
     { headers: { 'Cache-Control': 'no-store' } }
   );

--- a/src/app/api/cluster/route.ts
+++ b/src/app/api/cluster/route.ts
@@ -1,12 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { ServerData } from '@/types/system';
-import {
-  ClusterServer,
-  getClusterHost,
-  getClusterServers,
-  getClusterUrl
-} from '@/config/clusterConfig';
+import { ClusterServer, getClusterHost, getClusterServers, getClusterUrl } from '@/config/clusterConfig';
 
 // 클러스터 뷰는 지금까지 브라우저에서 각 노드의 /api/system 을 직접 폴링했다.
 // 그래서 (a) 모든 노드가 대시보드 오리진을 CORS 로 허용해야 하고, (b) 노드 IP 가
@@ -21,9 +16,7 @@ export const dynamic = 'force-dynamic';
 // 응답 없는 노드가 집계 전체를 붙잡지 않도록 노드별로 끊는다.
 const FETCH_TIMEOUT_MS = 5000;
 
-type NodeResult =
-  | { ok: true; data: ServerData }
-  | { ok: false; error: string };
+type NodeResult = { ok: true; data: ServerData } | { ok: false; error: string };
 
 export interface ClusterNode {
   name: string;
@@ -45,12 +38,22 @@ async function fetchNode(server: ClusterServer): Promise<ClusterNode> {
   try {
     const response = await fetch(url, { signal: controller.signal, headers, cache: 'no-store' });
     if (!response.ok) {
-      return { name: server.name, host: getClusterHost(server), type: server.type, result: { ok: false, error: `HTTP ${response.status}` } };
+      return {
+        name: server.name,
+        host: getClusterHost(server),
+        type: server.type,
+        result: { ok: false, error: `HTTP ${response.status}` }
+      };
     }
     const data = (await response.json()) as ServerData;
     return { name: server.name, host: getClusterHost(server), type: server.type, result: { ok: true, data } };
   } catch {
-    return { name: server.name, host: getClusterHost(server), type: server.type, result: { ok: false, error: 'Connection failed' } };
+    return {
+      name: server.name,
+      host: getClusterHost(server),
+      type: server.type,
+      result: { ok: false, error: 'Connection failed' }
+    };
   } finally {
     clearTimeout(timeout);
   }

--- a/src/app/api/cluster/route.ts
+++ b/src/app/api/cluster/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+
+import { ServerData } from '@/types/system';
+import {
+  ClusterServer,
+  getClusterHost,
+  getClusterServers,
+  getClusterUrl
+} from '@/config/clusterConfig';
+
+// 클러스터 뷰는 지금까지 브라우저에서 각 노드의 /api/system 을 직접 폴링했다.
+// 그래서 (a) 모든 노드가 대시보드 오리진을 CORS 로 허용해야 하고, (b) 노드 IP 가
+// 클라이언트 번들에 그대로 노출되며, (c) 뷰어 수만큼 노드 부하가 중복됐다.
+//
+// 이 라우트가 서버측에서 노드들을 대신 폴링해 압축 결과만 돌려준다. 브라우저는
+// 같은 오리진 한 곳만 부르면 되고, 노드 IP 는 서버에만 남는다.
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// 응답 없는 노드가 집계 전체를 붙잡지 않도록 노드별로 끊는다.
+const FETCH_TIMEOUT_MS = 5000;
+
+type NodeResult =
+  | { ok: true; data: ServerData }
+  | { ok: false; error: string };
+
+export interface ClusterNode {
+  name: string;
+  host: string;
+  type: ClusterServer['type'];
+  result: NodeResult;
+}
+
+async function fetchNode(server: ClusterServer): Promise<ClusterNode> {
+  const url = getClusterUrl(server, '/api/system');
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  // 노드에 API_AUTH_TOKEN 게이트가 켜져 있으면 서버가 대신 토큰을 실어 준다
+  // (브라우저는 실을 수 없던 값). 미설정이면 헤더를 붙이지 않는다.
+  const headers: Record<string, string> = {};
+  if (process.env.API_AUTH_TOKEN) headers.Authorization = `Bearer ${process.env.API_AUTH_TOKEN}`;
+
+  try {
+    const response = await fetch(url, { signal: controller.signal, headers, cache: 'no-store' });
+    if (!response.ok) {
+      return { name: server.name, host: getClusterHost(server), type: server.type, result: { ok: false, error: `HTTP ${response.status}` } };
+    }
+    const data = (await response.json()) as ServerData;
+    return { name: server.name, host: getClusterHost(server), type: server.type, result: { ok: true, data } };
+  } catch {
+    return { name: server.name, host: getClusterHost(server), type: server.type, result: { ok: false, error: 'Connection failed' } };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function GET() {
+  const servers = getClusterServers();
+  const nodes = await Promise.all(servers.map(fetchNode));
+
+  return NextResponse.json(
+    { nodes, timestamp: new Date().toISOString() },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,34 @@
+import os from 'os';
+import { NextResponse } from 'next/server';
+
+import { getLoopHealth } from '@/utils/systemStream';
+
+// 가벼운 헬스체크. /api/system 은 SSH IP·프로세스 목록 같은 무거운 정찰 정보를
+// 전부 수집하므로 컨테이너 orchestration/uptime 프로브에는 과하다. 이 라우트는
+// 수집을 트리거하지 않고 프로세스 생존과 수집 루프의 건강만 즉시 돌려준다.
+//
+// proxy.ts 의 토큰 게이트는 /api/system* 만 매칭하므로 이 경로는 게이트 밖 —
+// 오케스트레이터가 토큰 없이 프로브할 수 있다. 민감 정보는 노출하지 않는다.
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  const loop = getLoopHealth();
+
+  // 루프가 돌고 있는데도 마지막 틱이 너무 오래됐거나 연속 실패가 쌓이면
+  // degraded 로 보고한다(HTTP 는 여전히 200 — 프로브가 프로세스를 죽이지 않도록).
+  const stalled = loop.running && loop.lastTickAgeMs !== null && loop.lastTickAgeMs > 60_000;
+  const failing = loop.consecutiveFailures >= 5;
+  const status = stalled || failing ? 'degraded' : 'ok';
+
+  return NextResponse.json(
+    {
+      status,
+      uptime: Math.floor(os.uptime()),
+      loop,
+      timestamp: new Date().toISOString()
+    },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -59,6 +59,11 @@ export async function GET() {
   g('server_disk_percent', 'Disk usage percentage.', data.disk.percentage, { mount: '/' });
   g('server_disk_used_gb', 'Used disk in GB.', data.disk.used, { mount: '/' });
   g('server_disk_total_gb', 'Total disk in GB.', data.disk.total, { mount: '/' });
+  g(
+    'server_disk_hours_to_full',
+    'Estimated hours until root fills at the current rate.',
+    data.disk.hoursToFull
+  );
   if (data.disks) {
     const rowsPct: string[] = [];
     const rowsUsed: string[] = [];

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,126 @@
+import { getSystemInfo } from '@/utils/systemMonitor';
+import { isX86TemperatureInfo } from '@/types/system';
+
+// Prometheus 스크레이프 엔드포인트. 모니터링 도구인데 표준 노출 포맷이 없어
+// Grafana/Prometheus 로 장기 저장·경보를 위임할 수 없었다. getSystemInfo() 는
+// 이미 1초 캐시라 스크레이프가 추가 수집을 유발하지 않는다.
+//
+// 중요: SSH 접속 IP·프로세스명·트래픽 피어 같은 민감 정보는 내보내지 않고,
+// 수치 지표만 노출한다. (/api/system 과 달리 정찰용으로 쓸 수 없다.)
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Labels = Record<string, string>;
+
+function line(name: string, value: number, labels?: Labels): string {
+  if (!labels || Object.keys(labels).length === 0) return `${name} ${value}`;
+  const rendered = Object.entries(labels)
+    .map(([key, val]) => `${key}="${val.replace(/["\\\n]/g, '_')}"`)
+    .join(',');
+  return `${name}{${rendered}} ${value}`;
+}
+
+export async function GET() {
+  const data = await getSystemInfo();
+  const out: string[] = [];
+
+  const metric = (name: string, help: string, type: 'gauge' | 'counter', rows: string[]) => {
+    if (rows.length === 0) return;
+    out.push(`# HELP ${name} ${help}`);
+    out.push(`# TYPE ${name} ${type}`);
+    out.push(...rows);
+  };
+
+  const numeric = (value: number | 'N/A' | null | undefined): number | null =>
+    typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+  const g = (name: string, help: string, value: number | 'N/A' | null | undefined, labels?: Labels) => {
+    const v = numeric(value);
+    if (v !== null) metric(name, help, 'gauge', [line(name, v, labels)]);
+  };
+
+  out.push('# HELP server_up Whether the exporter responded (always 1).');
+  out.push('# TYPE server_up gauge');
+  out.push(line('server_up', 1));
+
+  g('server_cpu_usage_percent', 'CPU usage across all cores.', data.cpu.usage);
+  g('server_cpu_cores', 'Number of logical CPU cores.', data.cpu.cores);
+  g('server_cpu_temperature_celsius', 'CPU package temperature.', data.cpu.temperature);
+
+  g('server_memory_used_mb', 'Used memory in MB.', data.memory.used);
+  g('server_memory_total_mb', 'Total memory in MB.', data.memory.total);
+  g('server_memory_percent', 'Memory usage percentage.', data.memory.percentage);
+
+  // 루트 파일시스템. 다중 디스크(disks[])가 있으면 마운트별로도 노출한다.
+  g('server_disk_percent', 'Disk usage percentage.', data.disk.percentage, { mount: '/' });
+  g('server_disk_used_gb', 'Used disk in GB.', data.disk.used, { mount: '/' });
+  g('server_disk_total_gb', 'Total disk in GB.', data.disk.total, { mount: '/' });
+  if (data.disks) {
+    const rowsPct: string[] = [];
+    const rowsUsed: string[] = [];
+    const rowsTotal: string[] = [];
+    for (const d of data.disks) {
+      rowsPct.push(line('server_disk_percent', d.percentage, { mount: d.mount }));
+      rowsUsed.push(line('server_disk_used_gb', d.used, { mount: d.mount }));
+      rowsTotal.push(line('server_disk_total_gb', d.total, { mount: d.mount }));
+    }
+    metric('server_disk_percent', 'Disk usage percentage.', 'gauge', rowsPct);
+    metric('server_disk_used_gb', 'Used disk in GB.', 'gauge', rowsUsed);
+    metric('server_disk_total_gb', 'Total disk in GB.', 'gauge', rowsTotal);
+  }
+
+  if (data.swap) g('server_swap_percent', 'Swap usage percentage.', data.swap.percentage);
+
+  g('server_network_download_kbps', 'Download throughput in KB/s.', data.network.download);
+  g('server_network_upload_kbps', 'Upload throughput in KB/s.', data.network.upload);
+  g('server_network_ping_ms', 'Ping latency in ms.', data.network.ping);
+  g('server_network_connections', 'Established connections.', data.network.connections);
+  g('server_network_listening_ports', 'Listening ports.', data.network.listeningPorts);
+  g('server_network_bandwidth_percent', 'Link bandwidth utilisation.', data.network.bandwidthPercentage);
+
+  if (data.load) {
+    g('server_load1', '1-minute load average.', data.load.avg1);
+    g('server_load5', '5-minute load average.', data.load.avg5);
+    g('server_load15', '15-minute load average.', data.load.avg15);
+    g('server_load_running', 'Running/runnable kernel entities.', data.load.running);
+  }
+
+  if (data.diskIO) {
+    g('server_diskio_read_mbps', 'Disk read throughput in MB/s.', data.diskIO.read);
+    g('server_diskio_write_mbps', 'Disk write throughput in MB/s.', data.diskIO.write);
+  }
+
+  if (data.gpu) {
+    g('server_gpu_usage_percent', 'GPU utilisation.', data.gpu.usage);
+    g('server_gpu_temperature_celsius', 'GPU temperature.', data.gpu.temperature);
+  }
+
+  const fanRows = (['cpu', 'case1', 'case2'] as const)
+    .filter(key => data.fan[key] > 0)
+    .map(key => line('server_fan_rpm', data.fan[key], { fan: key }));
+  metric('server_fan_rpm', 'Fan speed in RPM.', 'gauge', fanRows);
+
+  // 마더보드/기타 온도(수치인 것만).
+  if (isX86TemperatureInfo(data.temperature)) {
+    g('server_gpu_edge_temperature_celsius', 'GPU edge temperature.', data.temperature.gpu);
+    g('server_motherboard_temperature_celsius', 'Motherboard temperature.', data.temperature.motherboard);
+  }
+
+  g('server_process_count', 'Number of top processes reported.', data.processes.length);
+
+  const alerts = data.alerts ?? [];
+  const activeAlerts = alerts.filter(a => a.level === 'warning' || a.level === 'critical').length;
+  metric('server_active_alerts', 'Alerts currently at warning/critical.', 'gauge', [
+    line('server_active_alerts', activeAlerts)
+  ]);
+
+  // Prometheus 텍스트 노출 포맷은 마지막 줄에 개행이 있어야 한다.
+  const body = out.join('\n') + '\n';
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',
+      'Cache-Control': 'no-store'
+    }
+  });
+}

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -47,6 +47,9 @@ export async function GET() {
   g('server_cpu_usage_percent', 'CPU usage across all cores.', data.cpu.usage);
   g('server_cpu_cores', 'Number of logical CPU cores.', data.cpu.cores);
   g('server_cpu_temperature_celsius', 'CPU package temperature.', data.cpu.temperature);
+  g('server_cpu_iowait_percent', 'CPU time waiting on I/O.', data.cpu.iowait);
+  g('server_cpu_steal_percent', 'CPU time stolen by the hypervisor.', data.cpu.steal);
+  g('server_cpu_frequency_mhz', 'Average current CPU clock in MHz.', data.cpu.frequencyMhz);
 
   g('server_memory_used_mb', 'Used memory in MB.', data.memory.used);
   g('server_memory_total_mb', 'Total memory in MB.', data.memory.total);
@@ -107,7 +110,16 @@ export async function GET() {
     g('server_motherboard_temperature_celsius', 'Motherboard temperature.', data.temperature.motherboard);
   }
 
-  g('server_process_count', 'Number of top processes reported.', data.processes.length);
+  if (data.processSummary) {
+    g('server_processes_total', 'Total processes.', data.processSummary.total);
+    g('server_processes_running', 'Running processes.', data.processSummary.running);
+    g('server_processes_zombie', 'Zombie processes.', data.processSummary.zombie);
+    g('server_threads_total', 'Total tasks including threads.', data.processSummary.threads);
+  } else {
+    g('server_process_count', 'Number of top processes reported.', data.processes.length);
+  }
+
+  if (data.battery) g('server_battery_percent', 'Battery charge level.', data.battery.percentage);
 
   const alerts = data.alerts ?? [];
   const activeAlerts = alerts.filter(a => a.level === 'warning' || a.level === 'critical').length;

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -3,6 +3,7 @@ import { corsHeaders } from '@/utils/cors';
 import { getSystemInfo } from '@/utils/systemMonitor';
 import { isValidServerData } from '@/utils/validation';
 import { logger } from '@/utils/logger';
+import { jsonResponse } from '@/utils/http';
 
 // 수집기별 실패는 systemMonitor 안에서 각자 fallback 으로 처리되므로,
 // 여기까지 올라온 에러는 진짜 고장이다. 0으로 채운 정상 응답을 돌려주면
@@ -32,9 +33,8 @@ export async function GET(request: Request) {
       });
     }
 
-    return new NextResponse(JSON.stringify(data), {
-      headers: getCorsHeaders(origin)
-    });
+    // 큰 JSON(history + processes)이라 클라이언트가 gzip 을 받으면 압축해 보낸다.
+    return jsonResponse(request, data, { headers: getCorsHeaders(origin) });
   } catch (error) {
     // 원인(파일 경로/명령 실패 메시지 등)은 서버 로그에만 남기고, 클라이언트에는
     // 내부 구조를 드러내지 않는 일반 메시지만 돌려준다.

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { corsHeaders } from '@/utils/cors';
 import { getSystemInfo } from '@/utils/systemMonitor';
 import { isValidServerData } from '@/utils/validation';
+import { logger } from '@/utils/logger';
 
 // 수집기별 실패는 systemMonitor 안에서 각자 fallback 으로 처리되므로,
 // 여기까지 올라온 에러는 진짜 고장이다. 0으로 채운 정상 응답을 돌려주면
@@ -24,7 +25,7 @@ export async function GET(request: Request) {
 
     // 데이터 유효성 검사
     if (!data || !isValidServerData(data)) {
-      console.error('Invalid server data received');
+      logger.error('Invalid server data received');
       return new NextResponse(JSON.stringify({ error: 'Invalid server data received' }), {
         status: 500,
         headers: getCorsHeaders(origin)
@@ -37,7 +38,7 @@ export async function GET(request: Request) {
   } catch (error) {
     // 원인(파일 경로/명령 실패 메시지 등)은 서버 로그에만 남기고, 클라이언트에는
     // 내부 구조를 드러내지 않는 일반 메시지만 돌려준다.
-    console.error('Error fetching system data:', error);
+    logger.error('Error fetching system data:', error);
     return new NextResponse(JSON.stringify({ error: 'Failed to collect system data' }), {
       status: 500,
       headers: getCorsHeaders(origin)

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -8,45 +8,45 @@ import { isValidServerData } from '@/utils/validation';
 // 대시보드에 "모든 값이 0" 으로만 보이고 원인이 감춰지므로 5xx 로 알린다.
 
 function getCorsHeaders(origin: string | undefined) {
-    // 이 라우트는 GET/OPTIONS 만 구현한다. 쓰지도 않는 메서드/헤더를 광고하지 않는다.
-    return corsHeaders(origin, {
-        'Access-Control-Allow-Methods': 'GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-        'Content-Type': 'application/json'
-    });
+  // 이 라우트는 GET/OPTIONS 만 구현한다. 쓰지도 않는 메서드/헤더를 광고하지 않는다.
+  return corsHeaders(origin, {
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Content-Type': 'application/json'
+  });
 }
 
 export async function GET(request: Request) {
-    const origin = request.headers.get('origin') || undefined;
+  const origin = request.headers.get('origin') || undefined;
 
-    try {
-        const data = await getSystemInfo();
+  try {
+    const data = await getSystemInfo();
 
-        // 데이터 유효성 검사
-        if (!data || !isValidServerData(data)) {
-            console.error('Invalid server data received');
-            return new NextResponse(JSON.stringify({ error: 'Invalid server data received' }), {
-                status: 500,
-                headers: getCorsHeaders(origin)
-            });
-        }
-
-        return new NextResponse(JSON.stringify(data), {
-            headers: getCorsHeaders(origin)
-        });
-    } catch (error) {
-        // 원인(파일 경로/명령 실패 메시지 등)은 서버 로그에만 남기고, 클라이언트에는
-        // 내부 구조를 드러내지 않는 일반 메시지만 돌려준다.
-        console.error('Error fetching system data:', error);
-        return new NextResponse(JSON.stringify({ error: 'Failed to collect system data' }), {
-            status: 500,
-            headers: getCorsHeaders(origin)
-        });
+    // 데이터 유효성 검사
+    if (!data || !isValidServerData(data)) {
+      console.error('Invalid server data received');
+      return new NextResponse(JSON.stringify({ error: 'Invalid server data received' }), {
+        status: 500,
+        headers: getCorsHeaders(origin)
+      });
     }
+
+    return new NextResponse(JSON.stringify(data), {
+      headers: getCorsHeaders(origin)
+    });
+  } catch (error) {
+    // 원인(파일 경로/명령 실패 메시지 등)은 서버 로그에만 남기고, 클라이언트에는
+    // 내부 구조를 드러내지 않는 일반 메시지만 돌려준다.
+    console.error('Error fetching system data:', error);
+    return new NextResponse(JSON.stringify({ error: 'Failed to collect system data' }), {
+      status: 500,
+      headers: getCorsHeaders(origin)
+    });
+  }
 }
 
 // OPTIONS 메서드 핸들링 (CORS preflight 요청 처리)
 export function OPTIONS(request: Request) {
-    const origin = request.headers.get('origin') || undefined;
-    return new NextResponse(null, { headers: getCorsHeaders(origin) });
+  const origin = request.headers.get('origin') || undefined;
+  return new NextResponse(null, { headers: getCorsHeaders(origin) });
 }

--- a/src/app/api/system/stream/route.ts
+++ b/src/app/api/system/stream/route.ts
@@ -14,60 +14,60 @@ export const runtime = 'nodejs';
 const KEEPALIVE_MS = 15000;
 
 export async function GET(request: Request) {
-    const origin = request.headers.get('origin') || undefined;
-    const encoder = new TextEncoder();
+  const origin = request.headers.get('origin') || undefined;
+  const encoder = new TextEncoder();
 
-    let unsubscribe: () => void = () => {};
-    let keepAlive: ReturnType<typeof setInterval> | null = null;
+  let unsubscribe: () => void = () => {};
+  let keepAlive: ReturnType<typeof setInterval> | null = null;
 
-    const stream = new ReadableStream({
-        start(controller) {
-            const push = (chunk: string) => {
-                try {
-                    controller.enqueue(encoder.encode(chunk));
-                } catch {
-                    // 컨트롤러가 이미 닫힘(클라이언트 종료). 정리는 abort/cancel 이 맡는다.
-                }
-            };
-
-            const send = (data: ServerData) => push(`data: ${JSON.stringify(data)}\n\n`);
-
-            unsubscribe = subscribe(send);
-
-            // ": " 로 시작하는 줄은 SSE 코멘트라 클라이언트가 무시한다. 연결 유지용.
-            keepAlive = setInterval(() => push(': ping\n\n'), KEEPALIVE_MS);
-
-            const cleanup = () => {
-                unsubscribe();
-                if (keepAlive) {
-                    clearInterval(keepAlive);
-                    keepAlive = null;
-                }
-                try {
-                    controller.close();
-                } catch {
-                    // 이미 닫힌 경우 무시.
-                }
-            };
-
-            request.signal.addEventListener('abort', cleanup);
-        },
-        cancel() {
-            unsubscribe();
-            if (keepAlive) {
-                clearInterval(keepAlive);
-                keepAlive = null;
-            }
+  const stream = new ReadableStream({
+    start(controller) {
+      const push = (chunk: string) => {
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          // 컨트롤러가 이미 닫힘(클라이언트 종료). 정리는 abort/cancel 이 맡는다.
         }
-    });
+      };
 
-    const headers = corsHeaders(origin, {
-        'Content-Type': 'text/event-stream; charset=utf-8',
-        'Cache-Control': 'no-cache, no-transform',
-        Connection: 'keep-alive',
-        // nginx 리버스 프록시가 응답을 버퍼링해 실시간성이 깨지는 것을 막는다.
-        'X-Accel-Buffering': 'no'
-    });
+      const send = (data: ServerData) => push(`data: ${JSON.stringify(data)}\n\n`);
 
-    return new Response(stream, { headers });
+      unsubscribe = subscribe(send);
+
+      // ": " 로 시작하는 줄은 SSE 코멘트라 클라이언트가 무시한다. 연결 유지용.
+      keepAlive = setInterval(() => push(': ping\n\n'), KEEPALIVE_MS);
+
+      const cleanup = () => {
+        unsubscribe();
+        if (keepAlive) {
+          clearInterval(keepAlive);
+          keepAlive = null;
+        }
+        try {
+          controller.close();
+        } catch {
+          // 이미 닫힌 경우 무시.
+        }
+      };
+
+      request.signal.addEventListener('abort', cleanup);
+    },
+    cancel() {
+      unsubscribe();
+      if (keepAlive) {
+        clearInterval(keepAlive);
+        keepAlive = null;
+      }
+    }
+  });
+
+  const headers = corsHeaders(origin, {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    // nginx 리버스 프록시가 응답을 버퍼링해 실시간성이 깨지는 것을 막는다.
+    'X-Accel-Buffering': 'no'
+  });
+
+  return new Response(stream, { headers });
 }

--- a/src/app/api/system/stream/route.ts
+++ b/src/app/api/system/stream/route.ts
@@ -30,8 +30,15 @@ export async function GET(request: Request) {
         }
       };
 
-      const send = (data: ServerData) => push(`data: ${JSON.stringify(data)}\n\n`);
+      // 각 이벤트에 id 를 달고, 연결 시작에 재연결 지연(retry) 힌트를 준다.
+      // id 는 EventSource 가 재연결 시 Last-Event-ID 로 되돌려 보내며, retry 는
+      // 브라우저 기본 재연결 간격을 명시해 끊겼을 때 복구 동작을 예측 가능하게 한다.
+      const send = (data: ServerData) => {
+        const id = data.timestamp ?? new Date().toISOString();
+        push(`id: ${id}\ndata: ${JSON.stringify(data)}\n\n`);
+      };
 
+      push('retry: 3000\n\n');
       unsubscribe = subscribe(send);
 
       // ": " 로 시작하는 줄은 SSE 코멘트라 클라이언트가 무시한다. 연결 유지용.

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Activity,
   Clock,
@@ -18,70 +18,55 @@ import {
 import { Gauge, Sparkline } from '@/components/dashboard/primitives';
 import { useNow } from '@/hooks/useNow';
 import { cn } from '@/lib/utils';
-import {
-  ClusterServer,
-  getClusterHost,
-  getClusterServers,
-  getClusterUrl
-} from '@/config/clusterConfig';
 import { NetworkHistoryEntry, ServerData } from '@/types/system';
 import { formatClock, formatRate } from '@/utils/format';
 import { COLORS, statusColor, tempColor } from '@/utils/statusColors';
 
 // 이 페이지는 메인 대시보드(src/app/page.tsx)와 같은 터미널 디자인을 그대로 쓰되,
-// 한 호스트가 아니라 클러스터의 여러 노드를 한 화면에 나란히 띄운다. 각 노드는
-// 자기 /api/system 을 그대로 내주므로(같은 API), 여기서는 그 응답에서 핵심 지표만
-// 추려 노드당 카드 하나로 압축한다.
+// 한 호스트가 아니라 클러스터의 여러 노드를 한 화면에 나란히 띄운다. 예전에는
+// 브라우저가 각 노드의 /api/system 을 직접 폴링했지만, 이제 같은 오리진의
+// /api/cluster 가 서버측에서 노드들을 대신 모아 압축 결과만 내려준다 — 노드 IP 는
+// 클라이언트에 노출되지 않고, 노드마다 CORS 를 열 필요도 없다.
 
-// 노드마다 매초 갱신한다 — 메인 대시보드의 폴링 주기와 같다.
+// 매초 갱신한다 — 메인 대시보드의 폴링 주기와 같다.
 const POLL_INTERVAL_MS = 1000;
-// 응답이 없는 노드가 요청 전체를 붙잡지 않도록 노드별로 끊는다.
-const FETCH_TIMEOUT_MS = 5000;
 // 스파크라인이 덮는 구간. 노드 하나당 최근 30초.
 const MAX_NETWORK_POINTS = 30;
 
-type ServerResult =
+type NodeResult =
   | { ok: true; data: ServerData }
   | { ok: false; error: string };
 
-// 노드 하나를 가져온다. 컴포넌트 상태에 기대지 않는 순수 함수라 모듈 스코프에 둔다.
-async function fetchServer(server: ClusterServer): Promise<[string, ServerResult]> {
-  const url = getClusterUrl(server, '/api/system');
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      return [server.ip, { ok: false, error: `HTTP ${response.status}` }];
-    }
-    const data = (await response.json()) as ServerData;
-    return [server.ip, { ok: true, data }];
-  } catch {
-    return [server.ip, { ok: false, error: 'Connection failed' }];
-  } finally {
-    clearTimeout(timeout);
-  }
+// /api/cluster 가 노드당 내려주는 형태. IP 는 없고 표시용 host 라벨만 있다.
+interface ClusterNode {
+  name: string;
+  host: string;
+  type: 'intel' | 'rpi';
+  result: NodeResult;
 }
 
 export default function ClusterPage() {
-  // .env 의 NEXT_PUBLIC_CLUSTER_SERVERS 로 정해진 노드 목록. 렌더마다 다시 파싱하지 않는다.
-  const servers = useMemo(() => getClusterServers(), []);
-  const [results, setResults] = useState<Record<string, ServerResult>>({});
+  // null = 아직 첫 응답 전(연결 중), [] = 서버가 노드 없음이라고 확인해 준 상태.
+  const [nodes, setNodes] = useState<ClusterNode[] | null>(null);
   const [networkHistory, setNetworkHistory] = useState<Record<string, NetworkHistoryEntry[]>>({});
   const now = useNow();
 
   const refresh = useCallback(async () => {
-    if (servers.length === 0) return;
-
-    const entries = await Promise.all(servers.map(fetchServer));
-
-    const next: Record<string, ServerResult> = {};
-    for (const [ip, result] of entries) next[ip] = result;
-    setResults(next);
+    let received: ClusterNode[] = [];
+    try {
+      const response = await fetch('/api/cluster', { cache: 'no-store' });
+      if (response.ok) {
+        const payload = (await response.json()) as { nodes: ClusterNode[] };
+        received = payload.nodes ?? [];
+      }
+    } catch {
+      // 집계 엔드포인트에 못 닿으면 마지막 값을 유지한다(화면을 비우지 않는다).
+      return;
+    }
+    setNodes(received);
 
     // 스파크라인에 쓸 순간 처리량을 노드별 히스토리에 이어 붙인다. 넣을 때 잘라
-    // 두므로 별도 정리 타이머가 필요 없다.
+    // 두므로 별도 정리 타이머가 필요 없다. IP 가 없어 이름을 키로 쓴다.
     const time = new Date().toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
@@ -90,18 +75,18 @@ export default function ClusterPage() {
     });
     setNetworkHistory(prev => {
       const updated = { ...prev };
-      for (const [ip, result] of entries) {
-        if (!result.ok) continue;
+      for (const node of received) {
+        if (!node.result.ok) continue;
         const point: NetworkHistoryEntry = {
           time,
-          download: result.data.network?.download ?? 0,
-          upload: result.data.network?.upload ?? 0
+          download: node.result.data.network?.download ?? 0,
+          upload: node.result.data.network?.upload ?? 0
         };
-        updated[ip] = [...(updated[ip] ?? []), point].slice(-MAX_NETWORK_POINTS);
+        updated[node.name] = [...(updated[node.name] ?? []), point].slice(-MAX_NETWORK_POINTS);
       }
       return updated;
     });
-  }, [servers]);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -117,24 +102,20 @@ export default function ClusterPage() {
     };
   }, [refresh]);
 
-  const onlineCount = servers.filter(server => results[server.ip]?.ok).length;
+  const onlineCount = (nodes ?? []).filter(node => node.result.ok).length;
+  const total = nodes?.length ?? 0;
 
   return (
     <div className="terminal-bg min-h-screen text-gray-100">
       <TerminalTitleBar />
-      <ClusterHeader online={onlineCount} total={servers.length} now={now} />
+      <ClusterHeader online={onlineCount} total={total} now={now} />
 
-      {servers.length === 0 ? (
+      {nodes !== null && nodes.length === 0 ? (
         <EmptyCluster />
       ) : (
         <div className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-2 lg:grid-cols-4">
-          {servers.map(server => (
-            <ServerCard
-              key={server.ip}
-              server={server}
-              result={results[server.ip]}
-              history={networkHistory[server.ip] ?? []}
-            />
+          {(nodes ?? []).map(node => (
+            <ServerCard key={node.name} node={node} history={networkHistory[node.name] ?? []} />
           ))}
         </div>
       )}
@@ -216,25 +197,18 @@ const EmptyCluster: React.FC = () => (
 // --- 노드 카드 -------------------------------------------------------------
 
 interface ServerCardProps {
-  server: ClusterServer;
-  result: ServerResult | undefined;
+  node: ClusterNode;
   history: NetworkHistoryEntry[];
 }
 
-const ServerCard: React.FC<ServerCardProps> = ({ server, result, history }) => {
-  // 첫 응답 전(undefined)과 연결 실패(ok=false)를 나눠, 처음엔 "연결 중", 실패엔
-  // 그 이유를 보여 준다. 메인 대시보드가 마지막 값을 유지하듯 여기도 프레임은 늘 그린다.
-  if (!result) {
-    return (
-      <ServerShell server={server} status="connecting">
-        <Empty>connecting…</Empty>
-      </ServerShell>
-    );
-  }
+const ServerCard: React.FC<ServerCardProps> = ({ node, history }) => {
+  const { result } = node;
 
+  // 연결 실패면 그 이유를 보여 준다. 메인 대시보드가 마지막 값을 유지하듯 여기도
+  // 프레임은 늘 그린다.
   if (!result.ok) {
     return (
-      <ServerShell server={server} status="offline">
+      <ServerShell name={node.name} host={node.host} status="offline">
         <p className="t-body text-red-400">{result.error}</p>
       </ServerShell>
     );
@@ -250,7 +224,7 @@ const ServerCard: React.FC<ServerCardProps> = ({ server, result, history }) => {
   const topProcess = result.data.processes.find(process => process.cpu > 0 || process.memory > 0);
 
   return (
-    <ServerShell server={server} status="online">
+    <ServerShell name={node.name} host={node.host} status="online">
       <div className="grid grid-cols-3 gap-2">
         <MiniGauge icon={Cpu} iconColor="#60a5fa" label="CPU" percentage={cpu.usage} caption={`${cpu.cores}c`} />
         <MiniGauge
@@ -315,15 +289,16 @@ const STATUS_COLOR: Record<ServerStatus, string> = {
 
 // 노드 카드의 공통 껍데기 — 메인 대시보드의 Card 와 같은 결(보더/배경/헤더)이다.
 const ServerShell: React.FC<{
-  server: ClusterServer;
+  name: string;
+  host: string;
   status: ServerStatus;
   children: React.ReactNode;
-}> = ({ server, status, children }) => (
+}> = ({ name, host, status, children }) => (
   <section className="dash-card flex flex-col rounded-lg border border-gray-700 bg-gray-800">
     <div className="dash-card-head flex items-center justify-between gap-2">
       <div className="flex min-w-0 items-center gap-1.5">
         <Server className="dash-icon shrink-0" color={STATUS_COLOR[status]} strokeWidth={2} />
-        <h2 className="t-label truncate font-bold tracking-[0.04em] text-gray-100">{server.name}</h2>
+        <h2 className="t-label truncate font-bold tracking-[0.04em] text-gray-100">{name}</h2>
       </div>
       <span className="flex shrink-0 items-center gap-1">
         <span
@@ -334,7 +309,7 @@ const ServerShell: React.FC<{
             status === 'connecting' && 'bg-gray-500'
           )}
         />
-        <span className="t-micro font-mono text-gray-500">{getClusterHost(server)}</span>
+        <span className="t-micro font-mono text-gray-500">{host}</span>
       </span>
     </div>
     {children}
@@ -379,9 +354,6 @@ const InfoItem: React.FC<{ icon: LucideIcon; color: string; value: string }> = (
   </span>
 );
 
-const Empty: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <p className="t-body text-gray-500">{children}</p>
-);
 
 // --- 표기 헬퍼 -------------------------------------------------------------
 

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -33,9 +33,7 @@ const POLL_INTERVAL_MS = 1000;
 // 스파크라인이 덮는 구간. 노드 하나당 최근 30초.
 const MAX_NETWORK_POINTS = 30;
 
-type NodeResult =
-  | { ok: true; data: ServerData }
-  | { ok: false; error: string };
+type NodeResult = { ok: true; data: ServerData } | { ok: false; error: string };
 
 // /api/cluster 가 노드당 내려주는 형태. IP 는 없고 표시용 host 라벨만 있다.
 interface ClusterNode {
@@ -226,7 +224,13 @@ const ServerCard: React.FC<ServerCardProps> = ({ node, history }) => {
   return (
     <ServerShell name={node.name} host={node.host} status="online">
       <div className="grid grid-cols-3 gap-2">
-        <MiniGauge icon={Cpu} iconColor="#60a5fa" label="CPU" percentage={cpu.usage} caption={`${cpu.cores}c`} />
+        <MiniGauge
+          icon={Cpu}
+          iconColor="#60a5fa"
+          label="CPU"
+          percentage={cpu.usage}
+          caption={`${cpu.cores}c`}
+        />
         <MiniGauge
           icon={MemoryStick}
           iconColor="#4ade80"
@@ -345,7 +349,11 @@ const MiniGauge: React.FC<MiniGaugeProps> = ({ icon: Icon, iconColor, label, per
   );
 };
 
-const InfoItem: React.FC<{ icon: LucideIcon; color: string; value: string }> = ({ icon: Icon, color, value }) => (
+const InfoItem: React.FC<{ icon: LucideIcon; color: string; value: string }> = ({
+  icon: Icon,
+  color,
+  value
+}) => (
   <span className="flex items-center gap-1">
     <Icon className="dash-icon shrink-0" color={color} strokeWidth={2} />
     <span className="truncate font-mono" style={{ color }}>
@@ -353,7 +361,6 @@ const InfoItem: React.FC<{ icon: LucideIcon; color: string; value: string }> = (
     </span>
   </span>
 );
-
 
 // --- 표기 헬퍼 -------------------------------------------------------------
 

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -82,7 +82,7 @@ export default function ClusterPage() {
 
     // 스파크라인에 쓸 순간 처리량을 노드별 히스토리에 이어 붙인다. 넣을 때 잘라
     // 두므로 별도 정리 타이머가 필요 없다.
-    const time = new Date().toLocaleTimeString('ko-KR', {
+    const time = new Date().toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,10 +3,7 @@
 import { useEffect } from 'react';
 import { FallbackProps } from 'react-error-boundary';
 
-export default function Error({
-  error,
-  resetErrorBoundary,
-}: FallbackProps) {
+export default function Error({ error, resetErrorBoundary }: FallbackProps) {
   useEffect(() => {
     console.error(error);
   }, [error]);
@@ -24,4 +21,4 @@ export default function Error({
       </div>
     </div>
   );
-} 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,99 +1,99 @@
-import * as React from "react";
-import { Suspense } from "react";
-import type { Metadata, Viewport } from "next";
-import { ErrorBoundary } from "react-error-boundary";
-import { Geist, Geist_Mono } from "next/font/google";
+import * as React from 'react';
+import { Suspense } from 'react';
+import type { Metadata, Viewport } from 'next';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Geist, Geist_Mono } from 'next/font/google';
 
 import Loading from '@/app/loading';
 import Error from '@/app/error';
 import { SITE_URL, SITE_NAME, SITE_SHORT_NAME, SITE_DESCRIPTION, AUTHOR_NAME } from '@/config/siteConfig';
-import "@/styles/globals.css";
+import '@/styles/globals.css';
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+  variable: '--font-geist-sans',
+  subsets: ['latin']
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: '--font-geist-mono',
+  subsets: ['latin']
 });
 
 // 모바일에서 CSS 픽셀이 기기 폭을 따라가야 반응형 레이아웃이 의도대로 접힌다.
 // 사용자가 핀치/더블탭으로 화면을 확대·축소하지 못하도록 배율을 1로 고정한다.
 export const viewport: Viewport = {
-    width: "device-width",
-    initialScale: 1,
-    maximumScale: 1,
-    minimumScale: 1,
-    userScalable: false,
-    themeColor: "#0a0d13"
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  minimumScale: 1,
+  userScalable: false,
+  themeColor: '#0a0d13'
 };
 
 export const metadata: Metadata = {
-    metadataBase: new URL(SITE_URL),
-    title: {
-        template: `%s | ${SITE_SHORT_NAME}`,
-        default: SITE_NAME
-    },
+  metadataBase: new URL(SITE_URL),
+  title: {
+    template: `%s | ${SITE_SHORT_NAME}`,
+    default: SITE_NAME
+  },
+  description: SITE_DESCRIPTION,
+  manifest: '/manifest.json',
+  applicationName: SITE_NAME,
+  keywords: [],
+  authors: [{ name: AUTHOR_NAME }],
+  creator: AUTHOR_NAME,
+  publisher: AUTHOR_NAME,
+  formatDetection: {
+    telephone: true,
+    date: true,
+    address: true,
+    email: true,
+    url: true
+  },
+  icons: {
+    icon: [
+      { url: '/favicon.svg', type: 'image/svg+xml' },
+      { url: '/favicon.ico', sizes: 'any', type: 'image/x-icon' }
+    ],
+    shortcut: ['/favicon.svg']
+  },
+  openGraph: {
+    title: SITE_NAME,
     description: SITE_DESCRIPTION,
-    manifest: "/manifest.json",
-    applicationName: SITE_NAME,
-    keywords: [],
-    authors: [{ name: AUTHOR_NAME }],
-    creator: AUTHOR_NAME,
-    publisher: AUTHOR_NAME,
-    formatDetection: {
-        telephone: true,
-        date: true,
-        address: true,
-        email: true,
-        url: true
-    },
-    icons: {
-        icon: [
-            { url: "/favicon.svg", type: "image/svg+xml" },
-            { url: "/favicon.ico", sizes: "any", type: "image/x-icon" }
-        ],
-        shortcut: ["/favicon.svg"]
-    },
-    openGraph: {
-        title: SITE_NAME,
-        description: SITE_DESCRIPTION,
-        url: SITE_URL,
-        siteName: SITE_NAME,
-        images: [
-            {
-                url: `${SITE_URL}/screenshots/home.png`,
-                width: 1280,
-                height: 720,
-                alt: `${SITE_SHORT_NAME} Home`
-            }
-        ],
-        type: "website",
-        locale: "en_US",
-    },
-    twitter: {
-        card: "summary_large_image",
-        title: SITE_NAME,
-        description: SITE_DESCRIPTION,
-        images: [`${SITE_URL}/screenshots/home.png`],
-        creator: AUTHOR_NAME,
-    },
-    verification: {
-        // Google Search Console 등에 사용되는 확인 코드가 있다면 추가
-        // google: "VERIFICATION_CODE",
-    },
-    alternates: {
-        canonical: SITE_URL,
-        languages: {
-            'en-US': SITE_URL,
-        },
-    },
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    images: [
+      {
+        url: `${SITE_URL}/screenshots/home.png`,
+        width: 1280,
+        height: 720,
+        alt: `${SITE_SHORT_NAME} Home`
+      }
+    ],
+    type: 'website',
+    locale: 'en_US'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    images: [`${SITE_URL}/screenshots/home.png`],
+    creator: AUTHOR_NAME
+  },
+  verification: {
+    // Google Search Console 등에 사용되는 확인 코드가 있다면 추가
+    // google: "VERIFICATION_CODE",
+  },
+  alternates: {
+    canonical: SITE_URL,
+    languages: {
+      'en-US': SITE_URL
+    }
+  }
 };
 
 export default function RootLayout({
-  children,
+  children
 }: Readonly<{
   children: React.ReactNode;
 }>) {
@@ -101,19 +101,17 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         {/* theme-color 는 위의 viewport export 가 넣어준다. */}
-        <link rel="manifest" href="/manifest.json"/>
-        <meta name="mobile-web-app-capable" content="yes"/>
-        <meta name="mobile-web-app-status-bar-style" content="default"/>
-        <meta name="mobile-web-app-title" content={SITE_SHORT_NAME}/>
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-status-bar-style" content="default" />
+        <meta name="mobile-web-app-title" content={SITE_SHORT_NAME} />
         <title>{SITE_NAME}</title>
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased h-auto bg-gray-900 text-gray-100`}
       >
         <ErrorBoundary FallbackComponent={Error}>
-          <Suspense fallback={<Loading />}>
-            {children}
-          </Suspense>
+          <Suspense fallback={<Loading />}>{children}</Suspense>
         </ErrorBoundary>
       </body>
     </html>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -7,4 +7,4 @@ export default function Loading() {
       </div>
     </div>
   );
-} 
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
       <div className="text-center">
         <h2 className="text-2xl font-bold text-white mb-4">404 - Page Not Found</h2>
         <p className="text-gray-400 mb-6">The page you are looking for does not exist.</p>
-        <Link 
+        <Link
           href="/"
           className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
         >
@@ -15,4 +15,4 @@ export default function NotFound() {
       </div>
     </div>
   );
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import React, { useEffect } from 'react';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,44 @@ import React, { useEffect } from 'react';
 import { Dashboard } from '@/components/dashboard/Dashboard';
 import { useNow } from '@/hooks/useNow';
 import { useSystemData } from '@/hooks/useSystemData';
+import type { DashboardData } from '@/utils/dashboardData';
+
+// 탭만 봐도 경보를 알 수 있도록, 지금 당장 문제가 있으면 문서 제목에 ⚠ 를 붙이고
+// 파비콘을 빨간 점으로 바꾼다. 벽에 여러 탭을 띄워 두는 운용에서 유용하다.
+const BASE_TITLE = 'Server Monitor';
+const ALERT_FAVICON =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="14" fill="%23ef4444"/></svg>'
+  );
+
+function hasActiveAlert(data: DashboardData): boolean {
+  return (
+    data.cpu.usage > 85 ||
+    data.memory.percentage > 90 ||
+    data.disk.percentage > 90 ||
+    (data.cpu.temperature !== 'N/A' && data.cpu.temperature > 74) ||
+    (data.swap.total > 0 && data.swap.percentage > 80) ||
+    data.security.firewall.status === 'inactive'
+  );
+}
 
 export default function DisplayPage() {
   const { data, error, connected, lastUpdate, networkHistory, diskIoHistory } = useSystemData();
   const now = useNow();
+
+  const alerting = data !== null && hasActiveAlert(data);
+
+  useEffect(() => {
+    document.title = alerting ? `⚠ ${BASE_TITLE}` : BASE_TITLE;
+
+    const icon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (!icon) return;
+    // 원래 아이콘을 기억해 두었다가, 경보가 풀리면 되돌린다.
+    const original = icon.dataset.original ?? icon.getAttribute('href') ?? '/favicon.svg';
+    icon.dataset.original = original;
+    icon.setAttribute('href', alerting ? ALERT_FAVICON : original);
+  }, [alerting]);
 
   useEffect(() => {
     // 화면 잠김 방지

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,16 +1,16 @@
 import { SITE_URL } from '@/config/siteConfig';
 
 export default function robots() {
-    return {
-        rules: [
-            {
-                userAgent: '*',
-                allow: [],
-                disallow: ['/'],
-                crawlDelay: 5,
-            }
-        ],
-        sitemap: `${SITE_URL}/sitemap.xml`,
-        host: SITE_URL,
-    }
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: [],
+        disallow: ['/'],
+        crawlDelay: 5
+      }
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL
+  };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,17 +1,17 @@
 import { SITE_URL } from '@/config/siteConfig';
 
 export default function sitemap() {
-    const baseUrl = SITE_URL;
-    const currentDate = new Date().toISOString();
+  const baseUrl = SITE_URL;
+  const currentDate = new Date().toISOString();
 
-    const routes = [
-        {
-            url: baseUrl,
-            lastModified: currentDate,
-            changeFrequency: 'daily',
-            priority: 1,
-        }
-    ];
+  const routes = [
+    {
+      url: baseUrl,
+      lastModified: currentDate,
+      changeFrequency: 'daily',
+      priority: 1
+    }
+  ];
 
-    return routes;
+  return routes;
 }

--- a/src/components/charts/NetworkAreaChart.tsx
+++ b/src/components/charts/NetworkAreaChart.tsx
@@ -72,7 +72,9 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
     PAD_TOP + innerHeight - (Math.max(0, Math.min(max, value / divisor)) / max) * innerHeight;
 
   const line = (key: 'download' | 'upload') =>
-    data.map((entry, index) => `${index === 0 ? 'M' : 'L'}${x(index).toFixed(1)},${y(entry[key]).toFixed(1)}`).join(' ');
+    data
+      .map((entry, index) => `${index === 0 ? 'M' : 'L'}${x(index).toFixed(1)},${y(entry[key]).toFixed(1)}`)
+      .join(' ');
 
   const area = (key: 'download' | 'upload') =>
     `${line(key)} L${x(data.length - 1).toFixed(1)},${PAD_TOP + innerHeight} L${x(0).toFixed(1)},${PAD_TOP + innerHeight} Z`;
@@ -105,7 +107,14 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
         </linearGradient>
       </defs>
 
-      <line x1={PAD_LEFT} y1={PAD_TOP} x2={PAD_LEFT} y2={PAD_TOP + innerHeight} stroke="rgba(255,255,255,0.10)" strokeWidth={1} />
+      <line
+        x1={PAD_LEFT}
+        y1={PAD_TOP}
+        x2={PAD_LEFT}
+        y2={PAD_TOP + innerHeight}
+        stroke="rgba(255,255,255,0.10)"
+        strokeWidth={1}
+      />
       <line
         x1={PAD_LEFT}
         y1={PAD_TOP + innerHeight}
@@ -117,7 +126,14 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
 
       {ticks.map(tick => (
         <g key={tick}>
-          <line x1={PAD_LEFT - 4} y1={y(tick * divisor)} x2={PAD_LEFT} y2={y(tick * divisor)} stroke="rgba(255,255,255,0.14)" strokeWidth={1} />
+          <line
+            x1={PAD_LEFT - 4}
+            y1={y(tick * divisor)}
+            x2={PAD_LEFT}
+            y2={y(tick * divisor)}
+            stroke="rgba(255,255,255,0.14)"
+            strokeWidth={1}
+          />
           <text x={PAD_LEFT - 8} y={y(tick * divisor) + 3} fontSize={9} fill="#9ca3af" textAnchor="end">
             {`${tick.toFixed(tick < 2 ? 1 : 0)} ${unit}`}
           </text>
@@ -129,53 +145,82 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
       <path d={line('download')} fill="none" stroke="#3b82f6" strokeWidth={2} />
       <path d={line('upload')} fill="none" stroke="#10b981" strokeWidth={2} />
 
-      <text x={PAD_LEFT + innerWidth} y={PAD_TOP + innerHeight + 14} fontSize={9} fill="#6b7280" textAnchor="end">
+      <text
+        x={PAD_LEFT + innerWidth}
+        y={PAD_TOP + innerHeight + 14}
+        fontSize={9}
+        fill="#6b7280"
+        textAnchor="end"
+      >
         now
       </text>
 
-      {activeEntry && active !== null && (() => {
-        const cx = x(active);
-        const lines = [
-          activeEntry.time,
-          `↓ ${(activeEntry.download / divisor).toFixed(1)} ${unit}`,
-          `↑ ${(activeEntry.upload / divisor).toFixed(1)} ${unit}`
-        ];
-        const boxWidth = Math.max(...lines.map(text => text.length)) * READOUT_CHAR_W + READOUT_PAD * 2;
-        const boxHeight = lines.length * READOUT_LINE + READOUT_PAD * 2 - 3;
-        // 오른쪽 끝에서는 말풍선이 축 밖으로 나가므로 커서 왼쪽에 붙인다.
-        const flip = cx + 10 + boxWidth > PAD_LEFT + innerWidth;
-        const boxX = flip ? cx - 10 - boxWidth : cx + 10;
+      {activeEntry &&
+        active !== null &&
+        (() => {
+          const cx = x(active);
+          const lines = [
+            activeEntry.time,
+            `↓ ${(activeEntry.download / divisor).toFixed(1)} ${unit}`,
+            `↑ ${(activeEntry.upload / divisor).toFixed(1)} ${unit}`
+          ];
+          const boxWidth = Math.max(...lines.map(text => text.length)) * READOUT_CHAR_W + READOUT_PAD * 2;
+          const boxHeight = lines.length * READOUT_LINE + READOUT_PAD * 2 - 3;
+          // 오른쪽 끝에서는 말풍선이 축 밖으로 나가므로 커서 왼쪽에 붙인다.
+          const flip = cx + 10 + boxWidth > PAD_LEFT + innerWidth;
+          const boxX = flip ? cx - 10 - boxWidth : cx + 10;
 
-        return (
-          <g pointerEvents="none">
-            <line x1={cx} y1={PAD_TOP} x2={cx} y2={PAD_TOP + innerHeight} stroke="rgba(255,255,255,0.28)" strokeWidth={1} />
-            <circle cx={cx} cy={y(activeEntry.download)} r={3} fill="#3b82f6" stroke="#0a0d13" strokeWidth={1.5} />
-            <circle cx={cx} cy={y(activeEntry.upload)} r={3} fill="#10b981" stroke="#0a0d13" strokeWidth={1.5} />
+          return (
+            <g pointerEvents="none">
+              <line
+                x1={cx}
+                y1={PAD_TOP}
+                x2={cx}
+                y2={PAD_TOP + innerHeight}
+                stroke="rgba(255,255,255,0.28)"
+                strokeWidth={1}
+              />
+              <circle
+                cx={cx}
+                cy={y(activeEntry.download)}
+                r={3}
+                fill="#3b82f6"
+                stroke="#0a0d13"
+                strokeWidth={1.5}
+              />
+              <circle
+                cx={cx}
+                cy={y(activeEntry.upload)}
+                r={3}
+                fill="#10b981"
+                stroke="#0a0d13"
+                strokeWidth={1.5}
+              />
 
-            <rect
-              x={boxX}
-              y={PAD_TOP + 4}
-              width={boxWidth}
-              height={boxHeight}
-              rx={4}
-              fill="#111621"
-              stroke="rgba(255,255,255,0.14)"
-              strokeWidth={1}
-            />
-            {lines.map((text, row) => (
-              <text
-                key={text}
-                x={boxX + READOUT_PAD}
-                y={PAD_TOP + 4 + READOUT_PAD + READOUT_LINE * row + READOUT_FONT - 2}
-                fontSize={READOUT_FONT}
-                fill={row === 0 ? '#8b93a7' : row === 1 ? '#54a2ff' : '#00d294'}
-              >
-                {text}
-              </text>
-            ))}
-          </g>
-        );
-      })()}
+              <rect
+                x={boxX}
+                y={PAD_TOP + 4}
+                width={boxWidth}
+                height={boxHeight}
+                rx={4}
+                fill="#111621"
+                stroke="rgba(255,255,255,0.14)"
+                strokeWidth={1}
+              />
+              {lines.map((text, row) => (
+                <text
+                  key={text}
+                  x={boxX + READOUT_PAD}
+                  y={PAD_TOP + 4 + READOUT_PAD + READOUT_LINE * row + READOUT_FONT - 2}
+                  fontSize={READOUT_FONT}
+                  fill={row === 0 ? '#8b93a7' : row === 1 ? '#54a2ff' : '#00d294'}
+                >
+                  {text}
+                </text>
+              ))}
+            </g>
+          );
+        })()}
     </svg>
   );
 };

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,55 +1,39 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
-Card.displayName = "Card"
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
-))
-CardHeader.displayName = "CardHeader"
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
 
-const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-  <h3
-    ref={ref}
-    className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-))
-CardTitle.displayName = "CardTitle"
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+);
+CardContent.displayName = 'CardContent';
 
-export { Card, CardHeader, CardTitle, CardContent } 
+export { Card, CardHeader, CardTitle, CardContent };

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -339,11 +339,15 @@ const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
     2
   )}${cpuFreq} · iowait ${data.cpu.iowait.toFixed(1)}%${cpuSteal}`;
 
-  // DISK 툴팁에 루트 외 마운트의 사용률을 덧붙인다.
+  // DISK 툴팁에 루트 외 마운트의 사용률과, 채워지는 중이면 가득 참 예측을 덧붙인다.
   const extraMounts = data.disks.filter(mount => mount.mount !== '/');
   const mountDetail =
     extraMounts.length > 0
       ? ' · ' + extraMounts.map(mount => `${mount.mount} ${mount.percentage.toFixed(0)}%`).join(' · ')
+      : '';
+  const fillDetail =
+    data.disk.hoursToFull !== null && data.disk.hoursToFull !== undefined
+      ? ` · full in ~${data.disk.hoursToFull < 48 ? `${data.disk.hoursToFull.toFixed(1)}h` : `${Math.round(data.disk.hoursToFull / 24)}d`}`
       : '';
 
   // 시안은 네 개를 한 줄에 놓는다. 휴대폰 폭에서는 게이지 지름보다 칸이 좁아져
@@ -391,7 +395,7 @@ const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
         detail={`${data.disk.used.toFixed(1)}G used of ${data.disk.total.toFixed(1)}G · ${Math.max(
           0,
           data.disk.total - data.disk.used
-        ).toFixed(1)}G free${mountDetail}`}
+        ).toFixed(1)}G free${mountDetail}${fillDetail}`}
       />
     </div>
   );

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -195,6 +195,12 @@ type HeaderProps = Omit<DashboardProps, 'networkHistory' | 'diskIoHistory'>;
 const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => {
   const secondsAgo =
     now !== null && lastUpdate !== null ? Math.max(0, Math.round((now - lastUpdate) / 1000)) : 0;
+  // 연결은 살아 있는데 값이 멎었을 수 있다(수집 루프 정지 등). SSE connected 와
+  // 별개로, 마지막 성공 샘플이 오래됐으면 amber 로 알린다.
+  const stale = connected && secondsAgo > 5;
+  // API 가 돌려주는 warnings 는 어떤 수집기가 실패했는지 담는다. 지금까지 화면엔
+  // 안 보였다 — 몇 개가 degrade 됐는지 뱃지로 띄우고, 목록은 호버 툴팁에 담는다.
+  const degraded = data.warnings.length;
 
   return (
     <header className="dash-head sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-gray-700 bg-gray-800/95 backdrop-blur">
@@ -222,14 +228,31 @@ const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => 
                 : 'animate-[pulseDot_0.6s_ease-in-out_infinite] bg-red-400'
             )}
           />
-          <span className={cn('t-label', connected ? 'text-gray-400' : 'text-red-400')}>
+          <span
+            className={cn(
+              't-label',
+              !connected ? 'text-red-400' : stale ? 'text-amber-400' : 'text-gray-400'
+            )}
+          >
             {connected ? `Live · updated ${secondsAgo}s ago` : 'Reconnecting…'}
           </span>
         </div>
 
+        {degraded > 0 && (
+          <span
+            className="dash-tip t-label flex shrink-0 items-center gap-1 text-amber-400"
+            tabIndex={-1}
+            data-tip={data.warnings.join(' · ')}
+          >
+            <TriangleAlert className="dash-icon shrink-0" color={COLORS.warn} strokeWidth={2} />
+            {degraded} degraded
+          </span>
+        )}
+
         <span className="t-micro min-w-0 truncate font-mono text-gray-500">
           {data.host.hostname} · {data.host.os}
           {data.host.os.includes(shortKernel(data.host.kernel)) ? '' : ` · ${shortKernel(data.host.kernel)}`}
+          {data.host.virtualization ? ` · ${data.host.virtualization}` : ''}
         </span>
       </div>
     </header>
@@ -290,7 +313,12 @@ const GaugeCard: React.FC<GaugeTileProps> = ({
       {/* 툴팁은 게이지+수치 묶음이 진다. 카드 전체가 아니라 그림 위에서만 떠야
           이웃 카드로 넘어갈 때 깜빡이지 않는다. */}
       <div className="dash-tip flex flex-col items-center" tabIndex={-1} data-tip={detail}>
-        <Gauge percentage={percentage ?? 0} color={color} className="my-1" />
+        <Gauge
+          percentage={percentage ?? 0}
+          color={color}
+          className="my-1"
+          ariaLabel={percentage === null ? `${label} unavailable` : `${label} ${percentage.toFixed(0)}%`}
+        />
         <div className="t-value font-bold" style={{ color }}>
           {percentage === null ? 'N/A' : `${percentage.toFixed(1)}%`}
         </div>
@@ -303,6 +331,21 @@ const GaugeCard: React.FC<GaugeTileProps> = ({
 const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
   const toGb = (mb: number) => (mb / 1024).toFixed(1);
 
+  // CPU 툴팁에 새 지표들을 덧붙인다(레이아웃은 그대로, 호버 시에만 보인다):
+  // 현재 클럭·I/O 대기, 그리고 스틸이 0보다 크면(과판매 VPS) 스틸까지.
+  const cpuFreq = data.cpu.frequencyMhz === 'N/A' ? '' : ` · ${(data.cpu.frequencyMhz / 1000).toFixed(2)}GHz`;
+  const cpuSteal = data.cpu.steal > 0 ? ` · steal ${data.cpu.steal.toFixed(1)}%` : '';
+  const cpuDetail = `${data.cpu.usage.toFixed(1)}% across ${data.cpu.cores} cores · load 1m ${data.load.avg1.toFixed(
+    2
+  )}${cpuFreq} · iowait ${data.cpu.iowait.toFixed(1)}%${cpuSteal}`;
+
+  // DISK 툴팁에 루트 외 마운트의 사용률을 덧붙인다.
+  const extraMounts = data.disks.filter(mount => mount.mount !== '/');
+  const mountDetail =
+    extraMounts.length > 0
+      ? ' · ' + extraMounts.map(mount => `${mount.mount} ${mount.percentage.toFixed(0)}%`).join(' · ')
+      : '';
+
   // 시안은 네 개를 한 줄에 놓는다. 휴대폰 폭에서는 게이지 지름보다 칸이 좁아져
   // 넘치므로, 그때만 2x2 로 접는다.
   return (
@@ -313,7 +356,7 @@ const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
         label="CPU"
         percentage={data.cpu.usage}
         caption={`${data.cpu.cores} cores`}
-        detail={`${data.cpu.usage.toFixed(1)}% across ${data.cpu.cores} cores · load 1m ${data.load.avg1.toFixed(2)}`}
+        detail={cpuDetail}
       />
       <GaugeCard
         icon={Monitor}
@@ -348,7 +391,7 @@ const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
         detail={`${data.disk.used.toFixed(1)}G used of ${data.disk.total.toFixed(1)}G · ${Math.max(
           0,
           data.disk.total - data.disk.used
-        ).toFixed(1)}G free`}
+        ).toFixed(1)}G free${mountDetail}`}
       />
     </div>
   );
@@ -366,6 +409,12 @@ const UptimeCard: React.FC<{ data: DashboardData }> = ({ data }) => (
       Last reboot: {formatShortDateTime(data.host.bootTime)}
       <br />
       reason: {data.host.rebootReason ?? 'unknown'}
+      {data.battery && (
+        <>
+          <br />
+          battery: {data.battery.percentage}% ({data.battery.status})
+        </>
+      )}
     </div>
   </Card>
 );
@@ -657,14 +706,16 @@ const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[
       </span>
     }
   >
+    {/* 범례에 부팅 이후 누적 총량을 함께 적어(순간 속도만으로는 알 수 없는) 대역폭
+        사용량을 한눈에 보게 한다. */}
     <div className="t-micro flex items-center justify-center gap-4 text-gray-400">
       <span className="flex items-center gap-1">
         <span className="h-[7px] w-[7px] rounded-full bg-blue-500" />
-        Download
+        Download · {formatBytes(data.network.totalRxBytes)}
       </span>
       <span className="flex items-center gap-1">
         <span className="h-[7px] w-[7px] rounded-full bg-emerald-500" />
-        Upload
+        Upload · {formatBytes(data.network.totalTxBytes)}
       </span>
     </div>
     <div className="dash-chart">
@@ -777,9 +828,19 @@ const AlertsCard: React.FC<{ data: DashboardData; now: number | null }> = ({ dat
 
 const ProcessesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   const processes = data.processes.filter(p => p.cpu > 0 || p.memory > 0).slice(0, MAX_PROCESSES);
+  const { total, zombie } = data.processSummary;
+
+  // 전체 프로세스 규모를 카드 헤더에 요약한다(상위 목록은 그대로). 좀비가 있으면
+  // 빨갛게 — 프로세스 리크의 신호다.
+  const summary =
+    total > 0 ? (
+      <span className="t-micro shrink-0 font-mono text-gray-500">
+        {total} proc{zombie > 0 && <span className="text-red-400"> · {zombie}Z</span>}
+      </span>
+    ) : undefined;
 
   return (
-    <Card icon={AlignLeft} color="#fb923c" title="TOP PROCESSES">
+    <Card icon={AlignLeft} color="#fb923c" title="TOP PROCESSES" right={summary}>
       <div className="t-micro mb-0.5 flex items-center justify-between text-gray-500">
         <span>Name</span>
         <div className="flex gap-2">

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -193,7 +193,8 @@ const TerminalTitleBar: React.FC<{ data: DashboardData }> = ({ data }) => {
 type HeaderProps = Omit<DashboardProps, 'networkHistory' | 'diskIoHistory'>;
 
 const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => {
-  const secondsAgo = now !== null && lastUpdate !== null ? Math.max(0, Math.round((now - lastUpdate) / 1000)) : 0;
+  const secondsAgo =
+    now !== null && lastUpdate !== null ? Math.max(0, Math.round((now - lastUpdate) / 1000)) : 0;
 
   return (
     <header className="dash-head sticky top-0 z-10 flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-gray-700 bg-gray-800/95 backdrop-blur">
@@ -270,7 +271,14 @@ interface GaugeTileProps {
 }
 
 // 시안에서는 게이지 네 개가 각각 독립된 카드다.
-const GaugeCard: React.FC<GaugeTileProps> = ({ icon: Icon, iconColor, label, percentage, caption, detail }) => {
+const GaugeCard: React.FC<GaugeTileProps> = ({
+  icon: Icon,
+  iconColor,
+  label,
+  percentage,
+  caption,
+  detail
+}) => {
   const color = percentage === null ? COLORS.muted : statusColor(percentage);
 
   return (
@@ -420,7 +428,11 @@ const LoadCard: React.FC<{ data: DashboardData }> = ({ data }) => {
           </span>
         </span>
       </div>
-      <div className="dash-loadgrid grid grid-cols-12" role="list" aria-label="Load average, one cell per hour over the last 48 hours">
+      <div
+        className="dash-loadgrid grid grid-cols-12"
+        role="list"
+        aria-label="Load average, one cell per hour over the last 48 hours"
+      >
         {cells.map((cell, index) => {
           const label =
             cell?.avg1 != null ? `${formatShortDateTime(cell.at)} · load ${cell.avg1.toFixed(2)}` : 'no data';
@@ -469,7 +481,10 @@ const CoresCard: React.FC<{ data: DashboardData }> = ({ data }) => {
                 px 로 고정하면 큰 화면에서 숫자가 칸을 넘어 서로 붙는다. */}
             <span className="t-micro w-[3ch] shrink-0 text-gray-500">C{index}</span>
             <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded bg-gray-900">
-              <div className="h-full rounded" style={{ width: `${usage}%`, background: statusColor(usage) }} />
+              <div
+                className="h-full rounded"
+                style={{ width: `${usage}%`, background: statusColor(usage) }}
+              />
             </div>
             <span className="t-micro w-[4ch] shrink-0 text-right text-gray-400">{usage.toFixed(0)}%</span>
           </li>
@@ -538,7 +553,8 @@ const CpuDayCard: React.FC<{ data: DashboardData }> = ({ data }) => (
         >
           {data.history.cpuHourly.map(sample => {
             const hour = `${new Date(sample.at).getHours()}:00`;
-            const label = sample.usage === null ? `${hour} — no data` : `${hour} — ${sample.usage.toFixed(0)}%`;
+            const label =
+              sample.usage === null ? `${hour} — no data` : `${hour} — ${sample.usage.toFixed(0)}%`;
             return (
               <div
                 key={sample.at}
@@ -601,33 +617,35 @@ const DiskIoCard: React.FC<{ data: DashboardData; history: DiskIoPoint[] }> = ({
   const io = formatMbPair(data.diskIO.read, data.diskIO.write);
 
   return (
-  <Card
-    icon={HardDriveDownload}
-    color="#38bdf8"
-    title="DISK I/O"
-    right={
-      <span className="t-micro shrink-0 whitespace-nowrap font-mono">
-        <span className="text-blue-400">R {io.read}</span>{' '}
-        <span className="text-pink-400">W {io.write}</span>{' '}
-        <span className="text-gray-500">{io.unit}</span>
-      </span>
-    }
-  >
-    <div className="dash-spark">
-      <Sparkline
-        series={[
-          { key: 'read', values: history.map(point => point.read), color: '#60a5fa' },
-          { key: 'write', values: history.map(point => point.write), color: '#f472b6' }
-        ]}
-      />
-    </div>
-  </Card>
+    <Card
+      icon={HardDriveDownload}
+      color="#38bdf8"
+      title="DISK I/O"
+      right={
+        <span className="t-micro shrink-0 whitespace-nowrap font-mono">
+          <span className="text-blue-400">R {io.read}</span>{' '}
+          <span className="text-pink-400">W {io.write}</span> <span className="text-gray-500">{io.unit}</span>
+        </span>
+      }
+    >
+      <div className="dash-spark">
+        <Sparkline
+          series={[
+            { key: 'read', values: history.map(point => point.read), color: '#60a5fa' },
+            { key: 'write', values: history.map(point => point.write), color: '#f472b6' }
+          ]}
+        />
+      </div>
+    </Card>
   );
 };
 
 // --- 네트워크 --------------------------------------------------------------
 
-const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[] }> = ({ data, history }) => (
+const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[] }> = ({
+  data,
+  history
+}) => (
   <Card
     icon={Network}
     color="#22d3ee"
@@ -693,7 +711,9 @@ const InterfacesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
             <span className="min-w-0 truncate text-gray-400">
               {entry.name} <span className="text-gray-500">{entry.ip ?? '—'}</span>
             </span>
-            <span className={cn('shrink-0 font-mono', entry.state === 'up' ? 'text-green-400' : 'text-gray-500')}>
+            <span
+              className={cn('shrink-0 font-mono', entry.state === 'up' ? 'text-green-400' : 'text-gray-500')}
+            >
               {entry.state !== 'up'
                 ? entry.state
                 : entry.speedMbps === null
@@ -746,7 +766,9 @@ const AlertsCard: React.FC<{ data: DashboardData; now: number | null }> = ({ dat
           <span className="truncate" style={{ color: ALERT_LEVEL_COLORS[alert.level] ?? '#9ca3af' }}>
             {alert.message}
           </span>
-          <span className="shrink-0 text-gray-500">{now === null ? '' : formatRelativeTime(alert.at, now)}</span>
+          <span className="shrink-0 text-gray-500">
+            {now === null ? '' : formatRelativeTime(alert.at, now)}
+          </span>
         </li>
       ))}
     </ul>
@@ -798,7 +820,9 @@ const SshCard: React.FC<{ data: DashboardData; now: number | null }> = ({ data, 
           <span className="min-w-0 truncate text-gray-400">
             {session.user}@{session.ip}
           </span>
-          <span className="shrink-0 text-gray-500">{now === null ? '' : formatRelativeTime(session.since, now)}</span>
+          <span className="shrink-0 text-gray-500">
+            {now === null ? '' : formatRelativeTime(session.since, now)}
+          </span>
         </li>
       ))}
     </ul>
@@ -824,7 +848,8 @@ const TrafficCard: React.FC<{ data: DashboardData }> = ({ data }) => (
 
 const FirewallCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   const { firewall } = data.security;
-  const color = firewall.status === 'active' ? '#4ade80' : firewall.status === 'inactive' ? '#f87171' : '#9ca3af';
+  const color =
+    firewall.status === 'active' ? '#4ade80' : firewall.status === 'inactive' ? '#f87171' : '#9ca3af';
 
   return (
     <Card

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -9,6 +9,9 @@ interface GaugeProps {
   percentage: number;
   color: string;
   className?: string;
+  // 스크린리더용 라벨. 손수 그린 SVG 는 기본적으로 아무 것도 안 읽히므로,
+  // role="img" 와 함께 준다. 미지정 시 퍼센트만이라도 읽어 준다.
+  ariaLabel?: string;
 }
 
 // 크기는 CSS(.dash-gauge)가 정한다. viewBox 로 그리면 화면 밀도에 따라
@@ -18,13 +21,15 @@ const GAUGE_STROKE = 3.5;
 const GAUGE_RADIUS = GAUGE_BOX / 2 - GAUGE_STROKE / 2 - 1.25;
 const GAUGE_CIRCUMFERENCE = 2 * Math.PI * GAUGE_RADIUS;
 
-export const Gauge: React.FC<GaugeProps> = ({ percentage, color, className }) => {
+export const Gauge: React.FC<GaugeProps> = ({ percentage, color, className, ariaLabel }) => {
   const filled = Math.max(0, Math.min(100, percentage));
 
   return (
     <svg
       viewBox={`0 0 ${GAUGE_BOX} ${GAUGE_BOX}`}
       className={cn('dash-gauge shrink-0 -rotate-90', className)}
+      role="img"
+      aria-label={ariaLabel ?? `${Math.round(filled)}%`}
     >
       <circle
         cx={GAUGE_BOX / 2}
@@ -107,6 +112,8 @@ export const Sparkline: React.FC<SparklineProps> = ({ series, className, emptyLa
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="none"
       className={cn('h-full w-full', className)}
+      role="img"
+      aria-label={`trend of ${series.map(entry => entry.key).join(', ')}`}
     >
       {series.map(entry => (
         <path key={entry.key} d={path(entry.values)} fill="none" stroke={entry.color} strokeWidth={1.5} />

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -22,7 +22,10 @@ export const Gauge: React.FC<GaugeProps> = ({ percentage, color, className }) =>
   const filled = Math.max(0, Math.min(100, percentage));
 
   return (
-    <svg viewBox={`0 0 ${GAUGE_BOX} ${GAUGE_BOX}`} className={cn('dash-gauge shrink-0 -rotate-90', className)}>
+    <svg
+      viewBox={`0 0 ${GAUGE_BOX} ${GAUGE_BOX}`}
+      className={cn('dash-gauge shrink-0 -rotate-90', className)}
+    >
       <circle
         cx={GAUGE_BOX / 2}
         cy={GAUGE_BOX / 2}

--- a/src/config/clusterConfig.ts
+++ b/src/config/clusterConfig.ts
@@ -2,9 +2,9 @@
 // adding/removing/reassigning nodes never requires touching code.
 
 export interface ClusterServer {
-    name: string;
-    ip: string;
-    type: 'intel' | 'rpi';
+  name: string;
+  ip: string;
+  type: 'intel' | 'rpi';
 }
 
 export const CLUSTER_PORT = process.env.NEXT_PUBLIC_CLUSTER_PORT || '3000';
@@ -17,59 +17,57 @@ export const CLUSTER_PROTOCOL = process.env.NEXT_PUBLIC_CLUSTER_PROTOCOL || 'htt
 // possibly behind a reverse proxy) or a bare host/IP. Only the former carries
 // its own scheme.
 function hasScheme(value: string): boolean {
-    return /^https?:\/\//i.test(value);
+  return /^https?:\/\//i.test(value);
 }
 
 // Base URL for a node, without a trailing slash. If `ip` already includes a
 // scheme it is taken as-is (the port lives in the URL, not CLUSTER_PORT); a
 // bare host is expanded with the configured protocol and port.
 export function getClusterBaseUrl(server: ClusterServer): string {
-    const base = hasScheme(server.ip)
-        ? server.ip
-        : `${CLUSTER_PROTOCOL}://${server.ip}:${CLUSTER_PORT}`;
-    return base.replace(/\/+$/, '');
+  const base = hasScheme(server.ip) ? server.ip : `${CLUSTER_PROTOCOL}://${server.ip}:${CLUSTER_PORT}`;
+  return base.replace(/\/+$/, '');
 }
 
 // Full URL for one of a node's endpoints. Callers hardcode only the path
 // (e.g. "/api/system"); the host/scheme/port come from the node's `ip`.
 export function getClusterUrl(server: ClusterServer, path: string): string {
-    const suffix = path.startsWith('/') ? path : `/${path}`;
-    return `${getClusterBaseUrl(server)}${suffix}`;
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${getClusterBaseUrl(server)}${suffix}`;
 }
 
 // Host shown on the node card. For a full URL this is the hostname (dropping
 // scheme/port/path); for a bare host it's the value up to any ":port".
 export function getClusterHost(server: ClusterServer): string {
-    if (hasScheme(server.ip)) {
-        try {
-            return new URL(server.ip).hostname;
-        } catch {
-            return server.ip;
-        }
+  if (hasScheme(server.ip)) {
+    try {
+      return new URL(server.ip).hostname;
+    } catch {
+      return server.ip;
     }
-    return server.ip.split(':')[0];
+  }
+  return server.ip.split(':')[0];
 }
 
 function isClusterServer(value: unknown): value is ClusterServer {
-    if (!value || typeof value !== 'object') return false;
-    const server = value as Record<string, unknown>;
-    return (
-        typeof server.name === 'string' &&
-        typeof server.ip === 'string' &&
-        (server.type === 'intel' || server.type === 'rpi')
-    );
+  if (!value || typeof value !== 'object') return false;
+  const server = value as Record<string, unknown>;
+  return (
+    typeof server.name === 'string' &&
+    typeof server.ip === 'string' &&
+    (server.type === 'intel' || server.type === 'rpi')
+  );
 }
 
 export function getClusterServers(): ClusterServer[] {
-    const raw = process.env.NEXT_PUBLIC_CLUSTER_SERVERS;
-    if (!raw) return [];
+  const raw = process.env.NEXT_PUBLIC_CLUSTER_SERVERS;
+  if (!raw) return [];
 
-    try {
-        const parsed = JSON.parse(raw);
-        if (!Array.isArray(parsed)) return [];
-        return parsed.filter(isClusterServer);
-    } catch (error) {
-        console.error('Invalid NEXT_PUBLIC_CLUSTER_SERVERS value:', error);
-        return [];
-    }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isClusterServer);
+  } catch (error) {
+    console.error('Invalid NEXT_PUBLIC_CLUSTER_SERVERS value:', error);
+    return [];
+  }
 }

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -6,12 +6,13 @@
 // string concatenation (e.g. `${SITE_URL}/sitemap.xml`) never produces a
 // double slash and `new URL(SITE_URL)` never throws.
 function normalizeSiteUrl(url: string): string {
-    const withScheme = /^https?:\/\//i.test(url) ? url : `https://${url}`;
-    return withScheme.replace(/\/+$/, '');
+  const withScheme = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+  return withScheme.replace(/\/+$/, '');
 }
 
 export const SITE_URL = normalizeSiteUrl(process.env.NEXT_PUBLIC_SITE_URL || 'https://ruthcloud.xyz');
 export const SITE_NAME = process.env.NEXT_PUBLIC_SITE_NAME || 'RuthServer Cloud';
 export const SITE_SHORT_NAME = process.env.NEXT_PUBLIC_SITE_SHORT_NAME || 'RuthServer';
-export const SITE_DESCRIPTION = process.env.NEXT_PUBLIC_SITE_DESCRIPTION || 'RuthServer for multiple cloud platforms';
+export const SITE_DESCRIPTION =
+  process.env.NEXT_PUBLIC_SITE_DESCRIPTION || 'RuthServer for multiple cloud platforms';
 export const AUTHOR_NAME = process.env.NEXT_PUBLIC_AUTHOR_NAME || 'Ruthgyeul';

--- a/src/hooks/useSystemData.ts
+++ b/src/hooks/useSystemData.ts
@@ -61,7 +61,7 @@ export function useSystemData(): SystemDataState {
         assertServerData(payload);
 
         const data = toDashboardData(payload);
-        const time = new Date().toLocaleTimeString('ko-KR', {
+        const time = new Date().toLocaleTimeString('en-US', {
           hour: '2-digit',
           minute: '2-digit',
           second: '2-digit',

--- a/src/hooks/useSystemData.ts
+++ b/src/hooks/useSystemData.ts
@@ -8,7 +8,16 @@ import { DashboardData, toDashboardData } from '@/utils/dashboardData';
 const MAX_POINTS = 60;
 
 // 이 필드들이 없으면 응답이 /api/system 의 것이 아니거나 심하게 망가진 것이다.
-const REQUIRED_FIELDS = ['cpu', 'memory', 'disk', 'network', 'uptime', 'temperature', 'fan', 'processes'] as const;
+const REQUIRED_FIELDS = [
+  'cpu',
+  'memory',
+  'disk',
+  'network',
+  'uptime',
+  'temperature',
+  'fan',
+  'processes'
+] as const;
 
 export interface DiskIoPoint {
   read: number;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
-import { type ClassValue, clsx } from "clsx"
+import { type ClassValue, clsx } from 'clsx';
 
 export function cn(...inputs: ClassValue[]) {
-  return clsx(inputs)
-} 
+  return clsx(inputs);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* ---------------------------------------------------------------------------
    터미널 팔레트
@@ -9,7 +9,7 @@
    따라오므로 타일 배치나 정보는 건드리지 않는다.
 --------------------------------------------------------------------------- */
 @theme {
-  --color-gray-50:  #f4f6fb;
+  --color-gray-50: #f4f6fb;
   --color-gray-100: #e6e8ee; /* 본문 */
   --color-gray-200: #d5dae4;
   --color-gray-300: #c3c8d4; /* 흐린 본문 */
@@ -45,7 +45,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-geist-mono), ui-monospace, "SF Mono", "SFMono-Regular", Menlo, monospace;
+  font-family: var(--font-geist-mono), ui-monospace, 'SF Mono', 'SFMono-Regular', Menlo, monospace;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -115,24 +115,39 @@ body {
 /* 카드 호버 리프트 — 포트폴리오의 .card 와 동일 결 */
 .dash-card,
 .gauge-card {
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
 }
 .dash-card:hover,
 .gauge-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(56, 189, 248, 0.35);
+  box-shadow:
+    0 10px 28px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(56, 189, 248, 0.35);
   border-color: rgba(56, 189, 248, 0.35);
 }
 
 /* 대시보드 상태 표시용. Tailwind 의 animate-[pulseDot_...] 에서 참조한다. */
 @keyframes pulseDot {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 @keyframes alertBlink {
-  0%, 100% { background-color: rgba(239, 68, 68, 0.12); }
-  50% { background-color: rgba(239, 68, 68, 0.32); }
+  0%,
+  100% {
+    background-color: rgba(239, 68, 68, 0.12);
+  }
+  50% {
+    background-color: rgba(239, 68, 68, 0.32);
+  }
 }
 
 /* ---------------------------------------------------------------------------
@@ -151,15 +166,33 @@ body {
    늘려 놓은 꼴이 된다. 배율을 올려 카드가 열 폭을 제대로 쓰게 한다.
 --------------------------------------------------------------------------- */
 
-:root { --dash-scale: 1; }
+:root {
+  --dash-scale: 1;
+}
 
 /* 휴대폰: 카드 하나가 가로를 통째로 쓰니 조금 키워도 넘치지 않는다. */
-@media (max-width: 639px) { :root { --dash-scale: 1.08; } }
+@media (max-width: 639px) {
+  :root {
+    --dash-scale: 1.08;
+  }
+}
 
 /* 넓어질수록 열이 넓어진다. 그만큼 카드 속 내용도 키운다. */
-@media (min-width: 1280px) { :root { --dash-scale: 1.15; } }
-@media (min-width: 1600px) { :root { --dash-scale: 1.3; } }
-@media (min-width: 2000px) { :root { --dash-scale: 1.5; } }
+@media (min-width: 1280px) {
+  :root {
+    --dash-scale: 1.15;
+  }
+}
+@media (min-width: 1600px) {
+  :root {
+    --dash-scale: 1.3;
+  }
+}
+@media (min-width: 2000px) {
+  :root {
+    --dash-scale: 1.5;
+  }
+}
 
 .dash-layout {
   display: grid;
@@ -170,7 +203,9 @@ body {
 }
 
 @media (min-width: 640px) {
-  .dash-layout { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .dash-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (min-width: 1024px) {
@@ -197,26 +232,48 @@ body {
 }
 
 @media (min-width: 640px) {
-  .dash-subgrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .dash-subgrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
-.dash-card { padding: calc(12px * var(--dash-scale)); }
+.dash-card {
+  padding: calc(12px * var(--dash-scale));
+}
 
-.dash-head { padding: calc(8px * var(--dash-scale)) calc(12px * var(--dash-scale)); }
-.dash-alertbar { padding: calc(8px * var(--dash-scale)) calc(12px * var(--dash-scale)); }
+.dash-head {
+  padding: calc(8px * var(--dash-scale)) calc(12px * var(--dash-scale));
+}
+.dash-alertbar {
+  padding: calc(8px * var(--dash-scale)) calc(12px * var(--dash-scale));
+}
 
-.t-micro { font-size: calc(10px * var(--dash-scale)); }
-.t-label { font-size: calc(11px * var(--dash-scale)); }
-.t-body  { font-size: calc(12px * var(--dash-scale)); }
-.t-value { font-size: calc(15px * var(--dash-scale)); }
-.t-hero  { font-size: calc(20px * var(--dash-scale)); }
+.t-micro {
+  font-size: calc(10px * var(--dash-scale));
+}
+.t-label {
+  font-size: calc(11px * var(--dash-scale));
+}
+.t-body {
+  font-size: calc(12px * var(--dash-scale));
+}
+.t-value {
+  font-size: calc(15px * var(--dash-scale));
+}
+.t-hero {
+  font-size: calc(20px * var(--dash-scale));
+}
 
 .dash-icon {
   width: calc(14px * var(--dash-scale));
   height: calc(14px * var(--dash-scale));
 }
-.dash-card-head { margin-bottom: calc(6px * var(--dash-scale)); }
-.dash-rows > * + * { margin-top: calc(6px * var(--dash-scale)); }
+.dash-card-head {
+  margin-bottom: calc(6px * var(--dash-scale));
+}
+.dash-rows > * + * {
+  margin-top: calc(6px * var(--dash-scale));
+}
 
 /* 코어가 많으면 한 줄에 하나씩 쌓기엔 너무 길어진다. 두 줄로 접는다.
    단 휴대폰에서는 세로가 넉넉하고 가로가 없으니 한 줄로 둔다. */
@@ -227,18 +284,30 @@ body {
 }
 
 @media (min-width: 640px) {
-  .dash-corelist--split { grid-template-columns: 1fr 1fr; }
+  .dash-corelist--split {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .dash-gauge {
   width: calc(64px * var(--dash-scale));
   height: calc(64px * var(--dash-scale));
 }
-.dash-chart { height: calc(176px * var(--dash-scale)); }
-.dash-spark { height: calc(64px * var(--dash-scale)); }
-.dash-heat  { height: calc(28px * var(--dash-scale)); }
-.dash-loadgrid { gap: calc(4px * var(--dash-scale)); }
-.dash-loadcell { aspect-ratio: 1; }
+.dash-chart {
+  height: calc(176px * var(--dash-scale));
+}
+.dash-spark {
+  height: calc(64px * var(--dash-scale));
+}
+.dash-heat {
+  height: calc(28px * var(--dash-scale));
+}
+.dash-loadgrid {
+  gap: calc(4px * var(--dash-scale));
+}
+.dash-loadcell {
+  aspect-ratio: 1;
+}
 
 /* ---------------------------------------------------------------------------
    툴팁
@@ -251,7 +320,9 @@ body {
    아니라 손가락/마우스로 눌러서 들어간 포커스에는 :focus-visible 이 매칭되지
    않는다. 터치에서 뜨게 하는 게 목적이므로 :focus 여야 한다.
 --------------------------------------------------------------------------- */
-.dash-tip { position: relative; }
+.dash-tip {
+  position: relative;
+}
 
 .dash-tip::after {
   content: attr(data-tip);
@@ -307,10 +378,14 @@ body {
 /* 탭 순서를 72개(격자 48 + 히트맵 24)로 늘리지 않으려고 셀은 tabindex="-1" 이다.
    눌러서 들어간 포커스에 기본 아웃라인까지 그리면 툴팁과 겹쳐 지저분하므로 끈다.
    스크린리더는 탭이 아니라 목록(role=list)으로 훑는다. */
-.dash-tip:focus { outline: none; }
+.dash-tip:focus {
+  outline: none;
+}
 
 @media (prefers-reduced-motion: reduce) {
-  .dash-tip::after { transition: none; }
+  .dash-tip::after {
+    transition: none;
+  }
 }
 
 /* ---------------------------------------------------------------------------
@@ -330,32 +405,77 @@ body {
     padding: 8px;
   }
 
-  .dash-col { gap: 8px; }
-  .dash-subgrid { gap: 8px; }
-  .dash-card { padding: 6px; }
+  .dash-col {
+    gap: 8px;
+  }
+  .dash-subgrid {
+    gap: 8px;
+  }
+  .dash-card {
+    padding: 6px;
+  }
 
-  .dash-head { padding: 5px 12px; }
-  .dash-alertbar { padding: 3px 12px; }
+  .dash-head {
+    padding: 5px 12px;
+  }
+  .dash-alertbar {
+    padding: 3px 12px;
+  }
 
-  .t-micro { font-size: 8px; }
-  .t-label { font-size: 9px; }
-  .t-body  { font-size: 9.5px; }
-  .t-value { font-size: 12px; }
-  .t-hero  { font-size: 15px; }
+  .t-micro {
+    font-size: 8px;
+  }
+  .t-label {
+    font-size: 9px;
+  }
+  .t-body {
+    font-size: 9.5px;
+  }
+  .t-value {
+    font-size: 12px;
+  }
+  .t-hero {
+    font-size: 15px;
+  }
 
-  .dash-icon { width: 12px; height: 12px; }
-  .dash-card-head { margin-bottom: 2px; }
-  .dash-rows > * + * { margin-top: 2px; }
+  .dash-icon {
+    width: 12px;
+    height: 12px;
+  }
+  .dash-card-head {
+    margin-bottom: 2px;
+  }
+  .dash-rows > * + * {
+    margin-top: 2px;
+  }
 
   /* 코어 16개면 두 줄로 접어도 8행이다. 행 높이를 글자 크기까지 붙인다. */
-  .dash-corelist { gap: 1px 8px; }
-  .dash-corelist > li { line-height: 1; }
+  .dash-corelist {
+    gap: 1px 8px;
+  }
+  .dash-corelist > li {
+    line-height: 1;
+  }
 
-  .dash-gauge { width: 36px; height: 36px; }
-  .dash-chart { height: 158px; }
-  .dash-spark { height: 24px; }
-  .dash-heat  { height: 16px; }
-  .dash-loadgrid { gap: 3px; }
+  .dash-gauge {
+    width: 36px;
+    height: 36px;
+  }
+  .dash-chart {
+    height: 158px;
+  }
+  .dash-spark {
+    height: 24px;
+  }
+  .dash-heat {
+    height: 16px;
+  }
+  .dash-loadgrid {
+    gap: 3px;
+  }
   /* 열 폭이 넓어 정사각형을 유지하면 격자만 커진다. 높이를 고정해 납작하게. */
-  .dash-loadcell { aspect-ratio: auto; height: 12px; }
+  .dash-loadcell {
+    aspect-ratio: auto;
+    height: 12px;
+  }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -8,4 +8,4 @@ export interface SystemDataResponse {
 export interface ApiError {
   message: string;
   code: string;
-} 
+}

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -113,6 +113,15 @@ export interface SecurityInfo {
     topTraffic: TrafficPeer[];
 }
 
+// 개별 마운트된 파일시스템의 사용량. 루트(/) 외에 데이터 볼륨이 따로 붙은
+// 서버에서도 실제 사용량을 볼 수 있게 한다.
+export interface DiskMount {
+    mount: string;
+    used: number;  // GB
+    total: number; // GB
+    percentage: number;
+}
+
 export type AlertLevel = 'ok' | 'info' | 'warning' | 'critical';
 
 export interface AlertEntry {
@@ -158,6 +167,8 @@ export interface ServerData {
         total: number;
         percentage: number;
     };
+    // 루트 외 마운트를 포함한 전체 파일시스템 목록(선택적: 구버전 노드 호환).
+    disks?: DiskMount[];
     network: {
         download: number;
         upload: number;

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -188,6 +188,8 @@ export interface ServerData {
     used: number;
     total: number;
     percentage: number;
+    // 최근 추세로 추정한 100% 도달까지 남은 시간(시간). 채워지는 중이 아니면 null.
+    hoursToFull?: number | null;
   };
   // 루트 외 마운트를 포함한 전체 파일시스템 목록(선택적: 구버전 노드 호환).
   disks?: DiskMount[];

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -44,6 +44,8 @@ export interface HostInfo {
     bootTime: string; // ISO 8601
     // 마지막 재부팅이 정상 종료였는지. wtmp 를 못 읽으면 null.
     rebootReason: string | null;
+    // 가상화/컨테이너 종류(kvm/docker/lxc 등). 베어메탈이거나 감지 불가면 null.
+    virtualization?: string | null;
 }
 
 export interface LoadInfo {
@@ -122,6 +124,22 @@ export interface DiskMount {
     percentage: number;
 }
 
+// 배터리/UPS 상태. Pi·노트북·UPS 연결 서버에 유의미하고, 없으면 null.
+export interface BatteryInfo {
+    percentage: number;
+    status: string; // Charging / Discharging / Full / Not charging / Unknown
+}
+
+// 전체 프로세스 요약. top 목록(상위 20)과 달리 시스템 전체 규모를 센다.
+export interface ProcessSummary {
+    total: number;
+    running: number;
+    sleeping: number;
+    zombie: number;
+    // 스레드 포함 전체 태스크 수. /proc/loadavg 로 얻으며 없으면 null.
+    threads: number | null;
+}
+
 export type AlertLevel = 'ok' | 'info' | 'warning' | 'critical';
 
 export interface AlertEntry {
@@ -156,6 +174,10 @@ export interface ServerData {
         temperature: TemperatureValue;
         // 코어별 사용률. /proc/stat 를 못 읽으면 빈 배열.
         perCore?: number[];
+        // 아래는 선택적(구버전 노드 호환). iowait/steal 은 %, frequencyMhz 는 평균 MHz.
+        iowait?: number;
+        steal?: number;
+        frequencyMhz?: number | 'N/A';
     };
     memory: {
         used: number;
@@ -182,6 +204,9 @@ export interface ServerData {
         interfaces?: NetworkInterfaceInfo[];
         linkSpeedMbps?: number | null;
         bandwidthPercentage?: number;
+        // 부팅 이후 누적 바이트(선택적: 구버전 노드 호환).
+        totalRxBytes?: number;
+        totalTxBytes?: number;
     };
     uptime: {
         days: number;
@@ -203,6 +228,10 @@ export interface ServerData {
     diskIO?: DiskIoInfo;
     gpu?: GpuInfo;
     security?: SecurityInfo;
+    // 전체 프로세스 요약 / 메모리 상위 프로세스 / 배터리(선택적: 구버전 노드 호환).
+    processSummary?: ProcessSummary;
+    topProcessesByMemory?: Process[];
+    battery?: BatteryInfo | null;
     history?: HistoryInfo;
     alerts?: AlertEntry[];
     timestamp?: string;

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -1,9 +1,9 @@
 export interface Process {
-    id: number;
-    name: string;
-    cpu: number;
-    memory: number;
-    status: 'running' | 'sleeping';
+  id: number;
+  name: string;
+  cpu: number;
+  memory: number;
+  status: 'running' | 'sleeping';
 }
 
 // 온도 값 타입
@@ -11,16 +11,16 @@ export type TemperatureValue = number | 'N/A';
 
 // x86 아키텍처용 온도 정보
 export interface X86TemperatureInfo {
-    cpu: TemperatureValue;
-    gpu: TemperatureValue;
-    motherboard: TemperatureValue;
+  cpu: TemperatureValue;
+  gpu: TemperatureValue;
+  motherboard: TemperatureValue;
 }
 
 // ARM 아키텍처용 온도 정보
 export interface ARMTemperatureInfo {
-    cpu: TemperatureValue;
-    rp1: TemperatureValue;
-    ssd: TemperatureValue;
+  cpu: TemperatureValue;
+  rp1: TemperatureValue;
+  ssd: TemperatureValue;
 }
 
 // 온도 정보 (아키텍처별)
@@ -28,220 +28,220 @@ export type TemperatureInfo = X86TemperatureInfo | ARMTemperatureInfo;
 
 // 온도 정보 타입 가드
 export function isX86TemperatureInfo(temp: TemperatureInfo): temp is X86TemperatureInfo {
-    return 'gpu' in temp && 'motherboard' in temp;
+  return 'gpu' in temp && 'motherboard' in temp;
 }
 
 export function isARMTemperatureInfo(temp: TemperatureInfo): temp is ARMTemperatureInfo {
-    return 'rp1' in temp && 'ssd' in temp;
+  return 'rp1' in temp && 'ssd' in temp;
 }
 
 // 호스트 식별 정보. 헤더의 "Ubuntu 22.04 · 5.15.0" 표기와 재부팅 이력에 쓰인다.
 export interface HostInfo {
-    hostname: string;
-    os: string;
-    kernel: string;
-    arch: string;
-    bootTime: string; // ISO 8601
-    // 마지막 재부팅이 정상 종료였는지. wtmp 를 못 읽으면 null.
-    rebootReason: string | null;
-    // 가상화/컨테이너 종류(kvm/docker/lxc 등). 베어메탈이거나 감지 불가면 null.
-    virtualization?: string | null;
+  hostname: string;
+  os: string;
+  kernel: string;
+  arch: string;
+  bootTime: string; // ISO 8601
+  // 마지막 재부팅이 정상 종료였는지. wtmp 를 못 읽으면 null.
+  rebootReason: string | null;
+  // 가상화/컨테이너 종류(kvm/docker/lxc 등). 베어메탈이거나 감지 불가면 null.
+  virtualization?: string | null;
 }
 
 export interface LoadInfo {
-    avg1: number;
-    avg5: number;
-    avg15: number;
-    // 지금 이 순간 실행 중이거나 실행을 기다리는 커널 엔티티 수.
-    // /proc/loadavg 4번째 필드(running/total)의 앞쪽 값으로, 부하 평균과 같은
-    // 단위의 "순간값" 이다. /proc 가 없는 OS 에서는 null.
-    running: number | null;
-    // 커널은 1/5/15분 평균만 준다. 30분은 우리가 매초 남기는 샘플로 직접 낸다.
-    // 아직 30분이 안 찼으면 모인 만큼의 평균이고, 샘플이 없으면 null.
-    avg30: number | null;
-    // avg30 이 실제로 덮는 구간(초). 1800 보다 작으면 아직 창이 덜 찬 것이다.
-    avg30WindowSeconds: number;
+  avg1: number;
+  avg5: number;
+  avg15: number;
+  // 지금 이 순간 실행 중이거나 실행을 기다리는 커널 엔티티 수.
+  // /proc/loadavg 4번째 필드(running/total)의 앞쪽 값으로, 부하 평균과 같은
+  // 단위의 "순간값" 이다. /proc 가 없는 OS 에서는 null.
+  running: number | null;
+  // 커널은 1/5/15분 평균만 준다. 30분은 우리가 매초 남기는 샘플로 직접 낸다.
+  // 아직 30분이 안 찼으면 모인 만큼의 평균이고, 샘플이 없으면 null.
+  avg30: number | null;
+  // avg30 이 실제로 덮는 구간(초). 1800 보다 작으면 아직 창이 덜 찬 것이다.
+  avg30WindowSeconds: number;
 }
 
 export interface SwapInfo {
-    used: number;  // GB
-    total: number; // GB
-    percentage: number;
+  used: number; // GB
+  total: number; // GB
+  percentage: number;
 }
 
 export interface DiskIoInfo {
-    read: number;  // MB/s
-    write: number; // MB/s
+  read: number; // MB/s
+  write: number; // MB/s
 }
 
 export interface GpuInfo {
-    name: string | null;
-    usage: number | 'N/A';
-    temperature: TemperatureValue;
+  name: string | null;
+  usage: number | 'N/A';
+  temperature: TemperatureValue;
 }
 
 export interface NetworkInterfaceInfo {
-    name: string;
-    ip: string | null;
-    speedMbps: number | null;
-    state: 'up' | 'down' | 'unknown';
-    isDefault: boolean;
+  name: string;
+  ip: string | null;
+  speedMbps: number | null;
+  state: 'up' | 'down' | 'unknown';
+  isDefault: boolean;
 }
 
 // 대역폭 상위 피어. nf_conntrack 의 바이트 계정이 꺼져 있으면 bytes 는 null 이고
 // 연결 수(connections)만 의미가 있다.
 export interface TrafficPeer {
-    ip: string;
-    bytes: number | null;
-    connections: number;
+  ip: string;
+  bytes: number | null;
+  connections: number;
 }
 
 export interface SshSession {
-    user: string;
-    ip: string;
-    since: string; // ISO 8601
+  user: string;
+  ip: string;
+  since: string; // ISO 8601
 }
 
 export interface FirewallInfo {
-    status: 'active' | 'inactive' | 'unknown';
-    backend: string | null;
-    // 커널 로그를 읽을 권한이 없으면 null.
-    blockedAttempts: number | null;
+  status: 'active' | 'inactive' | 'unknown';
+  backend: string | null;
+  // 커널 로그를 읽을 권한이 없으면 null.
+  blockedAttempts: number | null;
 }
 
 export interface SecurityInfo {
-    firewall: FirewallInfo;
-    sshSessions: SshSession[];
-    topTraffic: TrafficPeer[];
+  firewall: FirewallInfo;
+  sshSessions: SshSession[];
+  topTraffic: TrafficPeer[];
 }
 
 // 개별 마운트된 파일시스템의 사용량. 루트(/) 외에 데이터 볼륨이 따로 붙은
 // 서버에서도 실제 사용량을 볼 수 있게 한다.
 export interface DiskMount {
-    mount: string;
-    used: number;  // GB
-    total: number; // GB
-    percentage: number;
+  mount: string;
+  used: number; // GB
+  total: number; // GB
+  percentage: number;
 }
 
 // 배터리/UPS 상태. Pi·노트북·UPS 연결 서버에 유의미하고, 없으면 null.
 export interface BatteryInfo {
-    percentage: number;
-    status: string; // Charging / Discharging / Full / Not charging / Unknown
+  percentage: number;
+  status: string; // Charging / Discharging / Full / Not charging / Unknown
 }
 
 // 전체 프로세스 요약. top 목록(상위 20)과 달리 시스템 전체 규모를 센다.
 export interface ProcessSummary {
-    total: number;
-    running: number;
-    sleeping: number;
-    zombie: number;
-    // 스레드 포함 전체 태스크 수. /proc/loadavg 로 얻으며 없으면 null.
-    threads: number | null;
+  total: number;
+  running: number;
+  sleeping: number;
+  zombie: number;
+  // 스레드 포함 전체 태스크 수. /proc/loadavg 로 얻으며 없으면 null.
+  threads: number | null;
 }
 
 export type AlertLevel = 'ok' | 'info' | 'warning' | 'critical';
 
 export interface AlertEntry {
-    id: string;
-    level: AlertLevel;
-    message: string;
-    at: string; // ISO 8601
+  id: string;
+  level: AlertLevel;
+  message: string;
+  at: string; // ISO 8601
 }
 
 // 히스토리는 프로세스 메모리에 쌓이고 data/history.json 으로 영속화된다. 재시작해도
 // 복구되지만, 서버가 꺼져 있던 구간은 값이 없어 UI 가 "수집 중" 으로 표시한다.
 export interface LoadSample {
-    at: string; // ISO 8601, 1시간 버킷의 시작
-    // 서버가 그 시간대에 켜져 있지 않았으면 null.
-    avg1: number | null;
+  at: string; // ISO 8601, 1시간 버킷의 시작
+  // 서버가 그 시간대에 켜져 있지 않았으면 null.
+  avg1: number | null;
 }
 
 export interface CpuHourSample {
-    at: string; // ISO 8601, 정시 버킷의 시작
-    usage: number | null;
+  at: string; // ISO 8601, 정시 버킷의 시작
+  usage: number | null;
 }
 
 export interface HistoryInfo {
-    load: LoadSample[];      // 최근 48시간, 1시간 버킷
-    cpuHourly: CpuHourSample[]; // 최근 24시간, 1시간 버킷
+  load: LoadSample[]; // 최근 48시간, 1시간 버킷
+  cpuHourly: CpuHourSample[]; // 최근 24시간, 1시간 버킷
 }
 
 export interface ServerData {
-    cpu: {
-        usage: number;
-        cores: number;
-        temperature: TemperatureValue;
-        // 코어별 사용률. /proc/stat 를 못 읽으면 빈 배열.
-        perCore?: number[];
-        // 아래는 선택적(구버전 노드 호환). iowait/steal 은 %, frequencyMhz 는 평균 MHz.
-        iowait?: number;
-        steal?: number;
-        frequencyMhz?: number | 'N/A';
+  cpu: {
+    usage: number;
+    cores: number;
+    temperature: TemperatureValue;
+    // 코어별 사용률. /proc/stat 를 못 읽으면 빈 배열.
+    perCore?: number[];
+    // 아래는 선택적(구버전 노드 호환). iowait/steal 은 %, frequencyMhz 는 평균 MHz.
+    iowait?: number;
+    steal?: number;
+    frequencyMhz?: number | 'N/A';
+  };
+  memory: {
+    used: number;
+    total: number;
+    percentage: number;
+  };
+  disk: {
+    used: number;
+    total: number;
+    percentage: number;
+  };
+  // 루트 외 마운트를 포함한 전체 파일시스템 목록(선택적: 구버전 노드 호환).
+  disks?: DiskMount[];
+  network: {
+    download: number;
+    upload: number;
+    ping: number;
+    errorRates: {
+      rx: string;
+      tx: string;
     };
-    memory: {
-        used: number;
-        total: number;
-        percentage: number;
-    };
-    disk: {
-        used: number;
-        total: number;
-        percentage: number;
-    };
-    // 루트 외 마운트를 포함한 전체 파일시스템 목록(선택적: 구버전 노드 호환).
-    disks?: DiskMount[];
-    network: {
-        download: number;
-        upload: number;
-        ping: number;
-        errorRates: {
-            rx: string;
-            tx: string;
-        };
-        connections?: number;
-        listeningPorts?: number;
-        interfaces?: NetworkInterfaceInfo[];
-        linkSpeedMbps?: number | null;
-        bandwidthPercentage?: number;
-        // 부팅 이후 누적 바이트(선택적: 구버전 노드 호환).
-        totalRxBytes?: number;
-        totalTxBytes?: number;
-    };
-    uptime: {
-        days: number;
-        hours: number;
-        minutes: number;
-    };
-    temperature: TemperatureInfo;
-    fan: {
-        cpu: number;
-        case1: number;
-        case2: number;
-    };
-    processes: Process[];
-    // 아래 필드들은 1.3 에서 추가됐다. 구버전을 돌리는 클러스터 노드도 같은
-    // 대시보드로 읽을 수 있어야 하므로 전부 optional 이다.
-    host?: HostInfo;
-    load?: LoadInfo;
-    swap?: SwapInfo;
-    diskIO?: DiskIoInfo;
-    gpu?: GpuInfo;
-    security?: SecurityInfo;
-    // 전체 프로세스 요약 / 메모리 상위 프로세스 / 배터리(선택적: 구버전 노드 호환).
-    processSummary?: ProcessSummary;
-    topProcessesByMemory?: Process[];
-    battery?: BatteryInfo | null;
-    history?: HistoryInfo;
-    alerts?: AlertEntry[];
-    timestamp?: string;
-    // 일부 수집기만 실패했을 때 어떤 지표가 왜 비었는지 알려준다.
-    // 헤드리스 서버에서 `curl localhost:3000/api/system` 만으로 진단할 수 있게 하는 용도.
-    warnings?: string[];
+    connections?: number;
+    listeningPorts?: number;
+    interfaces?: NetworkInterfaceInfo[];
+    linkSpeedMbps?: number | null;
+    bandwidthPercentage?: number;
+    // 부팅 이후 누적 바이트(선택적: 구버전 노드 호환).
+    totalRxBytes?: number;
+    totalTxBytes?: number;
+  };
+  uptime: {
+    days: number;
+    hours: number;
+    minutes: number;
+  };
+  temperature: TemperatureInfo;
+  fan: {
+    cpu: number;
+    case1: number;
+    case2: number;
+  };
+  processes: Process[];
+  // 아래 필드들은 1.3 에서 추가됐다. 구버전을 돌리는 클러스터 노드도 같은
+  // 대시보드로 읽을 수 있어야 하므로 전부 optional 이다.
+  host?: HostInfo;
+  load?: LoadInfo;
+  swap?: SwapInfo;
+  diskIO?: DiskIoInfo;
+  gpu?: GpuInfo;
+  security?: SecurityInfo;
+  // 전체 프로세스 요약 / 메모리 상위 프로세스 / 배터리(선택적: 구버전 노드 호환).
+  processSummary?: ProcessSummary;
+  topProcessesByMemory?: Process[];
+  battery?: BatteryInfo | null;
+  history?: HistoryInfo;
+  alerts?: AlertEntry[];
+  timestamp?: string;
+  // 일부 수집기만 실패했을 때 어떤 지표가 왜 비었는지 알려준다.
+  // 헤드리스 서버에서 `curl localhost:3000/api/system` 만으로 진단할 수 있게 하는 용도.
+  warnings?: string[];
 }
 
 export interface NetworkHistoryEntry {
-    time: string;
-    download: number;
-    upload: number;
-} 
+  time: string;
+  download: number;
+  upload: number;
+}

--- a/src/utils/collectors/alerts.test.ts
+++ b/src/utils/collectors/alerts.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AlertInput } from '@/utils/collectors/alerts';
+
+// alerts 는 모듈 스코프에 활성 룰/로그/known 상태를 들고 있어 테스트마다 새로
+// 불러온다. 저장 파일도 임시 디렉터리로 격리한다. 웹훅 호출은 fetch 를 목으로
+// 잡아 호출 횟수만 센다(실제 네트워크로 나가지 않게).
+async function freshAlerts(env: Record<string, string> = {}) {
+  vi.resetModules();
+  const dir = mkdtempSync(join(tmpdir(), 'alerts-test-'));
+  process.env.DATA_DIR = dir;
+  process.env.ALERTS_FILE = join(dir, 'alerts.json');
+  process.env.ALERT_WEBHOOK_URL = 'https://example.test/hook';
+  for (const [key, value] of Object.entries(env)) process.env[key] = value;
+
+  const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+
+  const mod = await import('@/utils/collectors/alerts');
+  return { ...mod, fetchMock, dir, file: process.env.ALERTS_FILE };
+}
+
+function baseInput(overrides: Partial<AlertInput> = {}): AlertInput {
+  return {
+    cpu: 10,
+    memory: 10,
+    disk: 10,
+    swap: 0,
+    temperature: 40,
+    firewall: 'active',
+    sshSessions: [],
+    interfaces: [],
+    ...overrides
+  };
+}
+
+const ENV_KEYS = [
+  'DATA_DIR',
+  'ALERTS_FILE',
+  'ALERT_WEBHOOK_URL',
+  'ALERT_WEBHOOK_FORMAT',
+  'ALERT_CPU_ENTER',
+  'ALERT_CPU_CLEAR',
+  'ALERT_RENOTIFY_MINUTES'
+];
+
+describe('evaluateAlerts', () => {
+  beforeEach(() => ENV_KEYS.forEach(key => delete process.env[key]));
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    ENV_KEYS.forEach(key => delete process.env[key]);
+  });
+
+  it('임계값을 넘으면 알림을 남기고, 히스테리시스로 내려오면 해제한다', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    // 첫 평가는 정상값 — 아무 알림도 없다(이후 전이를 첫 로그인처럼 쏟지 않기 위함).
+    expect(evaluateAlerts(baseInput(), t0)).toHaveLength(0);
+
+    // CPU 가 90 을 넘으면 warning 이 쌓인다.
+    const entered = evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
+    expect(entered[0].message).toContain('CPU usage 95%');
+    expect(entered[0].level).toBe('warning');
+
+    // 85(=clearBelow 80 보다 큼)에서는 아직 해제되지 않는다.
+    const held = evaluateAlerts(baseInput({ cpu: 85 }), t0 + 2000);
+    expect(held.find(e => e.message.includes('back to normal'))).toBeUndefined();
+
+    // 80 아래로 내려오면 해제 로그.
+    const cleared = evaluateAlerts(baseInput({ cpu: 70 }), t0 + 3000);
+    expect(cleared[0].message).toContain('CPU usage back to normal');
+    expect(cleared[0].level).toBe('ok');
+  });
+
+  it('첫 평가에서 이미 임계 상태면 로그엔 남기되 웹훅은 보내지 않는다', async () => {
+    const { evaluateAlerts, fetchMock } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    const first = evaluateAlerts(baseInput({ cpu: 99 }), t0);
+    expect(first[0].message).toContain('CPU usage 99%');
+    // 부팅 직후 이미 임계였던 값은 외부로 쏟지 않는다.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('전이가 생기면 웹훅으로 통지한다', async () => {
+    const { evaluateAlerts, fetchMock } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput(), t0); // 첫 평가 소진
+    evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.test/hook');
+    expect(JSON.parse((options as RequestInit).body as string).message).toContain('CPU usage 95%');
+  });
+
+  it('새 SSH 세션은 통지하고, 이미 있던 세션은 통지하지 않는다', async () => {
+    const { evaluateAlerts, fetchMock } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    const existing = { user: 'root', ip: '10.0.0.1', since: new Date(t0).toISOString() };
+    // 첫 평가: 이미 붙어 있던 세션은 조용히 기억만.
+    evaluateAlerts(baseInput({ sshSessions: [existing] }), t0);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // 새 세션 등장 → info 알림 + 통지.
+    const newSession = { user: 'deploy', ip: '10.0.0.2', since: new Date(t0 + 1000).toISOString() };
+    const log = evaluateAlerts(baseInput({ sshSessions: [existing, newSession] }), t0 + 1000);
+    expect(log[0].message).toBe('SSH login: deploy@10.0.0.2');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('인터페이스 다운/복구 전이를 기록한다', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput({ interfaces: [{ name: 'eth0', state: 'up' }] }), t0);
+
+    const down = evaluateAlerts(baseInput({ interfaces: [{ name: 'eth0', state: 'down' }] }), t0 + 1000);
+    expect(down[0].message).toBe('Interface eth0 down');
+
+    const up = evaluateAlerts(baseInput({ interfaces: [{ name: 'eth0', state: 'up' }] }), t0 + 2000);
+    expect(up[0].message).toBe('Interface eth0 back up');
+  });
+
+  it('임계값을 환경변수로 덮어쓸 수 있다', async () => {
+    const { evaluateAlerts } = await freshAlerts({ ALERT_CPU_ENTER: '50', ALERT_CPU_CLEAR: '40' });
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput(), t0);
+    // 기본값이면 60 은 임계가 아니지만, ENTER=50 이므로 알림이 뜬다.
+    const entered = evaluateAlerts(baseInput({ cpu: 60 }), t0 + 1000);
+    expect(entered[0].message).toContain('CPU usage 60%');
+  });
+
+  it('알림 로그를 디스크에 남기고 재시작 후 복구한다', async () => {
+    const first = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    first.evaluateAlerts(baseInput(), t0);
+    first.evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
+
+    // 예약 저장을 기다리지 않고 종료 경로와 같은 동기 저장을 태운다.
+    process.emit('SIGTERM');
+
+    vi.resetModules();
+    process.env.DATA_DIR = first.dir;
+    process.env.ALERTS_FILE = first.file;
+    const second = await import('@/utils/collectors/alerts');
+    // 복구된 로그가 이전 CPU 알림을 포함해야 한다. 정상값으로 한 번 평가해도 유지.
+    const log = second.evaluateAlerts(baseInput(), t0 + 2000);
+    expect(log.some(e => e.message.includes('CPU usage 95%'))).toBe(true);
+  });
+});

--- a/src/utils/collectors/alerts.test.ts
+++ b/src/utils/collectors/alerts.test.ts
@@ -95,9 +95,9 @@ describe('evaluateAlerts', () => {
     evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, options] = fetchMock.mock.calls[0];
+    const [url, options] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('https://example.test/hook');
-    expect(JSON.parse((options as RequestInit).body as string).message).toContain('CPU usage 95%');
+    expect(JSON.parse(options.body as string).message).toContain('CPU usage 95%');
   });
 
   it('새 SSH 세션은 통지하고, 이미 있던 세션은 통지하지 않는다', async () => {

--- a/src/utils/collectors/alerts.ts
+++ b/src/utils/collectors/alerts.ts
@@ -263,12 +263,7 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
 
   if (input.firewall !== 'unknown' && input.firewall !== knownFirewall) {
     if (knownFirewall !== null) {
-      push(
-        input.firewall === 'active' ? 'ok' : 'critical',
-        `Firewall ${input.firewall}`,
-        at,
-        true
-      );
+      push(input.firewall === 'active' ? 'ok' : 'critical', `Firewall ${input.firewall}`, at, true);
     }
     knownFirewall = input.firewall;
   }

--- a/src/utils/collectors/alerts.ts
+++ b/src/utils/collectors/alerts.ts
@@ -1,6 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
 import { AlertEntry, AlertLevel, FirewallInfo, SshSession, TemperatureValue } from '@/types/system';
+import { dispatchAlert } from '@/utils/collectors/notify';
 
 const MAX_ENTRIES = 30;
+
+// 임계값은 환경변수로 덮어쓸 수 있게 한다. 미설정이면 아래 기본값을 쓴다 —
+// 소스를 고치지 않고도 운영자가 호스트 특성에 맞춰 조정할 수 있어야 한다.
+function num(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : fallback;
+}
 
 // 임계값을 넘나드는 값 때문에 로그가 도배되지 않도록, 켜지는 값과 꺼지는 값을
 // 다르게 둔다(히스테리시스).
@@ -17,55 +30,149 @@ const RULES: Rule[] = [
   {
     key: 'cpu',
     level: 'warning',
-    enterAbove: 90,
-    clearBelow: 80,
+    enterAbove: num('ALERT_CPU_ENTER', 90),
+    clearBelow: num('ALERT_CPU_CLEAR', 80),
     onEnter: value => `CPU usage ${value.toFixed(0)}%`,
     onClear: () => 'CPU usage back to normal'
   },
   {
     key: 'memory',
     level: 'warning',
-    enterAbove: 90,
-    clearBelow: 80,
+    enterAbove: num('ALERT_MEM_ENTER', 90),
+    clearBelow: num('ALERT_MEM_CLEAR', 80),
     onEnter: value => `Memory usage ${value.toFixed(0)}%`,
     onClear: () => 'Memory usage back to normal'
   },
   {
     key: 'disk',
     level: 'warning',
-    enterAbove: 85,
-    clearBelow: 80,
+    enterAbove: num('ALERT_DISK_ENTER', 85),
+    clearBelow: num('ALERT_DISK_CLEAR', 80),
     onEnter: value => `Disk usage crossed ${value.toFixed(0)}%`,
     onClear: () => 'Disk usage back to normal'
   },
   {
     key: 'temperature',
     level: 'critical',
-    enterAbove: 74,
-    clearBelow: 70,
+    enterAbove: num('ALERT_TEMP_ENTER', 74),
+    clearBelow: num('ALERT_TEMP_CLEAR', 70),
     onEnter: value => `CPU temp ${value.toFixed(1)}°C`,
     onClear: () => 'CPU temp back to normal'
   },
   {
     key: 'swap',
     level: 'warning',
-    enterAbove: 80,
-    clearBelow: 60,
+    enterAbove: num('ALERT_SWAP_ENTER', 80),
+    clearBelow: num('ALERT_SWAP_CLEAR', 60),
     onEnter: value => `Swap usage ${value.toFixed(0)}%`,
     onClear: () => 'Swap usage back to normal'
   }
 ];
 
+// 임계 상태가 지속될 때 다시 통지할 간격(분). 0(기본)이면 재통지하지 않는다.
+// 화면 로그는 도배하지 않고, 외부 웹훅으로만 재통지한다.
+const RENOTIFY_MS = num('ALERT_RENOTIFY_MINUTES', 0) * 60 * 1000;
+
 const active = new Set<string>();
 const log: AlertEntry[] = [];
 let knownSessions: Set<string> | null = null;
 let knownFirewall: FirewallInfo['status'] | null = null;
+let knownIfaceDown: Set<string> | null = null;
 let sequence = 0;
+// 룰별 마지막 외부 통지 시각. 재통지 쿨다운 판단에 쓴다.
+const lastNotifiedAt = new Map<string, number>();
 
-function push(level: AlertLevel, message: string, at: number): void {
+// --- 디스크 영속화 -------------------------------------------------------
+// 알림 로그는 지금까지 프로세스 메모리에만 있어 재시작하면 사라졌다. history.json
+// 과 같은 방식으로 data/alerts.json 에 남겨, 배포/크래시 후에도 최근 알림이 유지된다.
+const DATA_DIR = process.env.DATA_DIR || path.join(/*turbopackIgnore: true*/ process.cwd(), 'data');
+const STORE_FILE = process.env.ALERTS_FILE || path.join(DATA_DIR, 'alerts.json');
+const STORE_VERSION = 1;
+
+interface StoreShape {
+  v: number;
+  log: AlertEntry[];
+}
+
+let loaded = false;
+function ensureLoaded(): void {
+  if (loaded) return;
+  loaded = true;
+  try {
+    const raw = fs.readFileSync(/*turbopackIgnore: true*/ STORE_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as StoreShape;
+    if (parsed && parsed.v === STORE_VERSION && Array.isArray(parsed.log)) {
+      // 최신순으로 저장돼 있으므로 그대로 복원하되 상한을 지킨다.
+      for (const entry of parsed.log.slice(0, MAX_ENTRIES)) log.push(entry);
+    }
+  } catch {
+    // 파일이 없거나(첫 실행) 읽을 수 없으면 빈 상태로 시작한다.
+  }
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+let writing = false;
+const SAVE_INTERVAL_MS = 5000;
+
+async function writeStore(): Promise<void> {
+  if (writing) return;
+  writing = true;
+  const payload: StoreShape = { v: STORE_VERSION, log };
+  try {
+    await fs.promises.mkdir(DATA_DIR, { recursive: true });
+    const tmp = `${STORE_FILE}.tmp`;
+    await fs.promises.writeFile(tmp, JSON.stringify(payload), 'utf-8');
+    await fs.promises.rename(tmp, STORE_FILE);
+  } catch {
+    // 디스크 쓰기 실패는 치명적이지 않다. 다음 저장에서 다시 시도한다.
+  } finally {
+    writing = false;
+  }
+}
+
+function scheduleSave(): void {
+  if (saveTimer) return;
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    void writeStore();
+  }, SAVE_INTERVAL_MS);
+  if (typeof saveTimer.unref === 'function') saveTimer.unref();
+}
+
+// 종료 신호에 마지막 상태를 동기로 한 번 더 남긴다. 예약 저장이 아직 안 돌았어도
+// 최근 알림을 잃지 않는다(history.ts 와 같은 방식).
+function flushSync(): void {
+  try {
+    const payload: StoreShape = { v: STORE_VERSION, log };
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(STORE_FILE, JSON.stringify(payload), 'utf-8');
+  } catch {
+    // 종료 중 실패는 삼킨다.
+  }
+}
+
+let exitHooked = false;
+function hookExit(): void {
+  if (exitHooked) return;
+  exitHooked = true;
+  process.once('SIGTERM', () => flushSync());
+  process.once('SIGINT', () => flushSync());
+  process.once('beforeExit', () => flushSync());
+}
+
+// --- 로그/통지 -----------------------------------------------------------
+
+// firstEvaluation: 프로세스가 막 떠서 처음 평가하는 순간에는, 이미 임계 상태이거나
+// 이미 붙어 있던 SSH/방화벽 상태를 "방금 일어난 일"처럼 외부로 쏟아내지 않는다.
+// 화면 로그에는 남기되(운영자가 현재 상태를 알 수 있게) 웹훅 통지는 건너뛴다.
+function push(level: AlertLevel, message: string, at: number, notify: boolean): void {
   sequence += 1;
-  log.unshift({ id: `${at}-${sequence}`, level, message, at: new Date(at).toISOString() });
+  const entry: AlertEntry = { id: `${at}-${sequence}`, level, message, at: new Date(at).toISOString() };
+  log.unshift(entry);
   if (log.length > MAX_ENTRIES) log.length = MAX_ENTRIES;
+  scheduleSave();
+
+  if (notify) void dispatchAlert(entry);
 }
 
 export interface AlertInput {
@@ -76,9 +183,15 @@ export interface AlertInput {
   temperature: TemperatureValue;
   firewall: FirewallInfo['status'];
   sshSessions: SshSession[];
+  // 인터페이스 다운 감지용. 이름과 상태만 있으면 된다(선택적: 구버전 입력 호환).
+  interfaces?: { name: string; state: 'up' | 'down' | 'unknown' }[];
 }
 
 export function evaluateAlerts(input: AlertInput, at: number = Date.now()): AlertEntry[] {
+  ensureLoaded();
+  hookExit();
+
+  const firstEvaluation = knownSessions === null && knownFirewall === null && knownIfaceDown === null;
   const values: Record<string, number | null> = {
     cpu: input.cpu,
     memory: input.memory,
@@ -93,10 +206,24 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
 
     if (!active.has(rule.key) && value > rule.enterAbove) {
       active.add(rule.key);
-      push(rule.level, rule.onEnter(value), at);
+      lastNotifiedAt.set(rule.key, at);
+      push(rule.level, rule.onEnter(value), at, !firstEvaluation);
     } else if (active.has(rule.key) && value < rule.clearBelow) {
       active.delete(rule.key);
-      push('ok', rule.onClear(value), at);
+      lastNotifiedAt.delete(rule.key);
+      push('ok', rule.onClear(value), at, !firstEvaluation);
+    } else if (active.has(rule.key) && RENOTIFY_MS > 0) {
+      // 임계 상태가 지속되면 재통지(외부 웹훅만, 화면 로그는 도배하지 않는다).
+      const last = lastNotifiedAt.get(rule.key) ?? 0;
+      if (at - last >= RENOTIFY_MS) {
+        lastNotifiedAt.set(rule.key, at);
+        void dispatchAlert({
+          id: `${at}-renotify-${rule.key}`,
+          level: rule.level,
+          message: `${rule.onEnter(value)} (still)`,
+          at: new Date(at).toISOString()
+        });
+      }
     }
   }
 
@@ -110,9 +237,28 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
   } else {
     for (const session of input.sshSessions) {
       const key = `${session.user}@${session.ip}`;
-      if (!knownSessions.has(key)) push('info', `SSH login: ${session.user}@${session.ip}`, at);
+      if (!knownSessions.has(key)) push('info', `SSH login: ${session.user}@${session.ip}`, at, true);
     }
     knownSessions = sessionKeys;
+  }
+
+  // 인터페이스 다운 전이. up→down 은 경고, down→up 은 해제로 남긴다.
+  if (input.interfaces) {
+    const downNow = new Set(input.interfaces.filter(i => i.state === 'down').map(i => i.name));
+    if (knownIfaceDown === null) {
+      knownIfaceDown = downNow;
+    } else {
+      for (const name of downNow) {
+        if (!knownIfaceDown.has(name)) push('warning', `Interface ${name} down`, at, true);
+      }
+      for (const name of knownIfaceDown) {
+        if (!downNow.has(name)) push('ok', `Interface ${name} back up`, at, true);
+      }
+      knownIfaceDown = downNow;
+    }
+  } else if (knownIfaceDown === null) {
+    // 인터페이스 정보가 아직 없으면 첫 평가 플래그만 소진되지 않도록 빈 집합으로 초기화.
+    knownIfaceDown = new Set();
   }
 
   if (input.firewall !== 'unknown' && input.firewall !== knownFirewall) {
@@ -120,7 +266,8 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
       push(
         input.firewall === 'active' ? 'ok' : 'critical',
         `Firewall ${input.firewall}`,
-        at
+        at,
+        true
       );
     }
     knownFirewall = input.firewall;

--- a/src/utils/collectors/battery.ts
+++ b/src/utils/collectors/battery.ts
@@ -1,0 +1,35 @@
+import { readdir } from 'fs/promises';
+
+import { BatteryInfo } from '@/types/system';
+import { readSys, withTtl } from '@/utils/collectors/shell';
+
+// /sys/class/power_supply 의 배터리/UPS 를 읽는다. 라즈베리파이 UPS HAT,
+// 노트북, USB UPS 등에서 채워지고, 없으면(대부분의 서버) null 이라 대시보드는
+// N/A 로 남긴다. 충전율은 급히 변하지 않으니 조금 캐시한다.
+//
+// 전원 공급 장치는 Battery/UPS 외에 Mains(AC 어댑터)도 있어, type 이 Battery 이거나
+// capacity 를 노출하는 것만 배터리로 취급한다.
+export const getBatteryInfo = withTtl(15_000, async (): Promise<BatteryInfo | null> => {
+  let entries: string[];
+  try {
+    entries = await readdir('/sys/class/power_supply');
+  } catch {
+    return null; // 리눅스 아님 또는 전원 클래스 없음
+  }
+
+  for (const name of entries) {
+    const base = `/sys/class/power_supply/${name}`;
+    const type = await readSys(`${base}/type`);
+    if (type !== null && type !== 'Battery') continue;
+
+    const capacityRaw = await readSys(`${base}/capacity`);
+    if (capacityRaw === null) continue;
+    const percentage = parseInt(capacityRaw, 10);
+    if (Number.isNaN(percentage)) continue;
+
+    const status = (await readSys(`${base}/status`)) ?? 'Unknown';
+    return { percentage, status };
+  }
+
+  return null;
+});

--- a/src/utils/collectors/cpu.ts
+++ b/src/utils/collectors/cpu.ts
@@ -1,31 +1,69 @@
-import { readFile } from 'fs/promises';
+import { readFile, readdir } from 'fs/promises';
 
-import { clamp, round } from '@/utils/collectors/shell';
+import { clamp, readSys, round } from '@/utils/collectors/shell';
 
 interface CpuTimes {
   idle: number;
+  iowait: number;
+  steal: number;
   total: number;
 }
 
 export interface CpuUsage {
   total: number;
   perCore: number[];
+  // I/O 대기 비율: 디스크 병목 신호. steal: 하이퍼바이저에 뺏긴 시간으로 VPS
+  // 과판매 신호. /proc/stat 를 못 읽는 OS 에서는 각각 0/무의미.
+  iowait: number;
+  steal: number;
+  // 논리 코어들의 현재 클럭 평균(MHz). cpufreq 가 없으면 'N/A'.
+  frequencyMhz: number | 'N/A';
 }
 
 // `top -bn1` 의 첫 샘플은 부팅 이후 누적 평균이라 항상 0에 가깝게 나온다.
 // /proc/stat 를 두 번 읽어 그 사이의 변화량으로 계산한다.
 let previousSample: { total: CpuTimes; perCore: CpuTimes[] } | null = null;
 
+// /proc/stat cpu 필드: user nice system idle iowait irq softirq steal ...
 function parseCpuLine(line: string): CpuTimes {
   const values = line.trim().split(/\s+/).slice(1).map(Number);
   if (values.length < 4 || values.some(Number.isNaN)) {
     throw new Error(`unparsable /proc/stat cpu line: ${line}`);
   }
 
+  const iowait = values[4] ?? 0;
+  const steal = values[7] ?? 0;
   return {
-    idle: values[3] + (values[4] ?? 0), // idle + iowait
+    idle: values[3] + iowait, // idle + iowait 는 "일 안 한 시간"
+    iowait,
+    steal,
     total: values.reduce((sum, value) => sum + value, 0)
   };
+}
+
+// 각 코어의 현재 동작 주파수(kHz)를 평균내 MHz 로 돌려준다. cpufreq 거버너가
+// 없는 환경(가상화 등)에서는 파일이 없어 'N/A'.
+async function readFrequencyMhz(): Promise<number | 'N/A'> {
+  let cpus: string[];
+  try {
+    cpus = (await readdir('/sys/devices/system/cpu')).filter(name => /^cpu\d+$/.test(name));
+  } catch {
+    return 'N/A';
+  }
+
+  let sumKhz = 0;
+  let count = 0;
+  for (const cpu of cpus) {
+    const raw = await readSys(`/sys/devices/system/cpu/${cpu}/cpufreq/scaling_cur_freq`);
+    if (raw === null) continue;
+    const khz = parseInt(raw, 10);
+    if (!Number.isNaN(khz)) {
+      sumKhz += khz;
+      count += 1;
+    }
+  }
+
+  return count === 0 ? 'N/A' : round(sumKhz / count / 1000, 0);
 }
 
 async function readCpuStat(): Promise<{ total: CpuTimes; perCore: CpuTimes[] }> {
@@ -56,7 +94,7 @@ export async function getCpuUsage(): Promise<CpuUsage> {
     await new Promise(resolve => setTimeout(resolve, 200));
   }
 
-  const current = await readCpuStat();
+  const [current, frequencyMhz] = await Promise.all([readCpuStat(), readFrequencyMhz()]);
   previousSample = current;
 
   // 코어가 오프라인이 되면 개수가 달라질 수 있으므로 짧은 쪽에 맞춘다.
@@ -65,5 +103,16 @@ export async function getCpuUsage(): Promise<CpuUsage> {
     usageBetween(previous.perCore[index], current.perCore[index])
   );
 
-  return { total: usageBetween(previous.total, current.total), perCore };
+  // iowait/steal 은 전체 시간 대비 비율(%)로. 델타가 0이면(첫 샘플 등) 0.
+  const totalDelta = current.total.total - previous.total.total;
+  const share = (deltaField: number) =>
+    totalDelta > 0 ? round(clamp((deltaField / totalDelta) * 100, 0, 100), 1) : 0;
+
+  return {
+    total: usageBetween(previous.total, current.total),
+    perCore,
+    iowait: share(current.total.iowait - previous.total.iowait),
+    steal: share(current.total.steal - previous.total.steal),
+    frequencyMhz
+  };
 }

--- a/src/utils/collectors/df.test.ts
+++ b/src/utils/collectors/df.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDf } from '@/utils/collectors/df';
+
+// `df -Pk` 출력 예시. 헤더 + 실 블록 장치 + 의사 파일시스템이 섞여 있다.
+const SAMPLE = `Filesystem     1024-blocks      Used  Available Capacity Mounted on
+udev              8123456         0    8123456       0% /dev
+tmpfs             1638400      2048    1636352       1% /run
+/dev/sda1        50000000  25000000   25000000      50% /
+/dev/sdb1       200000000  20000000  180000000      10% /data
+overlay          50000000  25000000   25000000      50% /var/lib/docker/overlay2/abc
+/dev/sda1        50000000  25000000   25000000      50% /`;
+
+describe('parseDf', () => {
+  it('실 블록 장치(/dev/*)만 남기고 의사 파일시스템은 버린다', () => {
+    const disks = parseDf(SAMPLE);
+    const mounts = disks.map(d => d.mount);
+    expect(mounts).toContain('/');
+    expect(mounts).toContain('/data');
+    expect(mounts).not.toContain('/run'); // tmpfs
+    expect(mounts).not.toContain('/dev'); // udev
+    expect(mounts.some(m => m.includes('overlay'))).toBe(false);
+  });
+
+  it('중복 마운트는 한 번만 센다', () => {
+    const roots = parseDf(SAMPLE).filter(d => d.mount === '/');
+    expect(roots).toHaveLength(1);
+  });
+
+  it('루트를 맨 앞에 두고 GB/퍼센트를 계산한다', () => {
+    const disks = parseDf(SAMPLE);
+    expect(disks[0].mount).toBe('/');
+    expect(disks[0].percentage).toBe(50);
+    // 50000000 KB ≈ 47.68 GB
+    expect(disks[0].total).toBeCloseTo(47.68, 1);
+  });
+
+  it('빈/깨진 출력에도 죽지 않는다', () => {
+    expect(parseDf('')).toEqual([]);
+    expect(parseDf('garbage header only')).toEqual([]);
+  });
+});

--- a/src/utils/collectors/df.ts
+++ b/src/utils/collectors/df.ts
@@ -1,0 +1,52 @@
+import { DiskMount } from '@/types/system';
+import { round } from '@/utils/collectors/shell';
+
+// `df -Pk` 한 번으로 모든 마운트를 읽어, 루트(/) 외에 데이터 볼륨이 따로 붙은
+// 서버에서도 실제 사용량을 볼 수 있게 한다. 파싱은 순수 함수로 떼어 테스트한다.
+//
+// 실 블록 장치(첫 컬럼이 /dev/ 로 시작)만 남긴다. tmpfs/devtmpfs/overlay/proc
+// 같은 의사 파일시스템은 사용량이 의미가 없거나 중복 집계되므로 버린다.
+
+const toGb = (kb: number) => round(kb / 1024 / 1024);
+
+export function parseDf(stdout: string): DiskMount[] {
+  const lines = stdout.split('\n').slice(1); // 헤더 제거
+  const byMount = new Map<string, DiskMount>();
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    // Filesystem  1024-blocks  Used  Available  Capacity  Mounted-on
+    const parts = line.split(/\s+/);
+    if (parts.length < 6) continue;
+
+    const source = parts[0];
+    if (!source.startsWith('/dev/')) continue;
+
+    const totalKb = parseInt(parts[1], 10);
+    const usedKb = parseInt(parts[2], 10);
+    const capacity = parseInt(parts[4].replace('%', ''), 10);
+    // 마운트 경로에 공백이 들어갈 수 있어 6번째 이후를 다시 합친다.
+    const mount = parts.slice(5).join(' ');
+
+    if (Number.isNaN(totalKb) || Number.isNaN(usedKb) || totalKb <= 0) continue;
+
+    // bind 마운트 등으로 같은 장치가 여러 번 나오면 첫(대개 최상위) 것만 쓴다.
+    if (byMount.has(mount)) continue;
+
+    byMount.set(mount, {
+      mount,
+      used: toGb(usedKb),
+      total: toGb(totalKb),
+      percentage: Number.isNaN(capacity) ? round((usedKb / totalKb) * 100, 1) : capacity
+    });
+  }
+
+  // 루트를 맨 앞에, 나머지는 사용률 높은 순으로.
+  return [...byMount.values()].sort((a, b) => {
+    if (a.mount === '/') return -1;
+    if (b.mount === '/') return 1;
+    return b.percentage - a.percentage;
+  });
+}

--- a/src/utils/collectors/diskTrend.test.ts
+++ b/src/utils/collectors/diskTrend.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { predictHoursToFull } from '@/utils/collectors/diskTrend';
+
+const HOUR = 3_600_000;
+
+describe('predictHoursToFull', () => {
+  it('일정하게 차오르면 남은 시간을 추정한다', () => {
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    // 4시간 동안 80% → 84% (시간당 1%p). 남은 16%p → 16시간.
+    const samples = [
+      { at: now - 4 * HOUR, percent: 80 },
+      { at: now, percent: 84 }
+    ];
+    expect(predictHoursToFull(samples, now)).toBe(16);
+  });
+
+  it('정체/감소 중이면 예측하지 않는다', () => {
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    expect(
+      predictHoursToFull(
+        [
+          { at: now - 4 * HOUR, percent: 50 },
+          { at: now, percent: 50 }
+        ],
+        now
+      )
+    ).toBeNull();
+    expect(
+      predictHoursToFull(
+        [
+          { at: now - 4 * HOUR, percent: 60 },
+          { at: now, percent: 55 }
+        ],
+        now
+      )
+    ).toBeNull();
+  });
+
+  it('샘플이 하나뿐이면 예측할 수 없다', () => {
+    const now = Date.now();
+    expect(predictHoursToFull([{ at: now, percent: 90 }], now)).toBeNull();
+  });
+
+  it('이미 가득 찼으면 0을 준다', () => {
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    const samples = [
+      { at: now - 2 * HOUR, percent: 99 },
+      { at: now, percent: 100 }
+    ];
+    expect(predictHoursToFull(samples, now)).toBe(0);
+  });
+});

--- a/src/utils/collectors/diskTrend.ts
+++ b/src/utils/collectors/diskTrend.ts
@@ -1,0 +1,45 @@
+// 루트 디스크 사용률의 최근 추세로 "이 속도면 언제 가득 차는가" 를 추정한다.
+// 히스토리 버킷(load/cpu)과 달리 라이브 추정이라 디스크에 남기지 않는다 —
+// 재시작하면 창이 다시 차오른다. 예측이 목적이라 그걸로 충분하다.
+
+export interface DiskSample {
+  at: number;
+  percent: number;
+}
+
+// 창 안의 첫/끝 샘플로 선형 증가율을 내, 100% 까지 남은 시간을 시간 단위로 준다.
+// 채워질 만큼 오르고 있지 않으면(감소/정체) null — "곧 가득 참" 이 아닐 때 숫자를
+// 억지로 만들지 않는다.
+export function predictHoursToFull(samples: DiskSample[], at: number): number | null {
+  if (samples.length < 2) return null;
+
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const spanHours = (last.at - first.at) / 3_600_000;
+  if (spanHours <= 0) return null;
+
+  const ratePerHour = (last.percent - first.percent) / spanHours;
+  // 시간당 0.1%p 미만 증가는 노이즈로 보고 예측하지 않는다(먼 미래의 헛수).
+  if (ratePerHour < 0.1) return null;
+
+  const remaining = 100 - last.percent;
+  if (remaining <= 0) return 0;
+
+  void at;
+  return Math.round((remaining / ratePerHour) * 10) / 10;
+}
+
+const WINDOW_MS = 6 * 60 * 60 * 1000; // 최근 6시간의 추세만 본다
+const samples: DiskSample[] = [];
+
+export function recordDiskSample(percent: number, at: number = Date.now()): void {
+  samples.push({ at, percent });
+  const oldest = at - WINDOW_MS;
+  let drop = 0;
+  while (drop < samples.length && samples[drop].at < oldest) drop += 1;
+  if (drop > 0) samples.splice(0, drop);
+}
+
+export function getHoursToFull(at: number = Date.now()): number | null {
+  return predictHoursToFull(samples, at);
+}

--- a/src/utils/collectors/diskio.ts
+++ b/src/utils/collectors/diskio.ts
@@ -25,7 +25,7 @@ async function readDiskTotals(): Promise<{ read: number; write: number }> {
     const name = fields[2];
     if (!WHOLE_DISK_PATTERN.test(name)) continue;
 
-    const read = Number(fields[5]);  // sectors read
+    const read = Number(fields[5]); // sectors read
     const written = Number(fields[9]); // sectors written
     if (Number.isNaN(read) || Number.isNaN(written)) continue;
 

--- a/src/utils/collectors/host.ts
+++ b/src/utils/collectors/host.ts
@@ -35,7 +35,10 @@ const readRebootReason = withTtl(5 * 60 * 1000, async (): Promise<string | null>
     return null; // last 미설치(busybox 등) 또는 wtmp 권한 없음
   }
 
-  const lines = output.split('\n').map(line => line.trim()).filter(Boolean);
+  const lines = output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
   const rebootIndex = lines.findIndex(line => line.startsWith('reboot'));
   if (rebootIndex === -1) return null;
 

--- a/src/utils/collectors/host.ts
+++ b/src/utils/collectors/host.ts
@@ -44,8 +44,27 @@ const readRebootReason = withTtl(5 * 60 * 1000, async (): Promise<string | null>
   return previous.startsWith('shutdown') ? 'clean shutdown' : 'unexpected shutdown';
 });
 
+// 가상화/컨테이너 종류. 일부 지표(steal, 온도, 팬)의 해석이 베어메탈과 달라지므로
+// 어떤 환경에서 도는지 표기한다. systemd-detect-virt 는 없으면 exit 1 이라 || true.
+// 값은 부팅 중 바뀌지 않으니 오래 캐시한다.
+const readVirtualization = withTtl(60 * 60 * 1000, async (): Promise<string | null> => {
+  try {
+    const output = await run('systemd-detect-virt 2>/dev/null || true');
+    const value = output.trim();
+    // "none" 은 베어메탈. 빈 문자열은 도구 미설치 — 둘 다 표기하지 않는다.
+    if (!value || value === 'none') return null;
+    return value;
+  } catch {
+    return null;
+  }
+});
+
 export async function getHostInfo(): Promise<HostInfo> {
-  const [distro, rebootReason] = await Promise.all([readDistro(), readRebootReason()]);
+  const [distro, rebootReason, virtualization] = await Promise.all([
+    readDistro(),
+    readRebootReason(),
+    readVirtualization()
+  ]);
 
   return {
     hostname: os.hostname(),
@@ -53,6 +72,7 @@ export async function getHostInfo(): Promise<HostInfo> {
     kernel: os.release(),
     arch: os.arch(),
     bootTime: new Date(Date.now() - os.uptime() * 1000).toISOString(),
-    rebootReason
+    rebootReason,
+    virtualization
   };
 }

--- a/src/utils/collectors/netstat.ts
+++ b/src/utils/collectors/netstat.ts
@@ -18,7 +18,10 @@ const TCP_LISTEN = '0A';
 function hexToIpv4(hex: string): string {
   const bytes = hex.match(/../g);
   if (!bytes || bytes.length !== 4) return '0.0.0.0';
-  return bytes.reverse().map(byte => parseInt(byte, 16)).join('.');
+  return bytes
+    .reverse()
+    .map(byte => parseInt(byte, 16))
+    .join('.');
 }
 
 function hexToIpv6(hex: string): string {
@@ -188,9 +191,7 @@ export async function getDefaultInterface(): Promise<string> {
 }
 
 async function listInterfaceNames(): Promise<string[]> {
-  return (await readdir('/sys/class/net')).filter(
-    name => name !== 'lo' && INTERFACE_NAME_PATTERN.test(name)
-  );
+  return (await readdir('/sys/class/net')).filter(name => name !== 'lo' && INTERFACE_NAME_PATTERN.test(name));
 }
 
 export async function readInterfaceStat(interfaceName: string, stat: string): Promise<number> {

--- a/src/utils/collectors/notify.ts
+++ b/src/utils/collectors/notify.ts
@@ -1,0 +1,66 @@
+import { AlertEntry } from '@/types/system';
+
+// 알림은 지금까지 화면(대시보드 alerts 카드)에만 표시됐다. 벽에 걸어둔 패널을
+// 24/7 쳐다보지 않는 한 임계값을 넘겨도 아무도 모른다. 여기서 임계 전이가 생길
+// 때마다 외부로 한 번 밀어준다. ALERT_WEBHOOK_URL 이 설정돼 있을 때만 동작하고,
+// 미설정이면(기본값) 완전히 무동작이라 기존 배포에 영향이 없다.
+
+const WEBHOOK_URL = process.env.ALERT_WEBHOOK_URL;
+// json  — AlertEntry 를 그대로 POST (자체 수신기/웹훅 브리지용)
+// slack — Slack Incoming Webhook 의 { text } 형태
+// discord — Discord Webhook 의 { content } 형태
+const WEBHOOK_FORMAT = (process.env.ALERT_WEBHOOK_FORMAT || 'json').toLowerCase();
+
+// 수집 루프는 매초 도는 민감한 경로다. 웹훅이 느리거나 죽어 있어도 루프를
+// 붙잡지 않도록 짧게 끊는다(클러스터 fetch 와 같은 방식).
+const TIMEOUT_MS = 5000;
+
+// UI 에서 쓰는 레벨을 사람이 읽는 접두사로. Slack/Discord 메시지 앞머리에 붙는다.
+const LEVEL_PREFIX: Record<AlertEntry['level'], string> = {
+  ok: '✅',
+  info: 'ℹ️',
+  warning: '⚠️',
+  critical: '🚨'
+};
+
+function formatPayload(entry: AlertEntry): string {
+  const prefix = LEVEL_PREFIX[entry.level] ?? '';
+  const host = process.env.NEXT_PUBLIC_SITE_SHORT_NAME || 'ServerMonitor';
+  const text = `${prefix} [${host}] ${entry.message}`;
+
+  switch (WEBHOOK_FORMAT) {
+    case 'slack':
+      return JSON.stringify({ text });
+    case 'discord':
+      return JSON.stringify({ content: text });
+    default:
+      return JSON.stringify(entry);
+  }
+}
+
+/**
+ * 새 알림 하나를 설정된 웹훅으로 밀어준다. 발송 여부/성공에 호출부가 기대지
+ * 않도록 항상 resolve 하며(실패는 로그만), fire-and-forget 으로 부르면 된다.
+ * 스팸 억제(히스테리시스·부팅 직후 무통지)는 호출부(alerts.ts)가 이미 처리한다.
+ */
+export async function dispatchAlert(entry: AlertEntry): Promise<void> {
+  if (!WEBHOOK_URL) return;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    await fetch(WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: formatPayload(entry),
+      signal: controller.signal
+    });
+  } catch (error) {
+    // 웹훅 실패는 치명적이지 않다. 대시보드/로그에는 알림이 그대로 남는다.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[alerts] webhook dispatch failed:', message);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/utils/collectors/notify.ts
+++ b/src/utils/collectors/notify.ts
@@ -1,4 +1,5 @@
 import { AlertEntry } from '@/types/system';
+import { logger } from '@/utils/logger';
 
 // 알림은 지금까지 화면(대시보드 alerts 카드)에만 표시됐다. 벽에 걸어둔 패널을
 // 24/7 쳐다보지 않는 한 임계값을 넘겨도 아무도 모른다. 여기서 임계 전이가 생길
@@ -59,7 +60,7 @@ export async function dispatchAlert(entry: AlertEntry): Promise<void> {
   } catch (error) {
     // 웹훅 실패는 치명적이지 않다. 대시보드/로그에는 알림이 그대로 남는다.
     const message = error instanceof Error ? error.message : String(error);
-    console.error('[alerts] webhook dispatch failed:', message);
+    logger.error('alerts webhook dispatch failed:', message);
   } finally {
     clearTimeout(timeout);
   }

--- a/src/utils/collectors/security.ts
+++ b/src/utils/collectors/security.ts
@@ -60,7 +60,10 @@ const BOOT_MS = Date.now() - os.uptime() * 1000;
 async function processStart(pid: string): Promise<string> {
   try {
     const stat = await readFile(`/proc/${pid}/stat`, 'utf-8');
-    const afterComm = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/);
+    const afterComm = stat
+      .slice(stat.lastIndexOf(')') + 2)
+      .trim()
+      .split(/\s+/);
     const startTicks = Number(afterComm[19]); // 필드22 = state(3) 기준 인덱스 19
     if (!Number.isFinite(startTicks)) return new Date().toISOString();
 

--- a/src/utils/collectors/shell.ts
+++ b/src/utils/collectors/shell.ts
@@ -2,6 +2,8 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { readFile } from 'fs/promises';
 
+import { logger } from '@/utils/logger';
+
 const execAsync = promisify(exec);
 
 // `ip`, `sensors`, `ps` 등은 /usr/sbin, /sbin 에 설치되는 경우가 많은데
@@ -39,7 +41,7 @@ export async function collect<T>(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     warnings.push(`${name}: ${message}`);
-    console.warn(`[systemMonitor] ${name} failed:`, message);
+    logger.warn(`collector ${name} failed:`, message);
     return fallback;
   }
 }

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -15,7 +15,10 @@ export function isAllowedOrigin(origin: string | undefined): origin is string {
 // B 오리진에 그대로 재사용해, 허용되지 않은 오리진이 읽어 가거나 그 반대가 된다.
 // 오리진이 허용되지 않아 ACAO 를 안 붙이는 경우에도 응답은 Origin 에 의존하므로
 // 항상 붙인다.
-export function corsHeaders(origin: string | undefined, base: Record<string, string> = {}): Record<string, string> {
+export function corsHeaders(
+  origin: string | undefined,
+  base: Record<string, string> = {}
+): Record<string, string> {
   const headers: Record<string, string> = { ...base, Vary: 'Origin' };
   if (isAllowedOrigin(origin)) {
     headers['Access-Control-Allow-Origin'] = origin;

--- a/src/utils/dashboardData.ts
+++ b/src/utils/dashboardData.ts
@@ -9,7 +9,10 @@ import {
   ServerData,
   SwapInfo,
   DiskIoInfo,
+  DiskMount,
   GpuInfo,
+  ProcessSummary,
+  BatteryInfo,
   TemperatureInfo,
   TemperatureValue
 } from '@/types/system';
@@ -22,9 +25,13 @@ export interface DashboardData {
     cores: number;
     temperature: TemperatureValue;
     perCore: number[];
+    iowait: number;
+    steal: number;
+    frequencyMhz: number | 'N/A';
   };
   memory: { used: number; total: number; percentage: number };
   disk: { used: number; total: number; percentage: number };
+  disks: DiskMount[];
   swap: SwapInfo;
   diskIO: DiskIoInfo;
   gpu: GpuInfo;
@@ -38,6 +45,8 @@ export interface DashboardData {
     interfaces: NetworkInterfaceInfo[];
     linkSpeedMbps: number | null;
     bandwidthPercentage: number;
+    totalRxBytes: number;
+    totalTxBytes: number;
   };
   uptime: { days: number; hours: number; minutes: number };
   temperature: TemperatureInfo;
@@ -46,6 +55,9 @@ export interface DashboardData {
   host: HostInfo;
   load: LoadInfo;
   security: SecurityInfo;
+  processSummary: ProcessSummary;
+  topProcessesByMemory: Process[];
+  battery: BatteryInfo | null;
   history: HistoryInfo;
   alerts: AlertEntry[];
   timestamp: string;
@@ -66,10 +78,14 @@ export function toDashboardData(raw: ServerData): DashboardData {
       usage: raw.cpu.usage,
       cores: raw.cpu.cores,
       temperature: raw.cpu.temperature,
-      perCore: raw.cpu.perCore ?? []
+      perCore: raw.cpu.perCore ?? [],
+      iowait: raw.cpu.iowait ?? 0,
+      steal: raw.cpu.steal ?? 0,
+      frequencyMhz: raw.cpu.frequencyMhz ?? 'N/A'
     },
     memory: raw.memory,
     disk: raw.disk,
+    disks: raw.disks ?? [],
     swap: raw.swap ?? { used: 0, total: 0, percentage: 0 },
     diskIO: raw.diskIO ?? { read: 0, write: 0 },
     gpu: raw.gpu ?? { name: null, usage: 'N/A', temperature: 'N/A' },
@@ -82,7 +98,9 @@ export function toDashboardData(raw: ServerData): DashboardData {
       listeningPorts: raw.network.listeningPorts ?? 0,
       interfaces: raw.network.interfaces ?? [],
       linkSpeedMbps: raw.network.linkSpeedMbps ?? null,
-      bandwidthPercentage: raw.network.bandwidthPercentage ?? 0
+      bandwidthPercentage: raw.network.bandwidthPercentage ?? 0,
+      totalRxBytes: raw.network.totalRxBytes ?? 0,
+      totalTxBytes: raw.network.totalTxBytes ?? 0
     },
     uptime: raw.uptime,
     temperature: raw.temperature,
@@ -94,10 +112,14 @@ export function toDashboardData(raw: ServerData): DashboardData {
       kernel: '—',
       arch: '—',
       bootTime: new Date().toISOString(),
-      rebootReason: null
+      rebootReason: null,
+      virtualization: null
     },
     load: raw.load ?? { avg1: 0, avg5: 0, avg15: 0, running: null, avg30: null, avg30WindowSeconds: 0 },
     security: raw.security ?? EMPTY_SECURITY,
+    processSummary: raw.processSummary ?? { total: 0, running: 0, sleeping: 0, zombie: 0, threads: null },
+    topProcessesByMemory: raw.topProcessesByMemory ?? [],
+    battery: raw.battery ?? null,
     history: raw.history ?? EMPTY_HISTORY,
     alerts: raw.alerts ?? [],
     timestamp: raw.timestamp ?? new Date().toISOString(),

--- a/src/utils/dashboardData.ts
+++ b/src/utils/dashboardData.ts
@@ -30,7 +30,7 @@ export interface DashboardData {
     frequencyMhz: number | 'N/A';
   };
   memory: { used: number; total: number; percentage: number };
-  disk: { used: number; total: number; percentage: number };
+  disk: { used: number; total: number; percentage: number; hoursToFull: number | null };
   disks: DiskMount[];
   swap: SwapInfo;
   diskIO: DiskIoInfo;
@@ -84,7 +84,7 @@ export function toDashboardData(raw: ServerData): DashboardData {
       frequencyMhz: raw.cpu.frequencyMhz ?? 'N/A'
     },
     memory: raw.memory,
-    disk: raw.disk,
+    disk: { ...raw.disk, hoursToFull: raw.disk.hoursToFull ?? null },
     disks: raw.disks ?? [],
     swap: raw.swap ?? { used: 0, total: 0, percentage: 0 },
     diskIO: raw.diskIO ?? { read: 0, write: 0 },

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -52,8 +52,8 @@ export function formatRelativeTime(iso: string, now: number): string {
 }
 
 export function formatClock(date: Date): string {
-  const day = date.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
-  const time = date.toLocaleTimeString('ko-KR', {
+  const day = date.toLocaleDateString('en-US', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  const time = date.toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,49 @@
+import { gzip } from 'zlib';
+import { promisify } from 'util';
+
+const gzipAsync = promisify(gzip);
+
+// Next 는 라우트 핸들러가 돌려주는 Response 를 자동으로 압축하지 않는다.
+// /api/system 응답은 history + processes 로 수십 KB 에 이르고 클러스터가 매초
+// 폴링하므로, 클라이언트가 gzip 을 받는다고 알릴 때만 압축해서 돌려준다.
+//
+// 스트리밍(SSE)에는 쓰면 안 된다 — 그쪽은 연결을 열어둔 채 흘려보내므로 압축이
+// 실시간성을 깨뜨린다. 이 헬퍼는 완결된 JSON 바디에만 쓴다.
+export async function jsonResponse(
+  request: Request,
+  payload: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {}
+): Promise<Response> {
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    // 같은 URL 이 Accept-Encoding 에 따라 다른 바디를 내므로 캐시가 섞이지 않게 한다.
+    Vary: mergeVary(init.headers?.['Vary'], 'Accept-Encoding'),
+    ...init.headers
+  };
+  // 위에서 ...init.headers 가 Vary 를 덮으므로, 병합한 값을 다시 확정한다.
+  headers['Vary'] = mergeVary(init.headers?.['Vary'], 'Accept-Encoding');
+
+  const accepts = (request.headers.get('accept-encoding') || '').toLowerCase().includes('gzip');
+  // 아주 작은 바디는 압축 이득이 없다(헤더/CPU 오버헤드가 더 크다).
+  if (accepts && body.length > 1024) {
+    const compressed = await gzipAsync(body);
+    return new Response(compressed, {
+      status: init.status ?? 200,
+      headers: { ...headers, 'Content-Encoding': 'gzip' }
+    });
+  }
+
+  return new Response(body, { status: init.status ?? 200, headers });
+}
+
+function mergeVary(existing: string | undefined, add: string): string {
+  const parts = new Set(
+    (existing ?? '')
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean)
+  );
+  parts.add(add);
+  return [...parts].join(', ');
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,27 @@
+// 흩어져 있던 console.warn/error 를 레벨 있는 로거 하나로 모은다. LOG_LEVEL 로
+// 출력량을 조절한다(error < warn < info < debug). 기본은 info — 수집기 실패
+// 경고까지는 보이고, 상세 디버그는 감춘다. 의존성 없이 console 위에 얇게 얹는다.
+
+type Level = 'error' | 'warn' | 'info' | 'debug';
+
+const ORDER: Record<Level, number> = { error: 0, warn: 1, info: 2, debug: 3 };
+
+function threshold(): number {
+  const raw = (process.env.LOG_LEVEL || 'info').toLowerCase();
+  return raw in ORDER ? ORDER[raw as Level] : ORDER.info;
+}
+
+function emit(level: Level, args: unknown[]): void {
+  if (ORDER[level] > threshold()) return;
+  const prefix = `[${new Date().toISOString()}] ${level.toUpperCase()}`;
+  // error/warn 은 stderr, 나머지는 stdout 으로 나가도록 대응 console 메서드를 쓴다.
+  const sink = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+  sink(prefix, ...args);
+}
+
+export const logger = {
+  error: (...args: unknown[]) => emit('error', args),
+  warn: (...args: unknown[]) => emit('warn', args),
+  info: (...args: unknown[]) => emit('info', args),
+  debug: (...args: unknown[]) => emit('debug', args)
+};

--- a/src/utils/statusColors.test.ts
+++ b/src/utils/statusColors.test.ts
@@ -17,8 +17,7 @@ function hue([r, g, b]: [number, number, number]): number {
   if (max === min) return 0;
 
   const span = max - min;
-  const raw =
-    max === r ? ((g - b) / span) % 6 : max === g ? (b - r) / span + 2 : (r - g) / span + 4;
+  const raw = max === r ? ((g - b) / span) % 6 : max === g ? (b - r) / span + 2 : (r - g) / span + 4;
   return (raw * 60 + 360) % 360;
 }
 

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -510,7 +510,7 @@ export async function getSystemInfo(): Promise<ServerData> {
       temperature: cpu.temperature,
       firewall: security.firewall.status,
       sshSessions: security.sshSessions,
-      interfaces: network.interfaces.map(({ name, state }) => ({ name, state }))
+      interfaces: (network.interfaces ?? []).map(({ name, state }) => ({ name, state }))
     },
     now
   );

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -17,6 +17,7 @@ import {
 import { collect, readSys, round, run } from '@/utils/collectors/shell';
 import { parseDf } from '@/utils/collectors/df';
 import { getBatteryInfo } from '@/utils/collectors/battery';
+import { getHoursToFull, recordDiskSample } from '@/utils/collectors/diskTrend';
 import { getCpuUsage } from '@/utils/collectors/cpu';
 import { getHostInfo } from '@/utils/collectors/host';
 import { getLoadAverage, getSwapInfo } from '@/utils/collectors/load';
@@ -572,6 +573,8 @@ export async function getSystemInfo(): Promise<ServerData> {
   const security = await getSecurityInfo(sockets.peers, warnings);
 
   recordSample(cpu.usage, loadBase.avg1, now);
+  recordDiskSample(disk.percentage, now);
+  const diskHoursToFull = getHoursToFull(now);
 
   // 창은 방금 넣은 샘플까지 포함해야 하므로 recordSample 뒤에 읽는다.
   const rolling30m = getLoad30mAverage(now);
@@ -598,7 +601,12 @@ export async function getSystemInfo(): Promise<ServerData> {
   const data: ServerData = {
     cpu,
     memory,
-    disk: { used: disk.used, total: disk.total, percentage: disk.percentage },
+    disk: {
+      used: disk.used,
+      total: disk.total,
+      percentage: disk.percentage,
+      hoursToFull: diskHoursToFull
+    },
     disks: disk.mounts,
     network,
     temperature,

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -9,9 +9,14 @@ import {
   TemperatureInfo,
   TemperatureValue,
   SecurityInfo,
-  LoadInfo
+  LoadInfo,
+  DiskMount,
+  ProcessSummary,
+  BatteryInfo
 } from '@/types/system';
 import { collect, readSys, round, run } from '@/utils/collectors/shell';
+import { parseDf } from '@/utils/collectors/df';
+import { getBatteryInfo } from '@/utils/collectors/battery';
 import { getCpuUsage } from '@/utils/collectors/cpu';
 import { getHostInfo } from '@/utils/collectors/host';
 import { getLoadAverage, getSwapInfo } from '@/utils/collectors/load';
@@ -39,6 +44,9 @@ interface CpuInfo {
   cores: number;
   temperature: number | 'N/A';
   perCore: number[];
+  iowait: number;
+  steal: number;
+  frequencyMhz: number | 'N/A';
 }
 
 interface MemoryInfo {
@@ -66,6 +74,9 @@ interface NetworkInfo {
   interfaces: ServerData['network']['interfaces'];
   linkSpeedMbps: number | null;
   bandwidthPercentage: number;
+  // 부팅 이후 기본 인터페이스의 누적 수신/송신 바이트. 월 대역폭 관리에 쓴다.
+  totalRxBytes: number;
+  totalTxBytes: number;
 }
 
 interface FanInfo {
@@ -91,11 +102,24 @@ function getArchitecture(): 'x86' | 'arm' | 'unknown' {
 
 async function getCpuInfo(warnings: string[]): Promise<CpuInfo> {
   const [usage, temperature] = await Promise.all([
-    collect('cpu.usage', getCpuUsage, { total: 0, perCore: [] }, warnings),
+    collect(
+      'cpu.usage',
+      getCpuUsage,
+      { total: 0, perCore: [], iowait: 0, steal: 0, frequencyMhz: 'N/A' as const },
+      warnings
+    ),
     collect<number | 'N/A'>('cpu.temperature', getCpuTemperature, 'N/A', warnings)
   ]);
 
-  return { usage: usage.total, perCore: usage.perCore, cores: os.cpus().length, temperature };
+  return {
+    usage: usage.total,
+    perCore: usage.perCore,
+    cores: os.cpus().length,
+    temperature,
+    iowait: usage.iowait,
+    steal: usage.steal,
+    frequencyMhz: usage.frequencyMhz
+  };
 }
 
 // --- Memory ------------------------------------------------------------
@@ -124,25 +148,23 @@ async function getMemoryInfo(): Promise<MemoryInfo> {
 
 // --- Disk --------------------------------------------------------------
 
-async function getDiskInfo(): Promise<DiskInfo> {
+interface DiskReport extends DiskInfo {
+  mounts: DiskMount[];
+}
+
+async function getDiskInfo(): Promise<DiskReport> {
   // -P 는 긴 장치명 때문에 줄이 두 줄로 접히는 것을 막고,
   // -k 는 1K 블록으로 고정해 "20G"/"1.5T"/"800M" 단위 파싱을 없앤다.
-  const stdout = await run('df -Pk /');
-  const line = stdout.split('\n').pop() ?? '';
-  const [, totalKb, usedKb, , percentage] = line.trim().split(/\s+/);
+  // 경로 인자 없이 전체 마운트를 읽어 루트 외 파일시스템도 함께 돌려준다.
+  const stdout = await run('df -Pk');
+  const mounts = parseDf(stdout);
 
-  const total = parseInt(totalKb, 10);
-  const used = parseInt(usedKb, 10);
-  if (Number.isNaN(total) || Number.isNaN(used)) {
-    throw new Error(`unparsable df output: ${line}`);
+  const root = mounts.find(mount => mount.mount === '/');
+  if (!root) {
+    throw new Error(`no root filesystem in df output: ${stdout.split('\n')[1] ?? ''}`);
   }
 
-  const toGb = (kb: number) => round(kb / 1024 / 1024);
-  return {
-    used: toGb(used),
-    total: toGb(total),
-    percentage: parseInt(percentage.replace('%', ''), 10) || round((used / total) * 100, 1)
-  };
+  return { used: root.used, total: root.total, percentage: root.percentage, mounts };
 }
 
 // --- Network -----------------------------------------------------------
@@ -215,7 +237,9 @@ async function getNetworkInfo(warnings: string[], sockets: SocketSummary): Promi
     interfaces,
     linkSpeedMbps,
     bandwidthPercentage:
-      linkCapacityKbps === null ? 0 : round(Math.min(100, ((download + upload) / linkCapacityKbps) * 100), 1)
+      linkCapacityKbps === null ? 0 : round(Math.min(100, ((download + upload) / linkCapacityKbps) * 100), 1),
+    totalRxBytes: rxBytes,
+    totalTxBytes: txBytes
   };
 }
 
@@ -344,13 +368,13 @@ async function getFanSpeed(): Promise<FanInfo> {
 
 // --- Processes / Uptime ------------------------------------------------
 
-async function getProcesses(): Promise<Process[]> {
-  // `args`(전체 명령줄) 대신 `comm`(실행 파일명)만 읽는다. 명령줄 인자에는
-  // 비밀번호/토큰이 그대로 노출되는 경우가 많은데(예: `mysql -pSECRET`,
-  // `--api-key=...`), 이 목록은 API 로도 나가므로 실행 파일명이면 충분하고 안전하다.
-  // 파이프라인의 종료 코드는 head 의 것이라 ps 가 실패해도 0 이 된다.
-  // 빈 출력을 그대로 넘기면 원인 없이 목록만 비므로 여기서 에러로 올린다.
-  const stdout = await run('ps -eo pid,pcpu,pmem,stat,comm --sort=-pcpu | head -n 21');
+// `args`(전체 명령줄) 대신 `comm`(실행 파일명)만 읽는다. 명령줄 인자에는
+// 비밀번호/토큰이 그대로 노출되는 경우가 많은데(예: `mysql -pSECRET`,
+// `--api-key=...`), 이 목록은 API 로도 나가므로 실행 파일명이면 충분하고 안전하다.
+// 파이프라인의 종료 코드는 head 의 것이라 ps 가 실패해도 0 이 된다.
+// 빈 출력을 그대로 넘기면 원인 없이 목록만 비므로 여기서 에러로 올린다.
+async function getProcessesBy(sort: '-pcpu' | '-pmem'): Promise<Process[]> {
+  const stdout = await run(`ps -eo pid,pcpu,pmem,stat,comm --sort=${sort} | head -n 21`);
   const lines = stdout.split('\n').slice(1); // 헤더 제거
   if (lines.length === 0) {
     throw new Error('ps returned no rows (does this ps support --sort?)');
@@ -380,6 +404,40 @@ async function getProcesses(): Promise<Process[]> {
     throw new Error(`ps output could not be parsed: ${lines[0]}`);
   }
   return processes;
+}
+
+function getProcesses(): Promise<Process[]> {
+  return getProcessesBy('-pcpu');
+}
+
+// 전체 프로세스 규모 요약. 상위 목록(top 20)과 달리 시스템 전체를 센다. 상태 한
+// 글자만 읽어(`stat=`) 가볍게, 좀비(Z) 급증 같은 이상 징후를 드러낸다. 스레드
+// 포함 태스크 수는 /proc/loadavg 분모에서 얻는다.
+async function getProcessSummary(): Promise<ProcessSummary> {
+  const stdout = await run('ps -eo stat= 2>/dev/null');
+  const states = stdout.split('\n').map(line => line.trim()).filter(Boolean);
+  if (states.length === 0) throw new Error('ps returned no process states');
+
+  let running = 0;
+  let sleeping = 0;
+  let zombie = 0;
+  for (const state of states) {
+    const first = state[0];
+    if (first === 'R') running += 1;
+    else if (first === 'Z') zombie += 1;
+    else sleeping += 1;
+  }
+
+  let threads: number | null = null;
+  try {
+    const loadavg = await readFile('/proc/loadavg', 'utf-8');
+    const match = loadavg.match(/\d+\/(\d+)/);
+    if (match) threads = parseInt(match[1], 10);
+  } catch {
+    // /proc 없음(리눅스 아님). 스레드 수는 비운다.
+  }
+
+  return { total: states.length, running, sleeping, zombie, threads };
 }
 
 async function getUptime(): Promise<UptimeInfo> {
@@ -440,11 +498,26 @@ export async function getSystemInfo(): Promise<ServerData> {
 
   // Promise.all 이 아니라 개별 fallback 으로 감싼다. 예전에는 수집기 하나만
   // 실패해도 전체 응답이 0으로 떨어졌다.
-  const [cpu, memory, disk, network, temperature, fan, processes, uptime, host, swap, diskIO, gpu] =
-    await Promise.all([
+  const [
+    cpu,
+    memory,
+    disk,
+    network,
+    temperature,
+    fan,
+    processes,
+    uptime,
+    host,
+    swap,
+    diskIO,
+    gpu,
+    processSummary,
+    topProcessesByMemory,
+    battery
+  ] = await Promise.all([
       getCpuInfo(warnings),
       collect('memory', getMemoryInfo, { used: 0, total: 0, percentage: 0 }, warnings),
-      collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+      collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0, mounts: [] as DiskMount[] }, warnings),
       collect(
         'network',
         () => getNetworkInfo(warnings, sockets),
@@ -457,7 +530,9 @@ export async function getSystemInfo(): Promise<ServerData> {
           listeningPorts: 0,
           interfaces: [],
           linkSpeedMbps: null,
-          bandwidthPercentage: 0
+          bandwidthPercentage: 0,
+          totalRxBytes: 0,
+          totalTxBytes: 0
         },
         warnings
       ),
@@ -474,7 +549,8 @@ export async function getSystemInfo(): Promise<ServerData> {
           kernel: os.release(),
           arch: os.arch(),
           bootTime: new Date(Date.now() - os.uptime() * 1000).toISOString(),
-          rebootReason: null
+          rebootReason: null,
+          virtualization: null
         },
         warnings
       ),
@@ -485,7 +561,15 @@ export async function getSystemInfo(): Promise<ServerData> {
         getGpuInfo,
         { name: null, usage: 'N/A' as const, temperature: 'N/A' as const },
         warnings
-      )
+      ),
+      collect<ProcessSummary>(
+        'processSummary',
+        getProcessSummary,
+        { total: 0, running: 0, sleeping: 0, zombie: 0, threads: null },
+        warnings
+      ),
+      collect<Process[]>('processesByMemory', () => getProcessesBy('-pmem'), [], warnings),
+      collect<BatteryInfo | null>('battery', getBatteryInfo, null, warnings)
     ]);
 
   const loadBase = await getLoadAverage();
@@ -518,7 +602,8 @@ export async function getSystemInfo(): Promise<ServerData> {
   const data: ServerData = {
     cpu,
     memory,
-    disk,
+    disk: { used: disk.used, total: disk.total, percentage: disk.percentage },
+    disks: disk.mounts,
     network,
     temperature,
     fan,
@@ -530,6 +615,9 @@ export async function getSystemInfo(): Promise<ServerData> {
     diskIO,
     gpu,
     security,
+    processSummary,
+    topProcessesByMemory,
+    battery,
     history: getHistory(now),
     alerts,
     timestamp: new Date(now).toISOString(),

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -213,7 +213,8 @@ async function getNetworkInfo(warnings: string[], sockets: SocketSummary): Promi
   }
 
   // 에러율은 바이트가 아니라 패킷 대비로 계산해야 의미가 있다.
-  const rate = (errors: number, packets: number) => (packets > 0 ? ((errors / packets) * 100).toFixed(2) : '0.00');
+  const rate = (errors: number, packets: number) =>
+    packets > 0 ? ((errors / packets) * 100).toFixed(2) : '0.00';
 
   const [ping, interfaces] = await Promise.all([
     collect('network.ping', getPing, 0, warnings),
@@ -415,7 +416,10 @@ function getProcesses(): Promise<Process[]> {
 // 포함 태스크 수는 /proc/loadavg 분모에서 얻는다.
 async function getProcessSummary(): Promise<ProcessSummary> {
   const stdout = await run('ps -eo stat= 2>/dev/null');
-  const states = stdout.split('\n').map(line => line.trim()).filter(Boolean);
+  const states = stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
   if (states.length === 0) throw new Error('ps returned no process states');
 
   let running = 0;
@@ -452,10 +456,7 @@ async function getUptime(): Promise<UptimeInfo> {
 
 // --- Security ----------------------------------------------------------
 
-async function getSecurityInfo(
-  peers: Map<string, number>,
-  warnings: string[]
-): Promise<SecurityInfo> {
+async function getSecurityInfo(peers: Map<string, number>, warnings: string[]): Promise<SecurityInfo> {
   const [firewall, sshSessions, topTraffic] = await Promise.all([
     collect(
       'security.firewall',
@@ -515,62 +516,57 @@ export async function getSystemInfo(): Promise<ServerData> {
     topProcessesByMemory,
     battery
   ] = await Promise.all([
-      getCpuInfo(warnings),
-      collect('memory', getMemoryInfo, { used: 0, total: 0, percentage: 0 }, warnings),
-      collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0, mounts: [] as DiskMount[] }, warnings),
-      collect(
-        'network',
-        () => getNetworkInfo(warnings, sockets),
-        {
-          download: 0,
-          upload: 0,
-          ping: 0,
-          errorRates: { rx: '0.00', tx: '0.00' },
-          connections: 0,
-          listeningPorts: 0,
-          interfaces: [],
-          linkSpeedMbps: null,
-          bandwidthPercentage: 0,
-          totalRxBytes: 0,
-          totalTxBytes: 0
-        },
-        warnings
-      ),
-      collect('temperature', getTemperature, emptyTemperature(), warnings),
-      collect('fan', getFanSpeed, { cpu: 0, case1: 0, case2: 0 }, warnings),
-      collect<Process[]>('processes', getProcesses, [], warnings),
-      collect('uptime', getUptime, { days: 0, hours: 0, minutes: 0 }, warnings),
-      collect(
-        'host',
-        getHostInfo,
-        {
-          hostname: os.hostname(),
-          os: `${os.type()} ${os.release()}`,
-          kernel: os.release(),
-          arch: os.arch(),
-          bootTime: new Date(Date.now() - os.uptime() * 1000).toISOString(),
-          rebootReason: null,
-          virtualization: null
-        },
-        warnings
-      ),
-      collect('swap', getSwapInfo, { used: 0, total: 0, percentage: 0 }, warnings),
-      collect('diskIO', getDiskIo, { read: 0, write: 0 }, warnings),
-      collect(
-        'gpu',
-        getGpuInfo,
-        { name: null, usage: 'N/A' as const, temperature: 'N/A' as const },
-        warnings
-      ),
-      collect<ProcessSummary>(
-        'processSummary',
-        getProcessSummary,
-        { total: 0, running: 0, sleeping: 0, zombie: 0, threads: null },
-        warnings
-      ),
-      collect<Process[]>('processesByMemory', () => getProcessesBy('-pmem'), [], warnings),
-      collect<BatteryInfo | null>('battery', getBatteryInfo, null, warnings)
-    ]);
+    getCpuInfo(warnings),
+    collect('memory', getMemoryInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+    collect('disk', getDiskInfo, { used: 0, total: 0, percentage: 0, mounts: [] as DiskMount[] }, warnings),
+    collect(
+      'network',
+      () => getNetworkInfo(warnings, sockets),
+      {
+        download: 0,
+        upload: 0,
+        ping: 0,
+        errorRates: { rx: '0.00', tx: '0.00' },
+        connections: 0,
+        listeningPorts: 0,
+        interfaces: [],
+        linkSpeedMbps: null,
+        bandwidthPercentage: 0,
+        totalRxBytes: 0,
+        totalTxBytes: 0
+      },
+      warnings
+    ),
+    collect('temperature', getTemperature, emptyTemperature(), warnings),
+    collect('fan', getFanSpeed, { cpu: 0, case1: 0, case2: 0 }, warnings),
+    collect<Process[]>('processes', getProcesses, [], warnings),
+    collect('uptime', getUptime, { days: 0, hours: 0, minutes: 0 }, warnings),
+    collect(
+      'host',
+      getHostInfo,
+      {
+        hostname: os.hostname(),
+        os: `${os.type()} ${os.release()}`,
+        kernel: os.release(),
+        arch: os.arch(),
+        bootTime: new Date(Date.now() - os.uptime() * 1000).toISOString(),
+        rebootReason: null,
+        virtualization: null
+      },
+      warnings
+    ),
+    collect('swap', getSwapInfo, { used: 0, total: 0, percentage: 0 }, warnings),
+    collect('diskIO', getDiskIo, { read: 0, write: 0 }, warnings),
+    collect('gpu', getGpuInfo, { name: null, usage: 'N/A' as const, temperature: 'N/A' as const }, warnings),
+    collect<ProcessSummary>(
+      'processSummary',
+      getProcessSummary,
+      { total: 0, running: 0, sleeping: 0, zombie: 0, threads: null },
+      warnings
+    ),
+    collect<Process[]>('processesByMemory', () => getProcessesBy('-pmem'), [], warnings),
+    collect<BatteryInfo | null>('battery', getBatteryInfo, null, warnings)
+  ]);
 
   const loadBase = await getLoadAverage();
   const security = await getSecurityInfo(sockets.peers, warnings);

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -509,7 +509,8 @@ export async function getSystemInfo(): Promise<ServerData> {
       swap: swap.percentage,
       temperature: cpu.temperature,
       firewall: security.firewall.status,
-      sshSessions: security.sshSessions
+      sshSessions: security.sshSessions,
+      interfaces: network.interfaces.map(({ name, state }) => ({ name, state }))
     },
     now
   );

--- a/src/utils/systemStream.ts
+++ b/src/utils/systemStream.ts
@@ -1,5 +1,6 @@
 import { ServerData } from '@/types/system';
 import { getSystemInfo } from '@/utils/systemMonitor';
+import { logger } from '@/utils/logger';
 
 // 요청마다 수집기를 돌리는 대신, 프로세스 안에서 딱 하나의 루프만 돌린다.
 // 접속자가 몇 명이든 쉘 프로세스 spawn(sensors/ping/ps/df ...)은 한 번으로
@@ -52,14 +53,14 @@ async function tick(): Promise<void> {
       try {
         listener(data);
       } catch (error) {
-        console.error('SSE listener threw:', error);
+        logger.error('SSE listener threw:', error);
       }
     }
   } catch (error) {
     // 수집 자체가 실패해도 루프는 살려둔다. 이번 틱만 건너뛰고,
     // 구독자는 마지막으로 받은 값을 그대로 들고 있는다.
     consecutiveFailures += 1;
-    console.error('system collection loop failed:', error);
+    logger.error('system collection loop failed:', error);
   }
 }
 
@@ -97,7 +98,7 @@ export function subscribe(listener: Listener): () => void {
     try {
       listener(lastData);
     } catch (error) {
-      console.error('SSE listener threw on initial push:', error);
+      logger.error('SSE listener threw on initial push:', error);
     }
   }
 

--- a/src/utils/systemStream.ts
+++ b/src/utils/systemStream.ts
@@ -20,10 +20,33 @@ let running = false;
 let handle: ReturnType<typeof setTimeout> | null = null;
 let lastData: ServerData | null = null;
 
+// 수집 루프 자체의 건강 상태. /api/health 가 읽어, 루프가 멈췄거나 계속 실패하는
+// 상황을 스케줄러/모니터가 감지할 수 있게 한다.
+let lastTickAt = 0;
+let consecutiveFailures = 0;
+
+export interface LoopHealth {
+  running: boolean;
+  subscribers: number;
+  lastTickAgeMs: number | null;
+  consecutiveFailures: number;
+}
+
+export function getLoopHealth(): LoopHealth {
+  return {
+    running,
+    subscribers: listeners.size,
+    lastTickAgeMs: lastTickAt === 0 ? null : Date.now() - lastTickAt,
+    consecutiveFailures
+  };
+}
+
 async function tick(): Promise<void> {
   try {
     const data = await getSystemInfo();
     lastData = data;
+    lastTickAt = Date.now();
+    consecutiveFailures = 0;
     for (const listener of listeners) {
       // 한 구독자의 예외가 다른 구독자에게 번지지 않게 격리한다.
       try {
@@ -35,6 +58,7 @@ async function tick(): Promise<void> {
   } catch (error) {
     // 수집 자체가 실패해도 루프는 살려둔다. 이번 틱만 건너뛰고,
     // 구독자는 마지막으로 받은 값을 그대로 들고 있는다.
+    consecutiveFailures += 1;
     console.error('system collection loop failed:', error);
   }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,24 +1,24 @@
 import { ServerData } from '@/types/system';
 
 export function isValidServerData(data: unknown): data is ServerData {
-    if (!data || typeof data !== 'object') return false;
-    const d = data as Record<string, unknown>;
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
 
-    return (
-        d.cpu !== null &&
-        typeof d.cpu === 'object' &&
-        d.memory !== null &&
-        typeof d.memory === 'object' &&
-        d.disk !== null &&
-        typeof d.disk === 'object' &&
-        d.network !== null &&
-        typeof d.network === 'object' &&
-        d.uptime !== null &&
-        typeof d.uptime === 'object' &&
-        d.temperature !== null &&
-        typeof d.temperature === 'object' &&
-        d.fan !== null &&
-        typeof d.fan === 'object' &&
-        Array.isArray(d.processes)
-    );
-} 
+  return (
+    d.cpu !== null &&
+    typeof d.cpu === 'object' &&
+    d.memory !== null &&
+    typeof d.memory === 'object' &&
+    d.disk !== null &&
+    typeof d.disk === 'object' &&
+    d.network !== null &&
+    typeof d.network === 'object' &&
+    d.uptime !== null &&
+    typeof d.uptime === 'object' &&
+    d.temperature !== null &&
+    typeof d.temperature === 'object' &&
+    d.fan !== null &&
+    typeof d.fan === 'object' &&
+    Array.isArray(d.processes)
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,22 +19,10 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@public": [
-        "./public/*"
-      ]
+      "@/*": ["./src/*"],
+      "@public": ["./public/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
A whole-project scan turned up mostly **feature gaps** rather than bugs (the codebase is already mature). This PR closes them across alerting, deployment, the cluster view, metrics, API, UX/a11y, and tooling. Every new `ServerData` field is optional for backward compatibility with older cluster nodes, and every new metric degrades to `N/A`/null when its source is missing.

## What's in it

### Alerting
- **Outbound notifications** (`notify.ts`): POST each alert transition to `ALERT_WEBHOOK_URL` (`json`/`slack`/`discord` formats), with timeout and swallowed failures.
- **On-disk alert log** (`data/alerts.json`) so alerts survive a restart, mirroring `history.ts`.
- **Configurable thresholds** via env (`ALERT_CPU_ENTER/_CLEAR`, etc.), plus optional re-notify (`ALERT_RENOTIFY_MINUTES`) and interface up/down alerts.
- First-evaluation suppression so pre-existing breaches aren't replayed as fresh events.

### Deployment
- **Dockerfile** (multistage, standalone output, non-root, installs the host tools the collectors need), **docker-compose.yml** (`pid:host` + `/sys` mount + `./data` volume), **.dockerignore**.
- **GitHub Actions CI**: prettier → lint → typecheck → tests on push/PR.

### Cluster view
- **`/api/cluster`**: the dashboard server fans out to each node's `/api/system` instead of the browser doing it. Node IPs stay server-side, nodes no longer need per-node CORS, and one same-origin fetch replaces N cross-origin ones.

### New endpoints & metrics
- **`/api/health`**: lightweight liveness probe exposing collection-loop self-health, outside the token gate.
- **`/api/metrics`**: Prometheus exporter (non-sensitive numeric metrics only) — lets Grafana/Prometheus scrape the fleet.
- **New collectors**: multi-filesystem disk usage, CPU iowait%/steal%/current clock, cumulative network totals, process/zombie/thread counts, memory-sorted top processes, virtualization detection, battery/UPS, and a disk fill-rate forecast (hours-to-full).

### API / performance
- gzip for large JSON responses (`/api/system`, `/api/cluster`); SSE left uncompressed.
- SSE `id:`/`retry:` hints for cleaner reconnection.
- Leveled `LOG_LEVEL` logger replacing scattered `console.*`.

### UX / accessibility
- Header shows a "N degraded" badge (from the API `warnings` array), amber staleness when the last sample is >5s old, and virtualization on the host line.
- Gauge tooltips now include CPU clock/iowait/steal and per-mount disk usage + fill forecast; network legend shows cumulative totals; TOP PROCESSES shows total/zombie counts; UPTIME shows battery when present.
- `role="img"` + `aria-label` on the gauge/sparkline SVGs.
- Tab cue: `⚠` title prefix + red favicon while a condition is in alert.

### Tooling / docs
- Adopt **Prettier** (config matches the existing style; also unifies the two 4-space files), add `typecheck`/`format` scripts.
- Standardize display locale to `en-US` (English-only project).
- Add **LICENSE** (MIT — please adjust the holder/license if you prefer something else), **SECURITY.md**, **CONTRIBUTING.md**, **Dependabot**; fix the stale "load (12h)" note in `.env.example` (it's 48h).

## Verification
- `npm run format:check && npm run lint && npm run typecheck && npm test` (51 tests) — all pass.
- `npm run build` — standalone output builds with all new routes.
- Smoke-tested the built server on this Linux host: `/api/health`, `/api/metrics`, `/api/cluster` respond; `/api/system` returns `disks[]`, `processSummary` (correctly caught zombies + thread count), `virtualization:"docker"`, and gzip is applied when the client accepts it.

## Notes for the reviewer
- The `style: adopt Prettier` commit is a pure formatting pass — reviewing the other commits individually is easier.
- Deferred by design: the **React 19 upgrade** (Next 16 + React 18.3) is left out as a separate follow-up because of regression risk — Dependabot will surface it.
- The MIT LICENSE uses `Ruthgyeul` as the copyright holder; change it if that's not what you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014NW1o5A9egFuvNfEAqtqht)_