### PR TITLE
Finish 20-list UI items + translate the whole codebase to English

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
 
-# ServerMonitor 멀티스테이지 이미지. 런타임에는 next standalone 출력만 담아
-# 이미지를 작게 유지한다. 지표 수집이 읽는 sensors/ping/ps/df/last/who 등은
-# 호스트의 바이너리와 /proc·/sys 를 쓰므로 이미지에 넣지 않는다 —
-# docker-compose.yml 의 마운트/네임스페이스 설정을 참고하라.
+# ServerMonitor multistage image. The runtime holds only the Next standalone
+# output to keep the image small. The sensors/ping/ps/df/last/who tools that
+# metric collection reads use the host's binaries and /proc, /sys, so they are
+# not baked into the image — see docker-compose.yml's mount/namespace settings.
 
 FROM node:20-alpine AS deps
 WORKDIR /app
-# 락파일 기준 재현 가능한 설치. package*.json 만 먼저 복사해 레이어 캐시를 살린다.
+# Reproducible install from the lockfile. Copy package*.json first to keep the layer cache.
 COPY package.json package-lock.json ./
 RUN npm ci
 
@@ -16,8 +16,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
-# NEXT_PUBLIC_* 는 빌드 시 번들에 인라인된다. 클러스터/사이트 메타데이터를 바꾸려면
-# --build-arg 로 넘기거나, 배포 후 런타임 값만 쓰는 서버 전용 변수를 사용하라.
+# NEXT_PUBLIC_* is inlined into the bundle at build time. To change cluster/site
+# metadata, pass it via --build-arg, or use server-only variables read at runtime after deploy.
 RUN npm run build
 
 FROM node:20-alpine AS runner
@@ -27,27 +27,27 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
-# 지표 수집기가 shell out 하는 호스트 도구를 넣는다. busybox 의 ps 는
-# `-eo ... --sort` 를 지원하지 않으므로 GNU procps 가 필요하다. sensors/ping 도
-# 마찬가지다. journalctl/systemctl/who/last(systemd·utmp)는 컨테이너에서 얻기
-# 어렵지만, 수집기가 이미 N/A 로 우아하게 degrade 하므로 넣지 않는다.
-# pid:host + /proc·/sys 마운트(docker-compose.yml)와 함께 써야 호스트를 읽는다.
+# Install the host tools the metric collectors shell out to. busybox's ps
+# doesn't support `-eo ... --sort`, so GNU procps is needed; the same goes for
+# sensors/ping. journalctl/systemctl/who/last (systemd/utmp) are hard to get in
+# a container, but the collectors already degrade gracefully to N/A, so they're
+# not included. Must be used with pid:host + the /proc, /sys mounts (docker-compose.yml) to read the host.
 RUN apk add --no-cache procps lm-sensors iputils
 
-# 루트로 실행하지 않는다. standalone 서버 구동에 필요한 파일만 복사한다.
+# Don't run as root. Copy only the files needed to run the standalone server.
 RUN addgroup -g 1001 -S nodejs && adduser -u 1001 -S nextjs -G nodejs
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# 히스토리/알림 영속화 위치(gitignored data/). 볼륨으로 마운트해 재시작에도 유지.
+# The history/alert persistence location (gitignored data/). Mount as a volume to survive restarts.
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
 VOLUME /app/data
 
 USER nextjs
 EXPOSE 3000
 
-# 무거운 /api/system 이 아니라 경량 /api/health 로 헬스체크한다.
+# Health-check via the lightweight /api/health rather than the heavy /api/system.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
-// eslint-config-next 16 은 플랫 config 를 그대로 내보낸다. FlatCompat 로 감싸면
-// 설정 객체에 순환 참조가 생겨 검증 단계에서 터지므로, 직접 펼쳐 쓴다.
+// eslint-config-next 16 exports a flat config directly. Wrapping it in FlatCompat
+// creates a circular reference in the config object that blows up at the validation step, so spread it directly.
 import coreWebVitals from 'eslint-config-next/core-web-vitals';
 import typescript from 'eslint-config-next/typescript';
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,13 @@
 import type { NextConfig } from 'next';
 
-// 보안 응답 헤더. 대시보드는 임베드될 이유가 없으므로 클릭재킹을 원천 차단하고,
-// MIME 스니핑/플러그인 주입/base 태그 하이재킹을 막는다.
+// Security response headers. The dashboard has no reason to be embedded, so
+// clickjacking is blocked outright, along with MIME sniffing / plugin injection / base-tag hijacking.
 //
-// CSP 는 script/style/connect 를 제약하지 않는 최소 구성이다. 그 세 가지를
-// 좁히면 Next 의 인라인 부트스트랩, Tailwind/Recharts 의 인라인 스타일,
-// /cluster 의 교차-노드 fetch 가 깨지기 쉬워, 여기서는 확실히 안전한
-// frame-ancestors/object-src/base-uri 만 강제한다. 더 엄격한 CSP 가 필요하면
-// 배포 환경에 맞춰 script-src/connect-src 를 추가하라(README 참고).
+// The CSP is a minimal setup that doesn't restrict script/style/connect.
+// Narrowing those three easily breaks Next's inline bootstrap, the inline
+// styles of Tailwind/Recharts, and /cluster's cross-node fetch, so here we only
+// enforce the definitely-safe frame-ancestors/object-src/base-uri. If a
+// stricter CSP is needed, add script-src/connect-src to match the deployment (see README).
 const securityHeaders = [
   {
     key: 'Content-Security-Policy',
@@ -16,12 +16,12 @@ const securityHeaders = [
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-  // 이 대시보드는 카메라/마이크/위치정보 등을 쓰지 않는다. 전부 끈다.
+  // This dashboard uses no camera/microphone/geolocation, etc. Turn them all off.
   {
     key: 'Permissions-Policy',
     value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()'
   },
-  // HTTPS 응답에서만 브라우저가 적용한다. HTTP 로 서빙 중이면 무시되므로 안전.
+  // Browsers apply this only on HTTPS responses. It's ignored when served over HTTP, so it's safe.
   {
     key: 'Strict-Transport-Security',
     value: 'max-age=31536000; includeSubDomains'
@@ -29,8 +29,8 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  poweredByHeader: false, // "X-Powered-By: Next.js" 로 스택/버전을 광고하지 않는다
-  // Docker 이미지를 최소화한다: 서버 실행에 필요한 파일만 .next/standalone 로 추린다.
+  poweredByHeader: false, // don't advertise the stack/version via "X-Powered-By: Next.js"
+  // Minimize the Docker image: only the files needed to run the server are pruned into .next/standalone.
   output: 'standalone',
   async headers() {
     return [

--- a/src/app/api/cluster/route.ts
+++ b/src/app/api/cluster/route.ts
@@ -2,17 +2,18 @@ import { ServerData } from '@/types/system';
 import { ClusterServer, getClusterHost, getClusterServers, getClusterUrl } from '@/config/clusterConfig';
 import { jsonResponse } from '@/utils/http';
 
-// 클러스터 뷰는 지금까지 브라우저에서 각 노드의 /api/system 을 직접 폴링했다.
-// 그래서 (a) 모든 노드가 대시보드 오리진을 CORS 로 허용해야 하고, (b) 노드 IP 가
-// 클라이언트 번들에 그대로 노출되며, (c) 뷰어 수만큼 노드 부하가 중복됐다.
+// Until now the cluster view polled each node's /api/system directly from the
+// browser. That meant (a) every node had to CORS-allow the dashboard origin,
+// (b) node IPs were exposed in the client bundle, and (c) node load was
+// duplicated per viewer.
 //
-// 이 라우트가 서버측에서 노드들을 대신 폴링해 압축 결과만 돌려준다. 브라우저는
-// 같은 오리진 한 곳만 부르면 되고, 노드 IP 는 서버에만 남는다.
+// This route polls the nodes server-side instead and returns a compact result.
+// The browser calls one same-origin endpoint, and node IPs stay server-side.
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-// 응답 없는 노드가 집계 전체를 붙잡지 않도록 노드별로 끊는다.
+// Cap each node so an unresponsive one doesn't hold up the whole aggregation.
 const FETCH_TIMEOUT_MS = 5000;
 
 type NodeResult = { ok: true; data: ServerData } | { ok: false; error: string };
@@ -29,8 +30,8 @@ async function fetchNode(server: ClusterServer): Promise<ClusterNode> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  // 노드에 API_AUTH_TOKEN 게이트가 켜져 있으면 서버가 대신 토큰을 실어 준다
-  // (브라우저는 실을 수 없던 값). 미설정이면 헤더를 붙이지 않는다.
+  // If a node has the API_AUTH_TOKEN gate enabled, the server attaches the
+  // token on its behalf (something the browser couldn't do). If unset, no header is added.
   const headers: Record<string, string> = {};
   if (process.env.API_AUTH_TOKEN) headers.Authorization = `Bearer ${process.env.API_AUTH_TOKEN}`;
 
@@ -62,7 +63,7 @@ export async function GET(request: Request) {
   const servers = getClusterServers();
   const nodes = await Promise.all(servers.map(fetchNode));
 
-  // 노드 전체 데이터를 모은 큰 페이로드라 gzip 을 받으면 압축해 보낸다.
+  // Large payload aggregating every node's data, so compress it when gzip is accepted.
   return jsonResponse(
     request,
     { nodes, timestamp: new Date().toISOString() },

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -3,12 +3,13 @@ import { NextResponse } from 'next/server';
 
 import { getLoopHealth } from '@/utils/systemStream';
 
-// 가벼운 헬스체크. /api/system 은 SSH IP·프로세스 목록 같은 무거운 정찰 정보를
-// 전부 수집하므로 컨테이너 orchestration/uptime 프로브에는 과하다. 이 라우트는
-// 수집을 트리거하지 않고 프로세스 생존과 수집 루프의 건강만 즉시 돌려준다.
+// Lightweight health check. /api/system collects heavy reconnaissance (SSH
+// IPs, the process list, ...), which is overkill for a container
+// orchestration/uptime probe. This route triggers no collection and returns
+// process liveness and the collection loop's health immediately.
 //
-// proxy.ts 의 토큰 게이트는 /api/system* 만 매칭하므로 이 경로는 게이트 밖 —
-// 오케스트레이터가 토큰 없이 프로브할 수 있다. 민감 정보는 노출하지 않는다.
+// proxy.ts's token gate only matches /api/system*, so this path is outside it
+// — an orchestrator can probe it without a token. It exposes no sensitive data.
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -16,8 +17,8 @@ export const dynamic = 'force-dynamic';
 export function GET() {
   const loop = getLoopHealth();
 
-  // 루프가 돌고 있는데도 마지막 틱이 너무 오래됐거나 연속 실패가 쌓이면
-  // degraded 로 보고한다(HTTP 는 여전히 200 — 프로브가 프로세스를 죽이지 않도록).
+  // If the loop is running but the last tick is too old, or failures are
+  // piling up, report degraded (HTTP stays 200 so a probe doesn't kill the process).
   const stalled = loop.running && loop.lastTickAgeMs !== null && loop.lastTickAgeMs > 60_000;
   const failing = loop.consecutiveFailures >= 5;
   const status = stalled || failing ? 'degraded' : 'ok';

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,12 +1,13 @@
 import { getSystemInfo } from '@/utils/systemMonitor';
 import { isX86TemperatureInfo } from '@/types/system';
 
-// Prometheus 스크레이프 엔드포인트. 모니터링 도구인데 표준 노출 포맷이 없어
-// Grafana/Prometheus 로 장기 저장·경보를 위임할 수 없었다. getSystemInfo() 는
-// 이미 1초 캐시라 스크레이프가 추가 수집을 유발하지 않는다.
+// Prometheus scrape endpoint. This is a monitoring tool with no standard
+// exposition format, so long-term storage/alerting could not be delegated to
+// Grafana/Prometheus. getSystemInfo() is already cached for 1s, so a scrape
+// triggers no extra collection.
 //
-// 중요: SSH 접속 IP·프로세스명·트래픽 피어 같은 민감 정보는 내보내지 않고,
-// 수치 지표만 노출한다. (/api/system 과 달리 정찰용으로 쓸 수 없다.)
+// Important: sensitive data (SSH source IPs, process names, traffic peers) is
+// never emitted — only numeric metrics. Unlike /api/system it can't be used for recon.
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -55,7 +56,7 @@ export async function GET() {
   g('server_memory_total_mb', 'Total memory in MB.', data.memory.total);
   g('server_memory_percent', 'Memory usage percentage.', data.memory.percentage);
 
-  // 루트 파일시스템. 다중 디스크(disks[])가 있으면 마운트별로도 노출한다.
+  // Root filesystem. If multiple disks (disks[]) are present, expose them per-mount too.
   g('server_disk_percent', 'Disk usage percentage.', data.disk.percentage, { mount: '/' });
   g('server_disk_used_gb', 'Used disk in GB.', data.disk.used, { mount: '/' });
   g('server_disk_total_gb', 'Total disk in GB.', data.disk.total, { mount: '/' });
@@ -109,7 +110,7 @@ export async function GET() {
     .map(key => line('server_fan_rpm', data.fan[key], { fan: key }));
   metric('server_fan_rpm', 'Fan speed in RPM.', 'gauge', fanRows);
 
-  // 마더보드/기타 온도(수치인 것만).
+  // Motherboard / other temperatures (numeric ones only).
   if (isX86TemperatureInfo(data.temperature)) {
     g('server_gpu_edge_temperature_celsius', 'GPU edge temperature.', data.temperature.gpu);
     g('server_motherboard_temperature_celsius', 'Motherboard temperature.', data.temperature.motherboard);
@@ -132,7 +133,7 @@ export async function GET() {
     line('server_active_alerts', activeAlerts)
   ]);
 
-  // Prometheus 텍스트 노출 포맷은 마지막 줄에 개행이 있어야 한다.
+  // The Prometheus text exposition format requires a trailing newline.
   const body = out.join('\n') + '\n';
   return new Response(body, {
     headers: {

--- a/src/app/api/system/route.ts
+++ b/src/app/api/system/route.ts
@@ -5,12 +5,13 @@ import { isValidServerData } from '@/utils/validation';
 import { logger } from '@/utils/logger';
 import { jsonResponse } from '@/utils/http';
 
-// 수집기별 실패는 systemMonitor 안에서 각자 fallback 으로 처리되므로,
-// 여기까지 올라온 에러는 진짜 고장이다. 0으로 채운 정상 응답을 돌려주면
-// 대시보드에 "모든 값이 0" 으로만 보이고 원인이 감춰지므로 5xx 로 알린다.
+// Per-collector failures are each handled with a fallback inside systemMonitor,
+// so an error that reaches here is a real fault. Returning a zero-filled "ok"
+// response would just show "everything is 0" on the dashboard and hide the
+// cause, so we surface it as a 5xx instead.
 
 function getCorsHeaders(origin: string | undefined) {
-  // 이 라우트는 GET/OPTIONS 만 구현한다. 쓰지도 않는 메서드/헤더를 광고하지 않는다.
+  // This route only implements GET/OPTIONS. Don't advertise methods/headers it doesn't use.
   return corsHeaders(origin, {
     'Access-Control-Allow-Methods': 'GET, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
@@ -24,7 +25,7 @@ export async function GET(request: Request) {
   try {
     const data = await getSystemInfo();
 
-    // 데이터 유효성 검사
+    // Validate the data
     if (!data || !isValidServerData(data)) {
       logger.error('Invalid server data received');
       return new NextResponse(JSON.stringify({ error: 'Invalid server data received' }), {
@@ -33,11 +34,11 @@ export async function GET(request: Request) {
       });
     }
 
-    // 큰 JSON(history + processes)이라 클라이언트가 gzip 을 받으면 압축해 보낸다.
+    // Large JSON (history + processes), so compress it when the client accepts gzip.
     return jsonResponse(request, data, { headers: getCorsHeaders(origin) });
   } catch (error) {
-    // 원인(파일 경로/명령 실패 메시지 등)은 서버 로그에만 남기고, 클라이언트에는
-    // 내부 구조를 드러내지 않는 일반 메시지만 돌려준다.
+    // Keep the cause (file paths / command failure messages) in the server log
+    // only, and return the client a generic message that reveals no internals.
     logger.error('Error fetching system data:', error);
     return new NextResponse(JSON.stringify({ error: 'Failed to collect system data' }), {
       status: 500,
@@ -46,7 +47,7 @@ export async function GET(request: Request) {
   }
 }
 
-// OPTIONS 메서드 핸들링 (CORS preflight 요청 처리)
+// OPTIONS handling (CORS preflight)
 export function OPTIONS(request: Request) {
   const origin = request.headers.get('origin') || undefined;
   return new NextResponse(null, { headers: getCorsHeaders(origin) });

--- a/src/app/api/system/stream/route.ts
+++ b/src/app/api/system/stream/route.ts
@@ -2,15 +2,15 @@ import { ServerData } from '@/types/system';
 import { corsHeaders } from '@/utils/cors';
 import { subscribe } from '@/utils/systemStream';
 
-// 이 라우트는 연결을 열어둔 채 서버가 데이터를 밀어주는 SSE 스트림이다.
-// 폴링과 달리 클라이언트당 연결 1개만 유지되고, 실제 수집은 systemStream 의
-// 단일 루프가 담당한다(초당 1회 고정).
+// This route is an SSE stream: the server holds the connection open and pushes
+// data. Unlike polling, only one connection per client is kept, and the actual
+// collection is handled by systemStream's single loop (fixed at once per second).
 
-// 장기 연결 + Node 전용 수집(fs/os/child_process)이므로 정적 최적화를 끈다.
+// Long-lived connection + Node-only collection (fs/os/child_process), so disable static optimization.
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-// 유휴 연결이 프록시/방화벽에 끊기지 않도록 주기적으로 보내는 keep-alive.
+// Periodic keep-alive so idle connections aren't dropped by a proxy/firewall.
 const KEEPALIVE_MS = 15000;
 
 export async function GET(request: Request) {
@@ -26,13 +26,14 @@ export async function GET(request: Request) {
         try {
           controller.enqueue(encoder.encode(chunk));
         } catch {
-          // 컨트롤러가 이미 닫힘(클라이언트 종료). 정리는 abort/cancel 이 맡는다.
+          // Controller already closed (client left). abort/cancel handle cleanup.
         }
       };
 
-      // 각 이벤트에 id 를 달고, 연결 시작에 재연결 지연(retry) 힌트를 준다.
-      // id 는 EventSource 가 재연결 시 Last-Event-ID 로 되돌려 보내며, retry 는
-      // 브라우저 기본 재연결 간격을 명시해 끊겼을 때 복구 동작을 예측 가능하게 한다.
+      // Attach an id to each event and give a reconnect-delay (retry) hint at
+      // the start. EventSource sends the id back as Last-Event-ID on reconnect,
+      // and retry sets the browser's default reconnect interval so recovery
+      // after a drop is predictable.
       const send = (data: ServerData) => {
         const id = data.timestamp ?? new Date().toISOString();
         push(`id: ${id}\ndata: ${JSON.stringify(data)}\n\n`);
@@ -41,7 +42,7 @@ export async function GET(request: Request) {
       push('retry: 3000\n\n');
       unsubscribe = subscribe(send);
 
-      // ": " 로 시작하는 줄은 SSE 코멘트라 클라이언트가 무시한다. 연결 유지용.
+      // A line starting with ": " is an SSE comment the client ignores. Used to keep the connection alive.
       keepAlive = setInterval(() => push(': ping\n\n'), KEEPALIVE_MS);
 
       const cleanup = () => {
@@ -53,7 +54,7 @@ export async function GET(request: Request) {
         try {
           controller.close();
         } catch {
-          // 이미 닫힌 경우 무시.
+          // Ignore if already closed.
         }
       };
 
@@ -72,7 +73,7 @@ export async function GET(request: Request) {
     'Content-Type': 'text/event-stream; charset=utf-8',
     'Cache-Control': 'no-cache, no-transform',
     Connection: 'keep-alive',
-    // nginx 리버스 프록시가 응답을 버퍼링해 실시간성이 깨지는 것을 막는다.
+    // Stops an nginx reverse proxy from buffering the response and breaking real-time delivery.
     'X-Accel-Buffering': 'no'
   });
 

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -22,20 +22,21 @@ import { NetworkHistoryEntry, ServerData } from '@/types/system';
 import { formatClock, formatRate } from '@/utils/format';
 import { COLORS, statusColor, tempColor } from '@/utils/statusColors';
 
-// 이 페이지는 메인 대시보드(src/app/page.tsx)와 같은 터미널 디자인을 그대로 쓰되,
-// 한 호스트가 아니라 클러스터의 여러 노드를 한 화면에 나란히 띄운다. 예전에는
-// 브라우저가 각 노드의 /api/system 을 직접 폴링했지만, 이제 같은 오리진의
-// /api/cluster 가 서버측에서 노드들을 대신 모아 압축 결과만 내려준다 — 노드 IP 는
-// 클라이언트에 노출되지 않고, 노드마다 CORS 를 열 필요도 없다.
+// This page uses the same terminal design as the main dashboard
+// (src/app/page.tsx) but lays out several cluster nodes side by side instead of
+// one host. It used to poll each node's /api/system directly from the browser;
+// now the same-origin /api/cluster aggregates the nodes server-side and returns
+// only a compact result — node IPs aren't exposed to the client, and there's no
+// need to open CORS per node.
 
-// 매초 갱신한다 — 메인 대시보드의 폴링 주기와 같다.
+// Refresh every second — the same polling cadence as the main dashboard.
 const POLL_INTERVAL_MS = 1000;
-// 스파크라인이 덮는 구간. 노드 하나당 최근 30초.
+// The span the sparkline covers. The last 30 seconds per node.
 const MAX_NETWORK_POINTS = 30;
 
 type NodeResult = { ok: true; data: ServerData } | { ok: false; error: string };
 
-// /api/cluster 가 노드당 내려주는 형태. IP 는 없고 표시용 host 라벨만 있다.
+// The per-node shape /api/cluster returns. No IP, only a display host label.
 interface ClusterNode {
   name: string;
   host: string;
@@ -44,7 +45,7 @@ interface ClusterNode {
 }
 
 export default function ClusterPage() {
-  // null = 아직 첫 응답 전(연결 중), [] = 서버가 노드 없음이라고 확인해 준 상태.
+  // null = before the first response (connecting), [] = the server confirmed there are no nodes.
   const [nodes, setNodes] = useState<ClusterNode[] | null>(null);
   const [networkHistory, setNetworkHistory] = useState<Record<string, NetworkHistoryEntry[]>>({});
   const now = useNow();
@@ -58,13 +59,14 @@ export default function ClusterPage() {
         received = payload.nodes ?? [];
       }
     } catch {
-      // 집계 엔드포인트에 못 닿으면 마지막 값을 유지한다(화면을 비우지 않는다).
+      // If the aggregation endpoint is unreachable, keep the last value (don't blank the screen).
       return;
     }
     setNodes(received);
 
-    // 스파크라인에 쓸 순간 처리량을 노드별 히스토리에 이어 붙인다. 넣을 때 잘라
-    // 두므로 별도 정리 타이머가 필요 없다. IP 가 없어 이름을 키로 쓴다.
+    // Append the instantaneous throughput for the sparkline to each node's
+    // history. Trimming on insert means no separate cleanup timer is needed.
+    // There's no IP, so the name is used as the key.
     const time = new Date().toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
@@ -121,9 +123,9 @@ export default function ClusterPage() {
   );
 }
 
-// --- 상단 크롬 / 헤더 ------------------------------------------------------
+// --- Top chrome / header ---------------------------------------------------
 
-// 메인 대시보드와 똑같은 터미널 창 크롬. 경로만 클러스터 쪽으로 바꾼다.
+// The same terminal-window chrome as the main dashboard. Only the path changes to the cluster one.
 const TerminalTitleBar: React.FC = () => (
   <div className="term-titlebar">
     <div className="flex shrink-0 items-center gap-[7px]">
@@ -158,7 +160,7 @@ const ClusterHeader: React.FC<ClusterHeaderProps> = ({ online, total, now }) => 
         <div className="h-[7px] w-[7px] shrink-0 animate-[pulseDot_2s_ease-in-out_infinite] rounded-full bg-green-400" />
       </div>
 
-      {/* 마운트 전에는 시각을 그리지 않는다(하이드레이션 불일치 방지). */}
+      {/* Don't render the time before mount (avoids a hydration mismatch). */}
       <span className="t-body order-1 whitespace-nowrap font-mono text-gray-300 md:order-3">
         {now === null ? ' ' : formatClock(new Date(now))}
       </span>
@@ -192,7 +194,7 @@ const EmptyCluster: React.FC = () => (
   </div>
 );
 
-// --- 노드 카드 -------------------------------------------------------------
+// --- Node card -------------------------------------------------------------
 
 interface ServerCardProps {
   node: ClusterNode;
@@ -202,8 +204,8 @@ interface ServerCardProps {
 const ServerCard: React.FC<ServerCardProps> = ({ node, history }) => {
   const { result } = node;
 
-  // 연결 실패면 그 이유를 보여 준다. 메인 대시보드가 마지막 값을 유지하듯 여기도
-  // 프레임은 늘 그린다.
+  // On a connection failure, show the reason. Like the main dashboard keeping
+  // its last value, the frame is always drawn here too.
   if (!result.ok) {
     return (
       <ServerShell name={node.name} host={node.host} status="offline">
@@ -215,9 +217,9 @@ const ServerCard: React.FC<ServerCardProps> = ({ node, history }) => {
   const { cpu, memory, disk, network, uptime, fan } = result.data;
   const toGb = (mb: number) => (mb / 1024).toFixed(1);
 
-  // 팬은 값이 잡히는 첫 커넥터를 쓴다(메인보드마다 위치가 다르다).
+  // For fan, use the first connector that has a value (the position varies by motherboard).
   const rpm = [fan.cpu, fan.case1, fan.case2].find(value => value > 0) ?? 0;
-  // cpu.temperature 는 아키텍처와 무관하게 채워지는 대표 CPU 온도다.
+  // cpu.temperature is the representative CPU temperature, filled regardless of architecture.
   const temperature = cpu.temperature;
   const topProcess = result.data.processes.find(process => process.cpu > 0 || process.memory > 0);
 
@@ -291,7 +293,7 @@ const STATUS_COLOR: Record<ServerStatus, string> = {
   connecting: '#8b93a7'
 };
 
-// 노드 카드의 공통 껍데기 — 메인 대시보드의 Card 와 같은 결(보더/배경/헤더)이다.
+// The shared shell of a node card — the same look (border/background/header) as the main dashboard's Card.
 const ServerShell: React.FC<{
   name: string;
   host: string;
@@ -320,7 +322,7 @@ const ServerShell: React.FC<{
   </section>
 );
 
-// --- 카드 안 조각 ----------------------------------------------------------
+// --- Pieces inside the card ------------------------------------------------
 
 interface MiniGaugeProps {
   icon: LucideIcon;
@@ -330,7 +332,7 @@ interface MiniGaugeProps {
   caption: string;
 }
 
-// 메인 대시보드 GaugeRow 의 게이지 타일을, 카드 안에 3개 나란히 넣도록 압축한 판.
+// A compact version of the main dashboard's GaugeRow gauge tile, to fit three side by side in a card.
 const MiniGauge: React.FC<MiniGaugeProps> = ({ icon: Icon, iconColor, label, percentage, caption }) => {
   const color = statusColor(percentage);
 
@@ -362,7 +364,7 @@ const InfoItem: React.FC<{ icon: LucideIcon; color: string; value: string }> = (
   </span>
 );
 
-// --- 표기 헬퍼 -------------------------------------------------------------
+// --- Formatting helpers ----------------------------------------------------
 
 function formatUptime(uptime: ServerData['uptime']): string {
   const { days, hours, minutes } = uptime;
@@ -371,8 +373,8 @@ function formatUptime(uptime: ServerData['uptime']): string {
   return `${minutes}m`;
 }
 
-// `comm` 은 대개 실행 파일명뿐이지만, 경로/인자가 섞여 들어오는 노드도 있어 첫 토큰의
-// 파일명만 남긴다. 좁은 칸에 이름이 넘치지 않게 하기 위한 표기용 정리다.
+// `comm` is usually just the executable name, but some nodes mix in a
+// path/args, so keep only the basename of the first token. A display-only tidy-up to keep the name from overflowing a narrow cell.
 function shortProcessName(name: string): string {
   return name.split(' ')[0].split('/').pop() ?? name;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,8 +19,8 @@ const geistMono = Geist_Mono({
   subsets: ['latin']
 });
 
-// 모바일에서 CSS 픽셀이 기기 폭을 따라가야 반응형 레이아웃이 의도대로 접힌다.
-// 사용자가 핀치/더블탭으로 화면을 확대·축소하지 못하도록 배율을 1로 고정한다.
+// On mobile, CSS pixels must follow the device width for the responsive layout
+// to fold as intended. The scale is pinned to 1 so users can't pinch/double-tap to zoom.
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -81,7 +81,7 @@ export const metadata: Metadata = {
     creator: AUTHOR_NAME
   },
   verification: {
-    // Google Search Console 등에 사용되는 확인 코드가 있다면 추가
+    // Add a verification code here if one is used (e.g. Google Search Console)
     // google: "VERIFICATION_CODE",
   },
   alternates: {
@@ -100,7 +100,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* theme-color 는 위의 viewport export 가 넣어준다. */}
+        {/* theme-color is injected by the viewport export above. */}
         <link rel="manifest" href="/manifest.json" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="mobile-web-app-status-bar-style" content="default" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,9 @@ import { useNow } from '@/hooks/useNow';
 import { useSystemData } from '@/hooks/useSystemData';
 import type { DashboardData } from '@/utils/dashboardData';
 
-// 탭만 봐도 경보를 알 수 있도록, 지금 당장 문제가 있으면 문서 제목에 ⚠ 를 붙이고
-// 파비콘을 빨간 점으로 바꾼다. 벽에 여러 탭을 띄워 두는 운용에서 유용하다.
+// So an alert is visible from the tab alone: when there's a current problem,
+// prefix the document title with ⚠ and turn the favicon into a red dot. Useful
+// when several tabs are left open on a wall.
 const BASE_TITLE = 'Server Monitor';
 const ALERT_FAVICON =
   'data:image/svg+xml,' +
@@ -38,14 +39,14 @@ export default function DisplayPage() {
 
     const icon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
     if (!icon) return;
-    // 원래 아이콘을 기억해 두었다가, 경보가 풀리면 되돌린다.
+    // Remember the original icon and restore it when the alert clears.
     const original = icon.dataset.original ?? icon.getAttribute('href') ?? '/favicon.svg';
     icon.dataset.original = original;
     icon.setAttribute('href', alerting ? ALERT_FAVICON : original);
   }, [alerting]);
 
   useEffect(() => {
-    // 화면 잠김 방지
+    // Prevent the screen from locking
     const wakeLock = async () => {
       try {
         if ('wakeLock' in navigator) {
@@ -78,8 +79,8 @@ export default function DisplayPage() {
   );
 }
 
-// 첫 응답을 받기 전에만 보인다. 한 번이라도 받은 뒤에는 연결이 끊겨도
-// 마지막 값을 계속 띄우고, 헤더의 표시등으로 상태를 알린다.
+// Only shown before the first response. After receiving one, it keeps showing
+// the last value even if the connection drops, and signals status via the header indicator.
 const StartupState: React.FC<{ error: string | null }> = ({ error }) => (
   <div className="flex flex-col items-center justify-center gap-3 p-8">
     {error ? (

--- a/src/components/charts/NetworkAreaChart.tsx
+++ b/src/components/charts/NetworkAreaChart.tsx
@@ -5,8 +5,8 @@ import React, { useRef, useState } from 'react';
 import { NetworkHistoryEntry } from '@/types/system';
 import { rateUnit } from '@/utils/format';
 
-// 시안의 차트를 그대로 옮긴 SVG. 고정 캔버스(1024x600) 안에서는 recharts 의
-// 반응형 측정이 필요 없고, viewBox 만으로 정확히 같은 비율이 나온다.
+// An SVG that reproduces the design's chart. Inside a fixed canvas (1024x600)
+// recharts' responsive measurement isn't needed, and a viewBox alone gives exactly the same proportions.
 const WIDTH = 700;
 const HEIGHT = 260;
 const PAD_LEFT = 50;
@@ -15,13 +15,13 @@ const PAD_TOP = 8;
 const PAD_BOTTOM = 16;
 const TICK_COUNT = 4;
 
-// 크로스헤어 말풍선. 모노스페이스라 글자폭이 일정해서 폭을 글자 수로 계산할 수 있다.
+// The crosshair tooltip. Monospace has a constant glyph width, so the width can be computed from the character count.
 const READOUT_FONT = 9;
 const READOUT_CHAR_W = READOUT_FONT * 0.62;
 const READOUT_PAD = 6;
 const READOUT_LINE = 11;
 
-// 축 최댓값을 1/2/5 배수로 올려 눈금 숫자가 지저분해지지 않게 한다.
+// Round the axis max up to a 1/2/5 multiple so the tick numbers don't get messy.
 function niceMax(value: number): number {
   if (value <= 0) return 4;
   const raw = value / TICK_COUNT;
@@ -39,8 +39,8 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [active, setActive] = useState<number | null>(null);
 
-  // 화면 좌표 → viewBox 좌표. preserveAspectRatio 로 레터박스가 생길 수 있어
-  // 폭 비율로 어림하지 않고 CTM 역행렬을 쓴다.
+  // Screen coords -> viewBox coords. preserveAspectRatio can produce letterboxing,
+  // so use the inverse CTM rather than estimating from the width ratio.
   const indexAt = (clientX: number, clientY: number, count: number): number | null => {
     const svg = svgRef.current;
     const ctm = svg?.getScreenCTM();
@@ -90,8 +90,8 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
       height="100%"
       viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
       preserveAspectRatio="xMidYMid meet"
-      // 마우스는 hover, 터치는 탭/드래그로 같은 지점을 집는다. touch-action 은
-      // 건드리지 않는다 — 차트 위에서 페이지 세로 스크롤이 막히면 손해가 더 크다.
+      // Mouse picks a point via hover, touch via tap/drag. Don't touch
+      // touch-action — blocking vertical page scroll over the chart would cost more.
       onPointerMove={event => setActive(indexAt(event.clientX, event.clientY, data.length))}
       onPointerDown={event => setActive(indexAt(event.clientX, event.clientY, data.length))}
       onPointerLeave={() => setActive(null)}
@@ -166,7 +166,7 @@ export const NetworkAreaChart: React.FC<NetworkAreaChartProps> = ({ data }) => {
           ];
           const boxWidth = Math.max(...lines.map(text => text.length)) * READOUT_CHAR_W + READOUT_PAD * 2;
           const boxHeight = lines.length * READOUT_LINE + READOUT_PAD * 2 - 3;
-          // 오른쪽 끝에서는 말풍선이 축 밖으로 나가므로 커서 왼쪽에 붙인다.
+          // At the right edge the tooltip would run off the axis, so pin it to the left of the cursor.
           const flip = cx + 10 + boxWidth > PAD_LEFT + innerWidth;
           const boxX = flip ? cx - 10 - boxWidth : cx + 10;
 

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -45,8 +45,8 @@ import {
   tempColor
 } from '@/utils/statusColors';
 
-// 카드는 멀티컬럼(.dash-grid)으로 흘러 화면 폭에 따라 1/2/3열이 된다.
-// 열 수와 치수는 전부 src/styles/globals.css 가 정한다.
+// Cards flow in a multi-column layout (.dash-grid), becoming 1/2/3 columns with
+// screen width. The column count and dimensions are all set by src/styles/globals.css.
 const TEMP_SCALE_MAX = 90;
 const TEMP_WARN = 65;
 const TEMP_CRITICAL = 74;
@@ -55,13 +55,13 @@ const MAX_ALERTS = 5;
 const MAX_PROCESSES = 6;
 const MAX_SESSIONS = 4;
 const MAX_PEERS = 4;
-// 도커/브리지/veth 까지 다 그리면 카드 하나가 열 하나를 잡아먹는다.
+// Drawing docker/bridge/veth too would let one card eat an entire column.
 const MAX_INTERFACES = 4;
-// 이보다 많으면 코어 막대를 두 줄로 접는다.
+// Above this, the core bars fold onto two rows.
 const CORE_SPLIT_THRESHOLD = 8;
 const LOAD_CELLS = 48;
-// 30분 이동평균의 창 길이. history.ts 의 ROLLING_WINDOW_MS 와 같은 값이며,
-// 여기서는 "창이 다 찼는가" 를 판정하는 데만 쓴다.
+// The 30-minute moving-average window length. Same value as ROLLING_WINDOW_MS in
+// history.ts; used here only to decide "is the window full".
 const ROLLING_30M_SECONDS = 30 * 60;
 
 interface DashboardProps {
@@ -86,8 +86,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
     <Header data={data} connected={connected} lastUpdate={lastUpdate} now={now} />
     <AlertBar data={data} />
 
-    {/* 열 구성과 각 열 안의 순서는 디자인 시안 그대로다.
-        화면이 좁아지면 열이 통째로 아래로 접힐 뿐, 카드가 재배치되지는 않는다. */}
+    {/* The column makeup and the order within each column follow the design.
+        As the screen narrows, columns fold below whole; cards are never rearranged. */}
     <div className="dash-layout">
       <div className="dash-col">
         <UptimeCard data={data} />
@@ -123,7 +123,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   </div>
 );
 
-// --- 공통 조각 -------------------------------------------------------------
+// --- Shared pieces ---------------------------------------------------------
 
 interface CardProps {
   icon: LucideIcon;
@@ -150,9 +150,9 @@ const Empty: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <p className="t-body text-gray-500">{children}</p>
 );
 
-// --- 헤더 / 경고 -----------------------------------------------------------
+// --- Header / alerts -------------------------------------------------------
 
-// 배너에 띄울 만한 "지금 당장 문제" 만 고른다. 지나간 사건은 ALERTS LOG 가 맡는다.
+// Pick only "a problem right now" worth showing in the banner. Past events are handled by the ALERTS LOG.
 function currentAlerts(data: DashboardData): string[] {
   const alerts: string[] = [];
 
@@ -168,8 +168,8 @@ function currentAlerts(data: DashboardData): string[] {
   return alerts;
 }
 
-// 터미널 윈도우 크롬. 신호등 + 경로만 얹어 대시보드를 "터미널 창"처럼 감싼다.
-// 배치나 정보는 건드리지 않는, 순수 장식용 상단 바다.
+// Terminal-window chrome. Just the traffic lights + path wrap the dashboard like
+// a "terminal window". A purely decorative top bar that touches no layout or data.
 const TerminalTitleBar: React.FC<{ data: DashboardData }> = ({ data }) => {
   const host = data.host.hostname || 'server';
 
@@ -195,11 +195,11 @@ type HeaderProps = Omit<DashboardProps, 'networkHistory' | 'diskIoHistory'>;
 const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => {
   const secondsAgo =
     now !== null && lastUpdate !== null ? Math.max(0, Math.round((now - lastUpdate) / 1000)) : 0;
-  // 연결은 살아 있는데 값이 멎었을 수 있다(수집 루프 정지 등). SSE connected 와
-  // 별개로, 마지막 성공 샘플이 오래됐으면 amber 로 알린다.
+  // The connection may be alive while the values are stuck (a stalled collection
+  // loop, etc.). Independent of SSE connected, show amber when the last successful sample is old.
   const stale = connected && secondsAgo > 5;
-  // API 가 돌려주는 warnings 는 어떤 수집기가 실패했는지 담는다. 지금까지 화면엔
-  // 안 보였다 — 몇 개가 degrade 됐는지 뱃지로 띄우고, 목록은 호버 툴팁에 담는다.
+  // The warnings the API returns hold which collectors failed. They weren't shown
+  // on screen before — show how many degraded as a badge, with the list in a hover tooltip.
   const degraded = data.warnings.length;
 
   return (
@@ -211,13 +211,13 @@ const Header: React.FC<HeaderProps> = ({ data, connected, lastUpdate, now }) => 
         <div className="h-[7px] w-[7px] shrink-0 animate-[pulseDot_2s_ease-in-out_infinite] rounded-full bg-green-400" />
       </div>
 
-      {/* 마운트 전에는 시각을 그리지 않는다(하이드레이션 불일치 방지). */}
+      {/* Don't render the time before mount (avoids a hydration mismatch). */}
       <span className="t-body order-1 whitespace-nowrap font-mono text-gray-300 md:order-3">
         {now === null ? ' ' : formatClock(new Date(now))}
       </span>
 
-      {/* 좁은 화면에서는 w-full 때문에 이 묶음만 통째로 둘째 줄로 내려간다.
-          넓은 화면에서는 시계 앞에 나란히 붙는다. */}
+      {/* On a narrow screen, w-full drops this whole group onto a second row.
+          On a wide screen it sits inline before the clock. */}
       <div className="order-2 flex w-full items-center justify-between gap-3 md:order-2 md:w-auto md:justify-end">
         <div className="flex shrink-0 items-center gap-1">
           <div
@@ -280,7 +280,7 @@ const AlertBar: React.FC<{ data: DashboardData }> = ({ data }) => {
   );
 };
 
-// --- 게이지 ----------------------------------------------------------------
+// --- Gauges ----------------------------------------------------------------
 
 interface GaugeTileProps {
   icon: LucideIcon;
@@ -288,12 +288,12 @@ interface GaugeTileProps {
   label: string;
   percentage: number | null;
   caption: string;
-  // 게이지에 마우스를 올리거나 손으로 눌렀을 때 보여줄 한 줄. caption 은 칸에
-  // 맞춰 잘리지만 이쪽은 잘리지 않은 전체 수치를 담는다.
+  // The line shown on hover or tap of the gauge. caption is truncated to fit the
+  // cell, but this holds the full, un-truncated numbers.
   detail: string;
 }
 
-// 시안에서는 게이지 네 개가 각각 독립된 카드다.
+// In the design the four gauges are each their own card.
 const GaugeCard: React.FC<GaugeTileProps> = ({
   icon: Icon,
   iconColor,
@@ -310,8 +310,8 @@ const GaugeCard: React.FC<GaugeTileProps> = ({
         <Icon className="dash-icon shrink-0" color={iconColor} strokeWidth={2} />
         <span className="t-micro truncate text-gray-300">{label}</span>
       </div>
-      {/* 툴팁은 게이지+수치 묶음이 진다. 카드 전체가 아니라 그림 위에서만 떠야
-          이웃 카드로 넘어갈 때 깜빡이지 않는다. */}
+      {/* The gauge+value group owns the tooltip. It must appear only over the
+          graphic, not the whole card, so it doesn't flicker when moving to a neighbor. */}
       <div className="dash-tip flex flex-col items-center" tabIndex={-1} data-tip={detail}>
         <Gauge
           percentage={percentage ?? 0}
@@ -331,15 +331,15 @@ const GaugeCard: React.FC<GaugeTileProps> = ({
 const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
   const toGb = (mb: number) => (mb / 1024).toFixed(1);
 
-  // CPU 툴팁에 새 지표들을 덧붙인다(레이아웃은 그대로, 호버 시에만 보인다):
-  // 현재 클럭·I/O 대기, 그리고 스틸이 0보다 크면(과판매 VPS) 스틸까지.
+  // Append the new metrics to the CPU tooltip (layout unchanged, only shown on
+  // hover): current clock, I/O wait, and steal when it's above 0 (an oversubscribed VPS).
   const cpuFreq = data.cpu.frequencyMhz === 'N/A' ? '' : ` · ${(data.cpu.frequencyMhz / 1000).toFixed(2)}GHz`;
   const cpuSteal = data.cpu.steal > 0 ? ` · steal ${data.cpu.steal.toFixed(1)}%` : '';
   const cpuDetail = `${data.cpu.usage.toFixed(1)}% across ${data.cpu.cores} cores · load 1m ${data.load.avg1.toFixed(
     2
   )}${cpuFreq} · iowait ${data.cpu.iowait.toFixed(1)}%${cpuSteal}`;
 
-  // DISK 툴팁에 루트 외 마운트의 사용률과, 채워지는 중이면 가득 참 예측을 덧붙인다.
+  // Append non-root mount usage to the DISK tooltip, plus the fill forecast when it's filling.
   const extraMounts = data.disks.filter(mount => mount.mount !== '/');
   const mountDetail =
     extraMounts.length > 0
@@ -350,8 +350,8 @@ const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
       ? ` · full in ~${data.disk.hoursToFull < 48 ? `${data.disk.hoursToFull.toFixed(1)}h` : `${Math.round(data.disk.hoursToFull / 24)}d`}`
       : '';
 
-  // 시안은 네 개를 한 줄에 놓는다. 휴대폰 폭에서는 게이지 지름보다 칸이 좁아져
-  // 넘치므로, 그때만 2x2 로 접는다.
+  // The design places four on one row. At phone width the cell gets narrower than
+  // the gauge diameter and overflows, so it folds to 2x2 only then.
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
       <GaugeCard
@@ -401,7 +401,7 @@ const GaugeRow: React.FC<{ data: DashboardData }> = ({ data }) => {
   );
 };
 
-// --- 시스템 ----------------------------------------------------------------
+// --- System ----------------------------------------------------------------
 
 const UptimeCard: React.FC<{ data: DashboardData }> = ({ data }) => (
   <Card icon={Clock} color="#4ade80" title="UPTIME">
@@ -426,19 +426,25 @@ const UptimeCard: React.FC<{ data: DashboardData }> = ({ data }) => (
 const LoadCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   const { load, cpu, history } = data;
 
-  // 한 칸이 1시간이라 48칸이면 48시간이다. 아직 다 못 채웠으면 앞쪽을 빈 칸으로
-  // 메워 격자 모양을 유지한다.
+  // One cell is 1 hour, so 48 cells is 48 hours. If not yet full, pad the front
+  // with empty cells to keep the grid shape.
   const cells = [
     ...Array(Math.max(0, LOAD_CELLS - history.load.length)).fill(null),
     ...history.load.slice(-LOAD_CELLS)
   ];
 
-  // 순간값은 실행 대기 태스크 수다. /proc 가 없는 OS 에서는 못 읽으므로 1분 평균으로
-  // 물러난다 — 색을 고를 기준값도 같이 따라간다.
+  // The instantaneous value is the run-queue task count. On an OS without /proc
+  // it can't be read, so it falls back to the 1-minute average — the value used to pick the color follows too.
   const liveLoad = load.running ?? load.avg1;
 
-  // 30분은 커널이 주지 않아 우리 샘플로 낸다. 창이 아직 덜 찼으면 별표로 알리고,
-  // 툴팁에 실제로 덮은 구간을 적는다 — 시작 직후 "0분 평균" 이 되지 않도록 초로 받는다.
+  // Core-normalized load (1.00 = all cores saturated). A load of 8 means
+  // different things on 4 vs 16 cores, so show this alongside the absolute value.
+  const perCoreLoad = load.avg1 / Math.max(1, cpu.cores);
+  const perCoreTip = `1-minute load per core (1.00 = all ${cpu.cores} cores fully saturated)`;
+
+  // The kernel doesn't give 30m, so we compute it from our samples. If the window
+  // isn't full yet, mark it with an asterisk and note the actually-covered span in
+  // the tooltip — taken in seconds so it isn't a "0-minute average" right after start.
   const partial30m = load.avg30 !== null && load.avg30WindowSeconds < ROLLING_30M_SECONDS;
   const window30m =
     load.avg30WindowSeconds < 60
@@ -472,7 +478,15 @@ const LoadCard: React.FC<{ data: DashboardData }> = ({ data }) => {
       }
     >
       <div className="t-micro mb-1 flex items-center justify-between gap-2 text-gray-500">
-        <span>Last 48h</span>
+        <span
+          className="dash-tip"
+          tabIndex={-1}
+          data-tip={perCoreTip}
+          style={{ color: loadColor(load.avg1, cpu.cores) }}
+        >
+          {perCoreLoad.toFixed(2)}
+          <span className="text-gray-600">/core</span>
+        </span>
         <span className="truncate">
           1m {load.avg1.toFixed(2)} · 15m {load.avg15.toFixed(2)} ·{' '}
           <span className="dash-tip" tabIndex={-1} data-tip={avg30Tip}>
@@ -493,8 +507,8 @@ const LoadCard: React.FC<{ data: DashboardData }> = ({ data }) => {
             <div
               key={cell ? cell.at : `empty-${index}`}
               role="listitem"
-              // 탭 순서에는 넣지 않되(48칸이다) 눌렀을 때 포커스는 받게 한다.
-              // 터치에서 툴팁이 뜨는 경로가 이것뿐이다.
+              // Keep it out of tab order (there are 48 cells) but let it take focus on tap.
+              // This is the only path for the tooltip to appear on touch.
               tabIndex={-1}
               className="dash-loadcell dash-tip rounded-[2px]"
               style={{ background: loadCellColor(cell?.avg1 ?? null, cpu.cores) }}
@@ -520,18 +534,18 @@ const CoresCard: React.FC<{ data: DashboardData }> = ({ data }) => {
       right={hidden > 0 ? <span className="t-micro shrink-0 text-gray-500">+{hidden}</span> : undefined}
     >
       {cores.length === 0 && <Empty>per-core data unavailable</Empty>}
-      {/* 가로 막대라 코어가 몇 개든, 열이 얼마나 좁든 읽힌다. */}
+      {/* Horizontal bars stay readable no matter how many cores or how narrow the column. */}
       <ul className={cn('dash-corelist', cores.length > CORE_SPLIT_THRESHOLD && 'dash-corelist--split')}>
         {cores.map((usage, index) => (
           <li
             key={index}
             className="dash-tip flex items-center gap-1.5"
             tabIndex={-1}
-            // 막대 옆 숫자는 자리를 아끼려 정수로 줄여 놨다. 소수점은 여기서 준다.
+            // The number beside the bar is rounded to an integer to save space. The decimal is given here.
             data-tip={`core ${index} · ${usage.toFixed(1)}%`}
           >
-            {/* 폭을 ch 로 잡아야 글자 배율(--dash-scale)을 따라 같이 넓어진다.
-                px 로 고정하면 큰 화면에서 숫자가 칸을 넘어 서로 붙는다. */}
+            {/* Width in ch so it widens with the type scale (--dash-scale). Fixing
+                it in px would make the numbers overflow the cell and collide on large screens. */}
             <span className="t-micro w-[3ch] shrink-0 text-gray-500">C{index}</span>
             <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded bg-gray-900">
               <div
@@ -582,7 +596,7 @@ const TemperatureCard: React.FC<{ data: DashboardData }> = ({ data }) => {
 };
 
 const FanCard: React.FC<{ data: DashboardData }> = ({ data }) => {
-  // 메인보드마다 어느 커넥터에 팬이 꽂혀 있는지 달라서, 값이 잡히는 첫 번째를 쓴다.
+  // Which connector the fan is plugged into varies by motherboard, so use the first one that has a value.
   const rpm = [data.fan.cpu, data.fan.case1, data.fan.case2].find(value => value > 0) ?? 0;
 
   return (
@@ -693,7 +707,7 @@ const DiskIoCard: React.FC<{ data: DashboardData; history: DiskIoPoint[] }> = ({
   );
 };
 
-// --- 네트워크 --------------------------------------------------------------
+// --- Network ---------------------------------------------------------------
 
 const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[] }> = ({
   data,
@@ -710,8 +724,8 @@ const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[
       </span>
     }
   >
-    {/* 범례에 부팅 이후 누적 총량을 함께 적어(순간 속도만으로는 알 수 없는) 대역폭
-        사용량을 한눈에 보게 한다. */}
+    {/* Show the since-boot cumulative totals in the legend so bandwidth usage —
+        which the instantaneous rate alone can't tell you — is visible at a glance. */}
     <div className="t-micro flex items-center justify-center gap-4 text-gray-400">
       <span className="flex items-center gap-1">
         <span className="h-[7px] w-[7px] rounded-full bg-blue-500" />
@@ -728,7 +742,7 @@ const NetworkCard: React.FC<{ data: DashboardData; history: NetworkHistoryEntry[
   </Card>
 );
 
-// 시안에서 차트 아래 따로 놓인 한 줄짜리 요약 바.
+// A one-line summary bar placed separately below the chart in the design.
 const NetworkStripCard: React.FC<{ data: DashboardData }> = ({ data }) => (
   <section className="dash-card flex flex-wrap items-center justify-around gap-x-4 gap-y-1 rounded-lg border border-gray-700 bg-gray-800">
     <StripItem value={data.network.ping.toFixed(1)} unit="ms ping" color="text-yellow-400" />
@@ -787,7 +801,7 @@ const InterfacesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
 const BandwidthCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   const percentage = data.network.bandwidthPercentage;
   const color = statusColor(percentage);
-  // 게이지가 재는 것과 같은 값: 현재 총 처리량(다운로드+업로드).
+  // The same value the gauge measures: current total throughput (download + upload).
   const usage = data.network.download + data.network.upload;
 
   return (
@@ -810,7 +824,7 @@ const BandwidthCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   );
 };
 
-// --- 로그 / 보안 -----------------------------------------------------------
+// --- Logs / security -------------------------------------------------------
 
 const AlertsCard: React.FC<{ data: DashboardData; now: number | null }> = ({ data, now }) => (
   <Card icon={TriangleAlert} color="#f87171" title="ALERTS LOG">
@@ -831,34 +845,64 @@ const AlertsCard: React.FC<{ data: DashboardData; now: number | null }> = ({ dat
 );
 
 const ProcessesCard: React.FC<{ data: DashboardData }> = ({ data }) => {
-  const processes = data.processes.filter(p => p.cpu > 0 || p.memory > 0).slice(0, MAX_PROCESSES);
+  // Toggle the list between CPU-sorted (default) and memory-sorted. The
+  // memory-sorted list comes from a separate ps call surfaced by the API.
+  const [sortBy, setSortBy] = React.useState<'cpu' | 'mem'>('cpu');
+  const source = sortBy === 'mem' ? data.topProcessesByMemory : data.processes;
+  const processes = source.filter(p => p.cpu > 0 || p.memory > 0).slice(0, MAX_PROCESSES);
   const { total, zombie } = data.processSummary;
 
-  // 전체 프로세스 규모를 카드 헤더에 요약한다(상위 목록은 그대로). 좀비가 있으면
-  // 빨갛게 — 프로세스 리크의 신호다.
-  const summary =
-    total > 0 ? (
-      <span className="t-micro shrink-0 font-mono text-gray-500">
-        {total} proc{zombie > 0 && <span className="text-red-400"> · {zombie}Z</span>}
+  // Summarise the whole process table in the header (the list stays top-N).
+  // Zombies are shown in red — a sign of a process leak.
+  const summary = (
+    <span className="flex shrink-0 items-center gap-2">
+      {total > 0 && (
+        <span className="t-micro font-mono text-gray-500">
+          {total} proc{zombie > 0 && <span className="text-red-400"> · {zombie}Z</span>}
+        </span>
+      )}
+      <span className="t-micro flex overflow-hidden rounded border border-gray-700 font-mono">
+        {(['cpu', 'mem'] as const).map(key => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setSortBy(key)}
+            className={cn(
+              'px-1 uppercase',
+              sortBy === key ? 'bg-gray-700 text-gray-100' : 'text-gray-500 hover:text-gray-300'
+            )}
+            aria-pressed={sortBy === key}
+          >
+            {key === 'cpu' ? 'CPU' : 'MEM'}
+          </button>
+        ))}
       </span>
-    ) : undefined;
+    </span>
+  );
 
   return (
     <Card icon={AlignLeft} color="#fb923c" title="TOP PROCESSES" right={summary}>
       <div className="t-micro mb-0.5 flex items-center justify-between text-gray-500">
         <span>Name</span>
         <div className="flex gap-2">
-          <span className="w-[5ch] text-right text-yellow-400">CPU</span>
-          <span className="w-[5ch] text-right text-blue-400">RAM</span>
+          <span
+            className={cn('w-[5ch] text-right', sortBy === 'cpu' ? 'text-yellow-400' : 'text-yellow-400/60')}
+          >
+            CPU
+          </span>
+          <span className={cn('w-[5ch] text-right', sortBy === 'mem' ? 'text-blue-400' : 'text-blue-400/60')}>
+            RAM
+          </span>
         </div>
       </div>
       {processes.length === 0 && <Empty>process list unavailable</Empty>}
       <ul className="dash-rows">
         {processes.map(process => (
           <li key={process.id} className="t-body flex items-center justify-between gap-2">
-            {/* 툴팁을 truncate 한 요소에 직접 걸면 그 요소의 overflow:hidden 에
-                잘린다. 그래서 자르지 않는 바깥 span 이 툴팁을 진다. 전체 이름은
-                DOM 텍스트에 그대로 있어 스크린리더는 잘린 것과 무관하게 읽는다. */}
+            {/* Putting the tooltip on a truncated element clips it to that
+                element's overflow:hidden, so the un-truncated outer span owns
+                the tooltip. The full name stays in the DOM text, so a screen
+                reader reads it regardless of truncation. */}
             <span className="dash-tip min-w-0" tabIndex={-1} data-tip={process.name}>
               <span className="block truncate text-gray-400">{process.name}</span>
             </span>
@@ -901,7 +945,7 @@ const TrafficCard: React.FC<{ data: DashboardData }> = ({ data }) => (
       {data.security.topTraffic.slice(0, MAX_PEERS).map(peer => (
         <li key={peer.ip} className="t-body flex items-center justify-between gap-2">
           <span className="min-w-0 truncate font-mono text-gray-400">{peer.ip}</span>
-          {/* conntrack 이 바이트를 세지 않는 커널에서는 연결 수만 알 수 있다. */}
+          {/* On a kernel where conntrack doesn't count bytes, only the connection count is known. */}
           <span className="shrink-0 font-mono text-sky-400">
             {peer.bytes === null ? `${peer.connections} conn` : formatBytes(peer.bytes)}
           </span>

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 
 import { cn } from '@/lib/utils';
 
-// 대시보드 카드 안에서 반복되는 그래픽 조각들.
-// 치수는 CSS 클래스(.dash-*)가 정하므로, 화면 밀도가 바뀌어도 여기는 그대로다.
+// Graphic pieces reused inside the dashboard cards.
+// Dimensions come from CSS classes (.dash-*), so these stay the same as screen density changes.
 
 interface GaugeProps {
   percentage: number;
   color: string;
   className?: string;
-  // 스크린리더용 라벨. 손수 그린 SVG 는 기본적으로 아무 것도 안 읽히므로,
-  // role="img" 와 함께 준다. 미지정 시 퍼센트만이라도 읽어 준다.
+  // Screen-reader label. A hand-drawn SVG reads nothing by default, so provide
+  // it together with role="img". If unset, at least the percentage is read.
   ariaLabel?: string;
 }
 
-// 크기는 CSS(.dash-gauge)가 정한다. viewBox 로 그리면 화면 밀도에 따라
-// 지름이 바뀌어도 선 두께가 같은 비율로 따라간다.
+// Size comes from CSS (.dash-gauge). Drawing with a viewBox keeps the stroke
+// width in the same proportion even as the diameter changes with screen density.
 const GAUGE_BOX = 36;
 const GAUGE_STROKE = 3.5;
 const GAUGE_RADIUS = GAUGE_BOX / 2 - GAUGE_STROKE / 2 - 1.25;
@@ -82,7 +82,7 @@ interface SparklineProps {
   emptyLabel?: string;
 }
 
-// 축도 눈금도 없는 추세선. 세로 축은 표시된 구간의 최댓값에 맞춰 자동으로 늘어난다.
+// A trend line with no axes or ticks. The vertical axis auto-scales to the max of the shown range.
 export const Sparkline: React.FC<SparklineProps> = ({ series, className, emptyLabel = 'collecting…' }) => {
   const width = 200;
   const height = 34;

--- a/src/hooks/useNow.ts
+++ b/src/hooks/useNow.ts
@@ -2,11 +2,13 @@
 
 import { useCallback, useSyncExternalStore } from 'react';
 
-// 서버 렌더 결과에 시각이 박히면 하이드레이션 불일치가 난다. 서버 스냅샷은 null 로
-// 두고(화면은 자리표시자를 그린다) 클라이언트에서만 실제 시각을 흘려보낸다.
+// Baking the time into the server render causes a hydration mismatch. The
+// server snapshot is null (the screen draws a placeholder) and only the client
+// streams the real time.
 //
-// effect 안에서 setState 를 부르는 대신 외부 스토어로 구독한다. 그래야 하이드레이션
-// 직후 한 번 더 렌더되는 일이 없고, 같은 간격을 쓰는 훅끼리 타이머 하나를 공유한다.
+// Subscribe via an external store instead of calling setState inside an effect.
+// That avoids an extra render right after hydration, and hooks using the same
+// interval share a single timer.
 
 interface Ticker {
   now: number;
@@ -26,18 +28,18 @@ function tickerFor(intervalMs: number): Ticker {
 }
 
 export function useNow(intervalMs = 1000): number | null {
-  // 티커는 콜백 안에서만 집는다. 렌더 중에 꺼내 두면 "렌더에서 만든 값을 나중에
-  // 수정한다" 로 잡히므로(react-hooks/immutability) 그렇게 하지 않는다.
+  // Grab the ticker only inside the callback. Pulling it out during render would
+  // be flagged as "mutating a value created during render" (react-hooks/immutability), so we don't.
   const subscribe = useCallback(
     (listener: () => void) => {
       const ticker = tickerFor(intervalMs);
 
-      // 오래 놀던 티커라면 캐시된 시각이 낡았다. 구독 시점에 한 번 맞춰 둔다.
-      // React 가 구독 직후 스냅샷을 다시 읽어 달라진 값을 반영한다.
+      // A long-idle ticker has a stale cached time. Sync it once at subscribe time.
+      // React re-reads the snapshot right after subscribing to reflect the changed value.
       ticker.now = Date.now();
       ticker.listeners.add(listener);
 
-      // 첫 구독자에서만 타이머를 켜고, 마지막 구독자가 떠나면 끈다.
+      // Start the timer only on the first subscriber, and stop it when the last one leaves.
       if (!ticker.handle) {
         ticker.handle = setInterval(() => {
           ticker.now = Date.now();
@@ -56,8 +58,8 @@ export function useNow(intervalMs = 1000): number | null {
     [intervalMs]
   );
 
-  // getSnapshot 은 값이 안 바뀐 동안 같은 값을 돌려줘야 한다(아니면 무한 렌더).
-  // 그래서 Date.now() 를 직접 부르지 않고 티커가 캐시한 값을 읽는다.
+  // getSnapshot must return the same value while nothing changes (otherwise an
+  // infinite render). So it reads the ticker's cached value rather than calling Date.now() directly.
   const getSnapshot = useCallback(() => tickerFor(intervalMs).now, [intervalMs]);
 
   return useSyncExternalStore(subscribe, getSnapshot, () => null);

--- a/src/hooks/useSystemData.ts
+++ b/src/hooks/useSystemData.ts
@@ -7,7 +7,7 @@ import { DashboardData, toDashboardData } from '@/utils/dashboardData';
 
 const MAX_POINTS = 60;
 
-// 이 필드들이 없으면 응답이 /api/system 의 것이 아니거나 심하게 망가진 것이다.
+// Without these fields the response either isn't from /api/system or is badly broken.
 const REQUIRED_FIELDS = [
   'cpu',
   'memory',
@@ -56,8 +56,8 @@ export function useSystemData(): SystemDataState {
   });
 
   useEffect(() => {
-    // 폴링(초당 GET) 대신 연결 하나를 열어두고 서버가 밀어주는 SSE 를 구독한다.
-    // EventSource 는 연결이 끊기면 자동으로 재연결하므로 별도 백오프가 필요 없다.
+    // Instead of polling (a GET per second), keep one connection open and
+    // subscribe to the SSE the server pushes. EventSource auto-reconnects on drop, so no separate backoff is needed.
     const source = new EventSource('/api/system/stream');
 
     source.onopen = () => {
@@ -94,15 +94,15 @@ export function useSystemData(): SystemDataState {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error occurred';
         console.error('Error parsing system data:', error);
-        // 파싱 실패는 연결 문제가 아니다. 마지막 값은 유지하고 에러만 표시한다.
+        // A parse failure isn't a connection problem. Keep the last value and just show the error.
         setState(previous => ({ ...previous, error: message }));
       }
     };
 
     source.onerror = () => {
-      // 연결이 끊긴 상태. 마지막으로 받은 값은 지우지 않는다. 잠깐 끊겼다고
-      // 화면이 비어버리면 벽에 걸어둔 대시보드로서는 오히려 정보가 줄어든다.
-      // EventSource 가 알아서 재연결을 시도하며, 성공하면 onopen 이 복구한다.
+      // Disconnected. Don't clear the last received value. If the screen went
+      // blank on a brief drop, a wall-mounted dashboard would actually show less
+      // info. EventSource retries reconnection on its own, and onopen restores things on success.
       setState(previous => ({ ...previous, connected: false }));
     };
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,7 @@
-// Next.js 는 서버가 부팅될 때 이 register() 를 한 번 호출한다. 여기서 수집
-// 루프를 띄워, 브라우저가 한 번도 접속하지 않아도 히스토리/알림이 처음부터
-// 쌓이게 한다(24/7 수집). Edge 런타임에서는 fs/child_process 를 못 쓰므로
-// nodejs 런타임에서만 시작한다.
+// Next.js calls this register() once when the server boots. Starting the
+// collection loop here means history/alerts accumulate from the start even if a
+// browser never connects (24/7 collection). The Edge runtime can't use
+// fs/child_process, so start only on the nodejs runtime.
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
   const { ensureCollecting } = await import('@/utils/systemStream');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,27 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-// /api/system* 는 SSH 접속 IP/사용자명, 전체 프로세스 목록, 열린 포트, 트래픽
-// 상대 IP, 방화벽 상태 같은 민감한 정찰 정보를 돌려준다. CORS 는 브라우저의
-// 교차 출처 "읽기"만 막을 뿐, curl 같은 비-브라우저 클라이언트는 그대로 읽는다.
+// /api/system* returns sensitive reconnaissance: SSH source IPs/usernames, the
+// full process list, open ports, traffic peer IPs, firewall state. CORS only
+// blocks a browser's cross-origin "read"; a non-browser client like curl reads it freely.
 //
-// 그래서 선택적 공유 토큰 게이트를 둔다. API_AUTH_TOKEN 이 설정돼 있으면 모든
-// /api/system* 요청은 그 토큰을 제시해야 한다. 설정돼 있지 않으면(기본값)
-// 동작은 이전과 완전히 동일하다 — 대신 네트워크 레벨(로컬바인딩/VPN/리버스
-// 프록시)로 보호해야 한다(README 참고).
+// So there's an optional shared-token gate. When API_AUTH_TOKEN is set, every
+// /api/system* request must present that token. When unset (the default) the
+// behavior is exactly as before — but you must then protect it at the network
+// level (local binding/VPN/reverse proxy) (see README).
 //
-// 주의: 토큰을 켜면 브라우저 내장 대시보드(같은 오리진에서 /api/system/stream 을
-// 부른다)는 토큰을 실을 수 없어 동작하지 않는다. 이 모드는 리버스 프록시가
-// 토큰을 주입하거나, 머신-투-머신 폴링을 하는 배포를 위한 것이다.
+// Note: enabling the token breaks the built-in browser dashboard (which calls
+// /api/system/stream from the same origin) because it can't attach a token.
+// This mode is for a deployment where a reverse proxy injects the token, or for machine-to-machine polling.
 
 const AUTH_TOKEN = process.env.API_AUTH_TOKEN;
 
-// 길이가 다르거나 값이 다를 때 걸리는 시간을 최대한 균일하게 만들어
-// 타이밍 사이드채널로 토큰을 한 글자씩 알아내는 것을 어렵게 한다.
+// Make the time taken as uniform as possible whether the length or value
+// differs, to make it hard to recover the token one character at a time via a timing side channel.
 function timingSafeEqual(a: string, b: string): boolean {
   const encoder = new TextEncoder();
   const aBytes = encoder.encode(a);
   const bBytes = encoder.encode(b);
-  // 길이가 달라도 동일한 바이트 수를 비교하도록 긴 쪽 기준으로 순회한다.
+  // Iterate over the longer length so the same number of bytes is compared even when lengths differ.
   const length = Math.max(aBytes.length, bBytes.length);
   let mismatch = aBytes.length ^ bBytes.length;
   for (let i = 0; i < length; i += 1) {
@@ -35,16 +35,16 @@ function presentedToken(request: NextRequest): string | null {
   if (header && header.startsWith('Bearer ')) {
     return header.slice('Bearer '.length).trim();
   }
-  // EventSource 는 커스텀 헤더를 못 붙이므로 쿠키 경로도 허용한다(프록시가 주입).
+  // EventSource can't attach custom headers, so a cookie path is also allowed (injected by a proxy).
   const cookie = request.cookies.get('api_auth_token')?.value;
   return cookie ?? null;
 }
 
 export function proxy(request: NextRequest) {
-  // 토큰이 설정돼 있지 않으면 게이트를 열어둔다(기존 동작 유지).
+  // If no token is set, leave the gate open (preserving prior behavior).
   if (!AUTH_TOKEN) return NextResponse.next();
 
-  // preflight 는 인증 대상이 아니다. 실제 요청에서 검사한다.
+  // Preflight isn't subject to auth. Check it on the real request.
   if (request.method === 'OPTIONS') return NextResponse.next();
 
   const token = presentedToken(request);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,24 +1,24 @@
 @import 'tailwindcss';
 
 /* ---------------------------------------------------------------------------
-   터미널 팔레트
+   Terminal palette
 
-   포트폴리오(github.com/Ruthgyeul)의 터미널 감성을 그대로 옮겨 왔다.
-   대시보드 곳곳의 gray-* 유틸리티를 손대지 않고 색만 바꾸기 위해, Tailwind 의
-   회색 계열 토큰을 통째로 이 팔레트로 재정의한다. 카드/보더/글자 색이 한 번에
-   따라오므로 타일 배치나 정보는 건드리지 않는다.
+   Carries over the terminal feel from the portfolio (github.com/Ruthgyeul).
+   To recolor without touching the many gray-* utilities across the dashboard,
+   Tailwind's gray-scale tokens are wholesale redefined to this palette. Card/
+   border/text colors follow at once, so tile layout and information are untouched.
 --------------------------------------------------------------------------- */
 @theme {
   --color-gray-50: #f4f6fb;
-  --color-gray-100: #e6e8ee; /* 본문 */
+  --color-gray-100: #e6e8ee; /* body */
   --color-gray-200: #d5dae4;
-  --color-gray-300: #c3c8d4; /* 흐린 본문 */
-  --color-gray-400: #8b93a7; /* 라벨 */
-  --color-gray-500: #5c6478; /* 캡션 */
+  --color-gray-300: #c3c8d4; /* dim body */
+  --color-gray-400: #8b93a7; /* label */
+  --color-gray-500: #5c6478; /* caption */
   --color-gray-600: #454d5e;
-  --color-gray-700: rgba(255, 255, 255, 0.08); /* 카드 보더 */
-  --color-gray-800: #111621; /* 카드 배경 */
-  --color-gray-900: #0a0d13; /* 페이지 / 인셋 */
+  --color-gray-700: rgba(255, 255, 255, 0.08); /* card border */
+  --color-gray-800: #111621; /* card background */
+  --color-gray-900: #0a0d13; /* page / inset */
 }
 
 :root {
@@ -54,7 +54,7 @@ body {
   background: rgba(52, 211, 153, 0.3);
 }
 
-/* 스크롤바 — 포트폴리오와 동일한 얇은 터미널 스타일 */
+/* Scrollbar — the same thin terminal style as the portfolio */
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;
@@ -76,8 +76,8 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
-   터미널 배경 — 은은한 스캔라인 격자 + 상단 글로우.
-   대시보드 루트에 얹혀 검은 바탕에 CRT 결을 준다.
+   Terminal background — a subtle scanline grid + top glow.
+   Applied to the dashboard root to give the black base a CRT texture.
 --------------------------------------------------------------------------- */
 .terminal-bg {
   background-color: var(--term-bg);
@@ -92,7 +92,7 @@ body {
     );
 }
 
-/* 터미널 윈도우 크롬(신호등 + 경로)을 얹는 얇은 바 */
+/* A thin bar that adds the terminal-window chrome (traffic lights + path) */
 .term-titlebar {
   display: flex;
   align-items: center;
@@ -112,7 +112,7 @@ body {
   flex: none;
 }
 
-/* 카드 호버 리프트 — 포트폴리오의 .card 와 동일 결 */
+/* Card hover lift — the same feel as the portfolio's .card */
 .dash-card,
 .gauge-card {
   transition:
@@ -129,7 +129,7 @@ body {
   border-color: rgba(56, 189, 248, 0.35);
 }
 
-/* 대시보드 상태 표시용. Tailwind 의 animate-[pulseDot_...] 에서 참조한다. */
+/* For dashboard status indicators. Referenced by Tailwind's animate-[pulseDot_...]. */
 @keyframes pulseDot {
   0%,
   100% {
@@ -151,33 +151,33 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
-   대시보드 레이아웃
+   Dashboard layout
 
-   시안의 3열 구성을 그대로 쓴다. 어느 카드가 어느 열에, 어떤 순서로 들어가는지는
-   컴포넌트가 열 단위로 고정해 두었고(브라우저가 재배치하지 않는다), 여기서는
-   화면 폭에 따라 열을 몇 개 세울지만 정한다.
+   Uses the design's 3-column makeup as-is. Which card goes in which column, and
+   in what order, is fixed per column by the components (the browser doesn't
+   rearrange); here we only decide how many columns to stand up by screen width.
 
-   1024px 은 시안이 그려진 폭이라, 그 이상에서는 238:472:282 라는 시안의 열 비율을
-   그대로 유지한다. 더 좁아지면 열이 통째로 아래로 접히고, 각 열 안의 순서는
-   그대로 남는다.
+   1024px is the width the design was drawn at, so above it we keep the design's
+   column ratio of 238:472:282. Narrower than that, columns fold below whole and
+   the order within each column stays the same.
 
-   카드 안의 치수는 --dash-scale 하나가 통째로 배율을 잡는다. 화면이 넓어지면
-   열도 그만큼 넓어지므로, 같은 글자 크기를 유지하면 큰 모니터에서 휴대폰 화면을
-   늘려 놓은 꼴이 된다. 배율을 올려 카드가 열 폭을 제대로 쓰게 한다.
+   Dimensions inside cards are scaled wholesale by a single --dash-scale. As the
+   screen widens the columns widen too, so keeping the same type size would look
+   like a stretched phone screen on a big monitor. Raise the scale so cards use the column width properly.
 --------------------------------------------------------------------------- */
 
 :root {
   --dash-scale: 1;
 }
 
-/* 휴대폰: 카드 하나가 가로를 통째로 쓰니 조금 키워도 넘치지 않는다. */
+/* Phone: one card uses the full width, so bumping it up a little doesn't overflow. */
 @media (max-width: 639px) {
   :root {
     --dash-scale: 1.08;
   }
 }
 
-/* 넓어질수록 열이 넓어진다. 그만큼 카드 속 내용도 키운다. */
+/* The wider it gets, the wider the columns. Grow the card contents to match. */
 @media (min-width: 1280px) {
   :root {
     --dash-scale: 1.15;
@@ -214,7 +214,7 @@ body {
   }
 }
 
-/* 열 하나. 안의 카드 순서는 시안 그대로 고정된다. */
+/* One column. The card order inside is fixed per the design. */
 .dash-col {
   display: flex;
   flex-direction: column;
@@ -222,9 +222,9 @@ body {
   min-width: 0;
 }
 
-/* 시안에서 나란히 놓인 두 카드(FAN+TEMP, INTERFACES+BANDWIDTH).
-   휴대폰 폭에서는 반쪽이 170px 남짓이라 "eth0 192.168.0.14 · 1Gbps" 같은 줄이
-   잘린다. 그 구간에서만 위아래로 푼다. */
+/* Two cards placed side by side in the design (FAN+TEMP, INTERFACES+BANDWIDTH).
+   At phone width each half is about 170px, so a line like "eth0 192.168.0.14 ·
+   1Gbps" gets clipped. Only in that range, stack them vertically. */
 .dash-subgrid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -275,8 +275,8 @@ body {
   margin-top: calc(6px * var(--dash-scale));
 }
 
-/* 코어가 많으면 한 줄에 하나씩 쌓기엔 너무 길어진다. 두 줄로 접는다.
-   단 휴대폰에서는 세로가 넉넉하고 가로가 없으니 한 줄로 둔다. */
+/* With many cores, one per row gets too long. Fold onto two rows.
+   But on a phone there's plenty of height and no width, so keep one row. */
 .dash-corelist {
   display: grid;
   grid-template-columns: 1fr;
@@ -310,15 +310,15 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
-   툴팁
+   Tooltip
 
-   여기 쓰이던 title 속성은 터치 기기에서 아예 뜨지 않는다. 이 대시보드의 주
-   사용처가 7인치 키오스크 패널이라, 로드 격자와 히트맵의 시각/수치를 확인할
-   방법이 사실상 없었다. hover 와 focus 양쪽에 반응하는 CSS 툴팁으로 바꾼다.
+   The title attribute used here doesn't appear at all on touch devices. Since
+   this dashboard's main use is a 7-inch kiosk panel, there was effectively no way
+   to read the time/value on the load grid and heatmap. Switch to a CSS tooltip
+   that responds to both hover and focus.
 
-   :focus-visible 이 아니라 :focus 를 쓰는 이유 — 탭으로 포커스가 들어간 게
-   아니라 손가락/마우스로 눌러서 들어간 포커스에는 :focus-visible 이 매칭되지
-   않는다. 터치에서 뜨게 하는 게 목적이므로 :focus 여야 한다.
+   Why :focus rather than :focus-visible — focus entered by finger/mouse tap,
+   rather than by Tab, doesn't match :focus-visible. Appearing on touch is the goal, so it must be :focus.
 --------------------------------------------------------------------------- */
 .dash-tip {
   position: relative;
@@ -331,8 +331,8 @@ body {
   left: 50%;
   transform: translateX(-50%);
   z-index: 30;
-  /* max-content 라 짧은 라벨(격자 셀)은 그대로 한 줄이고, 게이지처럼 문장이 긴
-     것만 max-width 에 걸려 접힌다. nowrap 으로 고정하면 카드 밖까지 뻗는다. */
+  /* With max-content, short labels (grid cells) stay one line, and only long
+     sentences like the gauge's hit max-width and wrap. Fixing it to nowrap would stretch past the card. */
   width: max-content;
   max-width: min(220px, 60vw);
   white-space: normal;
@@ -354,8 +354,8 @@ body {
   opacity: 1;
 }
 
-/* 가장자리 칸은 가운데 정렬하면 말풍선이 카드/화면 밖으로 잘린다. 양 끝 세 칸만
-   바깥쪽 모서리에 맞춰 안쪽으로 펼친다. 로드 격자는 12열, 히트맵은 24칸이다. */
+/* Center-aligning edge cells clips the tooltip off the card/screen. For the
+   three cells at each end, align to the outer corner and open inward. The load grid is 12 columns, the heatmap 24 cells. */
 .dash-loadgrid > .dash-tip:nth-child(12n + 1)::after,
 .dash-loadgrid > .dash-tip:nth-child(12n + 2)::after,
 .dash-loadgrid > .dash-tip:nth-child(12n + 3)::after,
@@ -368,16 +368,16 @@ body {
 .dash-loadgrid > .dash-tip:nth-child(12n + 11)::after,
 .dash-loadgrid > .dash-tip:nth-child(12n + 10)::after,
 .dash-heatrow > .dash-tip:nth-last-child(-n + 3)::after,
-/* 게이지는 데스크톱 4열/모바일 2열 모두에서 짝수 번째가 오른쪽 열이다. */
+/* For gauges, the even-indexed one is the right column in both desktop (4-col) and mobile (2-col). */
 .gauge-card:nth-child(2n) .dash-tip::after {
   left: auto;
   right: 0;
   transform: none;
 }
 
-/* 탭 순서를 72개(격자 48 + 히트맵 24)로 늘리지 않으려고 셀은 tabindex="-1" 이다.
-   눌러서 들어간 포커스에 기본 아웃라인까지 그리면 툴팁과 겹쳐 지저분하므로 끈다.
-   스크린리더는 탭이 아니라 목록(role=list)으로 훑는다. */
+/* Cells are tabindex="-1" so tab order isn't grown to 72 (48 grid + 24 heatmap).
+   Drawing the default outline on tap-entered focus would overlap the tooltip and look messy, so it's turned off.
+   A screen reader scans them as a list (role=list), not via Tab. */
 .dash-tip:focus {
   outline: none;
 }
@@ -389,14 +389,15 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
-   7인치 키오스크(1024x600)
+   7-inch kiosk (1024x600)
 
-   이 패널에서는 17개 카드가 스크롤 없이 한 화면에 들어가야 한다. 배치는
-   그대로 두고 — 열 구성도 순서도 위와 같다 — 치수만 한 단계 줄인다.
+   On this panel, all 17 cards must fit on one screen without scrolling. The
+   layout stays the same — same column makeup and order as above — only the
+   dimensions drop one step.
 
-   기준 폭이 1024 가 아니라 960 인 이유: 내용이 조금이라도 넘쳐 세로
-   스크롤바가 생기면 뷰포트 폭이 1024 밑으로 떨어진다. 기준이 1024 면 그
-   순간 이 블록이 풀려 글자가 커지고 더 넘치는 되먹임이 생긴다.
+   Why the breakpoint is 960 rather than 1024: if the content overflows even
+   slightly and a vertical scrollbar appears, the viewport width drops below 1024.
+   At a 1024 breakpoint that moment would release this block, enlarging the type and overflowing further — a feedback loop.
 --------------------------------------------------------------------------- */
 @media (min-width: 960px) and (max-height: 700px) {
   .dash-layout {
@@ -449,7 +450,7 @@ body {
     margin-top: 2px;
   }
 
-  /* 코어 16개면 두 줄로 접어도 8행이다. 행 높이를 글자 크기까지 붙인다. */
+  /* 16 cores is 8 rows even folded to two columns. Pull the row height down to the type size. */
   .dash-corelist {
     gap: 1px 8px;
   }
@@ -473,7 +474,7 @@ body {
   .dash-loadgrid {
     gap: 3px;
   }
-  /* 열 폭이 넓어 정사각형을 유지하면 격자만 커진다. 높이를 고정해 납작하게. */
+  /* The column is wide, so keeping it square would only enlarge the grid. Fix the height to keep it flat. */
   .dash-loadcell {
     aspect-ratio: auto;
     height: 12px;

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -6,27 +6,27 @@ export interface Process {
   status: 'running' | 'sleeping';
 }
 
-// 온도 값 타입
+// Temperature value type
 export type TemperatureValue = number | 'N/A';
 
-// x86 아키텍처용 온도 정보
+// Temperature info for the x86 architecture
 export interface X86TemperatureInfo {
   cpu: TemperatureValue;
   gpu: TemperatureValue;
   motherboard: TemperatureValue;
 }
 
-// ARM 아키텍처용 온도 정보
+// Temperature info for the ARM architecture
 export interface ARMTemperatureInfo {
   cpu: TemperatureValue;
   rp1: TemperatureValue;
   ssd: TemperatureValue;
 }
 
-// 온도 정보 (아키텍처별)
+// Temperature info (per architecture)
 export type TemperatureInfo = X86TemperatureInfo | ARMTemperatureInfo;
 
-// 온도 정보 타입 가드
+// Temperature info type guards
 export function isX86TemperatureInfo(temp: TemperatureInfo): temp is X86TemperatureInfo {
   return 'gpu' in temp && 'motherboard' in temp;
 }
@@ -35,16 +35,16 @@ export function isARMTemperatureInfo(temp: TemperatureInfo): temp is ARMTemperat
   return 'rp1' in temp && 'ssd' in temp;
 }
 
-// 호스트 식별 정보. 헤더의 "Ubuntu 22.04 · 5.15.0" 표기와 재부팅 이력에 쓰인다.
+// Host identification. Used for the header's "Ubuntu 22.04 · 5.15.0" text and the reboot history.
 export interface HostInfo {
   hostname: string;
   os: string;
   kernel: string;
   arch: string;
   bootTime: string; // ISO 8601
-  // 마지막 재부팅이 정상 종료였는지. wtmp 를 못 읽으면 null.
+  // Whether the last reboot was a clean shutdown. null if wtmp can't be read.
   rebootReason: string | null;
-  // 가상화/컨테이너 종류(kvm/docker/lxc 등). 베어메탈이거나 감지 불가면 null.
+  // Virtualization/container kind (kvm/docker/lxc, etc.). null on bare metal or when undetectable.
   virtualization?: string | null;
 }
 
@@ -52,14 +52,15 @@ export interface LoadInfo {
   avg1: number;
   avg5: number;
   avg15: number;
-  // 지금 이 순간 실행 중이거나 실행을 기다리는 커널 엔티티 수.
-  // /proc/loadavg 4번째 필드(running/total)의 앞쪽 값으로, 부하 평균과 같은
-  // 단위의 "순간값" 이다. /proc 가 없는 OS 에서는 null.
+  // The number of kernel entities running or waiting to run right now. The
+  // value before the slash in /proc/loadavg's 4th field (running/total), an
+  // instantaneous value in the same unit as the load average. null on an OS without /proc.
   running: number | null;
-  // 커널은 1/5/15분 평균만 준다. 30분은 우리가 매초 남기는 샘플로 직접 낸다.
-  // 아직 30분이 안 찼으면 모인 만큼의 평균이고, 샘플이 없으면 null.
+  // The kernel only provides 1/5/15-minute averages. We compute the 30-minute
+  // one from the samples we record every second. If 30 minutes haven't elapsed
+  // yet it's the average of what's collected so far, and null if there are no samples.
   avg30: number | null;
-  // avg30 이 실제로 덮는 구간(초). 1800 보다 작으면 아직 창이 덜 찬 것이다.
+  // The span avg30 actually covers (seconds). Below 1800 the window isn't full yet.
   avg30WindowSeconds: number;
 }
 
@@ -88,8 +89,8 @@ export interface NetworkInterfaceInfo {
   isDefault: boolean;
 }
 
-// 대역폭 상위 피어. nf_conntrack 의 바이트 계정이 꺼져 있으면 bytes 는 null 이고
-// 연결 수(connections)만 의미가 있다.
+// Top bandwidth peers. If nf_conntrack byte accounting is off, bytes is null
+// and only the connection count is meaningful.
 export interface TrafficPeer {
   ip: string;
   bytes: number | null;
@@ -105,7 +106,7 @@ export interface SshSession {
 export interface FirewallInfo {
   status: 'active' | 'inactive' | 'unknown';
   backend: string | null;
-  // 커널 로그를 읽을 권한이 없으면 null.
+  // null if there's no permission to read the kernel log.
   blockedAttempts: number | null;
 }
 
@@ -115,8 +116,8 @@ export interface SecurityInfo {
   topTraffic: TrafficPeer[];
 }
 
-// 개별 마운트된 파일시스템의 사용량. 루트(/) 외에 데이터 볼륨이 따로 붙은
-// 서버에서도 실제 사용량을 볼 수 있게 한다.
+// Usage of an individually mounted filesystem. Lets servers with a separate
+// data volume besides root (/) see their real usage too.
 export interface DiskMount {
   mount: string;
   used: number; // GB
@@ -124,19 +125,19 @@ export interface DiskMount {
   percentage: number;
 }
 
-// 배터리/UPS 상태. Pi·노트북·UPS 연결 서버에 유의미하고, 없으면 null.
+// Battery/UPS status. Meaningful on Pi/laptop/UPS-connected servers, null otherwise.
 export interface BatteryInfo {
   percentage: number;
   status: string; // Charging / Discharging / Full / Not charging / Unknown
 }
 
-// 전체 프로세스 요약. top 목록(상위 20)과 달리 시스템 전체 규모를 센다.
+// Whole-process summary. Unlike the top list (top 20), it counts the whole system.
 export interface ProcessSummary {
   total: number;
   running: number;
   sleeping: number;
   zombie: number;
-  // 스레드 포함 전체 태스크 수. /proc/loadavg 로 얻으며 없으면 null.
+  // Total task count including threads. Obtained from /proc/loadavg, null if unavailable.
   threads: number | null;
 }
 
@@ -149,22 +150,23 @@ export interface AlertEntry {
   at: string; // ISO 8601
 }
 
-// 히스토리는 프로세스 메모리에 쌓이고 data/history.json 으로 영속화된다. 재시작해도
-// 복구되지만, 서버가 꺼져 있던 구간은 값이 없어 UI 가 "수집 중" 으로 표시한다.
+// History accumulates in process memory and is persisted to data/history.json.
+// It recovers across restarts, but a stretch when the server was down has no
+// value, which the UI shows as "collecting".
 export interface LoadSample {
-  at: string; // ISO 8601, 1시간 버킷의 시작
-  // 서버가 그 시간대에 켜져 있지 않았으면 null.
+  at: string; // ISO 8601, start of the 1-hour bucket
+  // null if the server wasn't up during that hour.
   avg1: number | null;
 }
 
 export interface CpuHourSample {
-  at: string; // ISO 8601, 정시 버킷의 시작
+  at: string; // ISO 8601, start of the on-the-hour bucket
   usage: number | null;
 }
 
 export interface HistoryInfo {
-  load: LoadSample[]; // 최근 48시간, 1시간 버킷
-  cpuHourly: CpuHourSample[]; // 최근 24시간, 1시간 버킷
+  load: LoadSample[]; // last 48 hours, 1-hour buckets
+  cpuHourly: CpuHourSample[]; // last 24 hours, 1-hour buckets
 }
 
 export interface ServerData {
@@ -172,9 +174,9 @@ export interface ServerData {
     usage: number;
     cores: number;
     temperature: TemperatureValue;
-    // 코어별 사용률. /proc/stat 를 못 읽으면 빈 배열.
+    // Per-core usage. Empty array if /proc/stat can't be read.
     perCore?: number[];
-    // 아래는 선택적(구버전 노드 호환). iowait/steal 은 %, frequencyMhz 는 평균 MHz.
+    // The following are optional (old-node compatible). iowait/steal are %, frequencyMhz is average MHz.
     iowait?: number;
     steal?: number;
     frequencyMhz?: number | 'N/A';
@@ -188,10 +190,10 @@ export interface ServerData {
     used: number;
     total: number;
     percentage: number;
-    // 최근 추세로 추정한 100% 도달까지 남은 시간(시간). 채워지는 중이 아니면 null.
+    // Estimated hours until 100% based on the recent trend. null when not filling.
     hoursToFull?: number | null;
   };
-  // 루트 외 마운트를 포함한 전체 파일시스템 목록(선택적: 구버전 노드 호환).
+  // Full filesystem list including non-root mounts (optional: old-node compatible).
   disks?: DiskMount[];
   network: {
     download: number;
@@ -206,7 +208,7 @@ export interface ServerData {
     interfaces?: NetworkInterfaceInfo[];
     linkSpeedMbps?: number | null;
     bandwidthPercentage?: number;
-    // 부팅 이후 누적 바이트(선택적: 구버전 노드 호환).
+    // Cumulative bytes since boot (optional: old-node compatible).
     totalRxBytes?: number;
     totalTxBytes?: number;
   };
@@ -222,23 +224,23 @@ export interface ServerData {
     case2: number;
   };
   processes: Process[];
-  // 아래 필드들은 1.3 에서 추가됐다. 구버전을 돌리는 클러스터 노드도 같은
-  // 대시보드로 읽을 수 있어야 하므로 전부 optional 이다.
+  // The fields below were added in 1.3. Cluster nodes running older versions
+  // must still be readable by the same dashboard, so all are optional.
   host?: HostInfo;
   load?: LoadInfo;
   swap?: SwapInfo;
   diskIO?: DiskIoInfo;
   gpu?: GpuInfo;
   security?: SecurityInfo;
-  // 전체 프로세스 요약 / 메모리 상위 프로세스 / 배터리(선택적: 구버전 노드 호환).
+  // Whole-process summary / memory-top processes / battery (optional: old-node compatible).
   processSummary?: ProcessSummary;
   topProcessesByMemory?: Process[];
   battery?: BatteryInfo | null;
   history?: HistoryInfo;
   alerts?: AlertEntry[];
   timestamp?: string;
-  // 일부 수집기만 실패했을 때 어떤 지표가 왜 비었는지 알려준다.
-  // 헤드리스 서버에서 `curl localhost:3000/api/system` 만으로 진단할 수 있게 하는 용도.
+  // When only some collectors fail, tells you which metric is empty and why.
+  // Lets you diagnose a headless server with just `curl localhost:3000/api/system`.
   warnings?: string[];
 }
 

--- a/src/utils/collectors/alerts.test.ts
+++ b/src/utils/collectors/alerts.test.ts
@@ -6,9 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AlertInput } from '@/utils/collectors/alerts';
 
-// alerts 는 모듈 스코프에 활성 룰/로그/known 상태를 들고 있어 테스트마다 새로
-// 불러온다. 저장 파일도 임시 디렉터리로 격리한다. 웹훅 호출은 fetch 를 목으로
-// 잡아 호출 횟수만 센다(실제 네트워크로 나가지 않게).
+// alerts holds active-rule/log/known state in module scope, so it's reimported
+// per test. The store file is also isolated to a temp directory. Webhook calls
+// are mocked via fetch to count invocations only (so nothing goes to the real network).
 async function freshAlerts(env: Record<string, string> = {}) {
   vi.resetModules();
   const dir = mkdtempSync(join(tmpdir(), 'alerts-test-'));
@@ -55,43 +55,43 @@ describe('evaluateAlerts', () => {
     ENV_KEYS.forEach(key => delete process.env[key]);
   });
 
-  it('임계값을 넘으면 알림을 남기고, 히스테리시스로 내려오면 해제한다', async () => {
+  it('records an alert when a threshold is crossed and clears it on hysteresis', async () => {
     const { evaluateAlerts } = await freshAlerts();
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
-    // 첫 평가는 정상값 — 아무 알림도 없다(이후 전이를 첫 로그인처럼 쏟지 않기 위함).
+    // The first evaluation is a normal value — no alerts (so later transitions aren't dumped like a first login).
     expect(evaluateAlerts(baseInput(), t0)).toHaveLength(0);
 
-    // CPU 가 90 을 넘으면 warning 이 쌓인다.
+    // When CPU crosses 90 a warning accumulates.
     const entered = evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
     expect(entered[0].message).toContain('CPU usage 95%');
     expect(entered[0].level).toBe('warning');
 
-    // 85(=clearBelow 80 보다 큼)에서는 아직 해제되지 않는다.
+    // At 85 (> clearBelow 80) it isn't cleared yet.
     const held = evaluateAlerts(baseInput({ cpu: 85 }), t0 + 2000);
     expect(held.find(e => e.message.includes('back to normal'))).toBeUndefined();
 
-    // 80 아래로 내려오면 해제 로그.
+    // Below 80 it logs a clear.
     const cleared = evaluateAlerts(baseInput({ cpu: 70 }), t0 + 3000);
     expect(cleared[0].message).toContain('CPU usage back to normal');
     expect(cleared[0].level).toBe('ok');
   });
 
-  it('첫 평가에서 이미 임계 상태면 로그엔 남기되 웹훅은 보내지 않는다', async () => {
+  it('on the first evaluation, an already-breached value is logged but not webhooked', async () => {
     const { evaluateAlerts, fetchMock } = await freshAlerts();
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
     const first = evaluateAlerts(baseInput({ cpu: 99 }), t0);
     expect(first[0].message).toContain('CPU usage 99%');
-    // 부팅 직후 이미 임계였던 값은 외부로 쏟지 않는다.
+    // A value already breached right after boot is not pushed out.
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('전이가 생기면 웹훅으로 통지한다', async () => {
+  it('notifies via webhook when a transition occurs', async () => {
     const { evaluateAlerts, fetchMock } = await freshAlerts();
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
-    evaluateAlerts(baseInput(), t0); // 첫 평가 소진
+    evaluateAlerts(baseInput(), t0); // consume the first evaluation
     evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -100,23 +100,23 @@ describe('evaluateAlerts', () => {
     expect(JSON.parse(options.body as string).message).toContain('CPU usage 95%');
   });
 
-  it('새 SSH 세션은 통지하고, 이미 있던 세션은 통지하지 않는다', async () => {
+  it('notifies on a new SSH session but not on an already-present one', async () => {
     const { evaluateAlerts, fetchMock } = await freshAlerts();
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
     const existing = { user: 'root', ip: '10.0.0.1', since: new Date(t0).toISOString() };
-    // 첫 평가: 이미 붙어 있던 세션은 조용히 기억만.
+    // First evaluation: quietly remember the already-attached session.
     evaluateAlerts(baseInput({ sshSessions: [existing] }), t0);
     expect(fetchMock).not.toHaveBeenCalled();
 
-    // 새 세션 등장 → info 알림 + 통지.
+    // A new session appears -> info alert + notify.
     const newSession = { user: 'deploy', ip: '10.0.0.2', since: new Date(t0 + 1000).toISOString() };
     const log = evaluateAlerts(baseInput({ sshSessions: [existing, newSession] }), t0 + 1000);
     expect(log[0].message).toBe('SSH login: deploy@10.0.0.2');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('인터페이스 다운/복구 전이를 기록한다', async () => {
+  it('records interface down/recovery transitions', async () => {
     const { evaluateAlerts } = await freshAlerts();
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
@@ -129,31 +129,31 @@ describe('evaluateAlerts', () => {
     expect(up[0].message).toBe('Interface eth0 back up');
   });
 
-  it('임계값을 환경변수로 덮어쓸 수 있다', async () => {
+  it('lets thresholds be overridden by environment variables', async () => {
     const { evaluateAlerts } = await freshAlerts({ ALERT_CPU_ENTER: '50', ALERT_CPU_CLEAR: '40' });
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
     evaluateAlerts(baseInput(), t0);
-    // 기본값이면 60 은 임계가 아니지만, ENTER=50 이므로 알림이 뜬다.
+    // With defaults 60 isn't a breach, but with ENTER=50 an alert fires.
     const entered = evaluateAlerts(baseInput({ cpu: 60 }), t0 + 1000);
     expect(entered[0].message).toContain('CPU usage 60%');
   });
 
-  it('알림 로그를 디스크에 남기고 재시작 후 복구한다', async () => {
+  it('persists the alert log to disk and recovers after a restart', async () => {
     const first = await freshAlerts();
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
 
     first.evaluateAlerts(baseInput(), t0);
     first.evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000);
 
-    // 예약 저장을 기다리지 않고 종료 경로와 같은 동기 저장을 태운다.
+    // Trigger the same synchronous save as the shutdown path instead of waiting for the scheduled save.
     process.emit('SIGTERM');
 
     vi.resetModules();
     process.env.DATA_DIR = first.dir;
     process.env.ALERTS_FILE = first.file;
     const second = await import('@/utils/collectors/alerts');
-    // 복구된 로그가 이전 CPU 알림을 포함해야 한다. 정상값으로 한 번 평가해도 유지.
+    // The recovered log must contain the earlier CPU alert. It persists even after one normal-value evaluation.
     const log = second.evaluateAlerts(baseInput(), t0 + 2000);
     expect(log.some(e => e.message.includes('CPU usage 95%'))).toBe(true);
   });

--- a/src/utils/collectors/alerts.ts
+++ b/src/utils/collectors/alerts.ts
@@ -6,8 +6,9 @@ import { dispatchAlert } from '@/utils/collectors/notify';
 
 const MAX_ENTRIES = 30;
 
-// 임계값은 환경변수로 덮어쓸 수 있게 한다. 미설정이면 아래 기본값을 쓴다 —
-// 소스를 고치지 않고도 운영자가 호스트 특성에 맞춰 조정할 수 있어야 한다.
+// Thresholds can be overridden by environment variables. Unset uses the
+// defaults below — an operator should be able to tune them to a host's
+// characteristics without editing the source.
 function num(key: string, fallback: number): number {
   const raw = process.env[key];
   if (raw === undefined || raw.trim() === '') return fallback;
@@ -15,8 +16,8 @@ function num(key: string, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
 }
 
-// 임계값을 넘나드는 값 때문에 로그가 도배되지 않도록, 켜지는 값과 꺼지는 값을
-// 다르게 둔다(히스테리시스).
+// To keep a value hovering around the threshold from flooding the log, the
+// enter value and clear value differ (hysteresis).
 interface Rule {
   key: string;
   level: AlertLevel;
@@ -69,8 +70,9 @@ const RULES: Rule[] = [
   }
 ];
 
-// 임계 상태가 지속될 때 다시 통지할 간격(분). 0(기본)이면 재통지하지 않는다.
-// 화면 로그는 도배하지 않고, 외부 웹훅으로만 재통지한다.
+// How often (minutes) to re-notify while a breach persists. 0 (default)
+// disables re-notification. This never floods the on-screen log — it re-notifies
+// via the external webhook only.
 const RENOTIFY_MS = num('ALERT_RENOTIFY_MINUTES', 0) * 60 * 1000;
 
 const active = new Set<string>();
@@ -79,12 +81,13 @@ let knownSessions: Set<string> | null = null;
 let knownFirewall: FirewallInfo['status'] | null = null;
 let knownIfaceDown: Set<string> | null = null;
 let sequence = 0;
-// 룰별 마지막 외부 통지 시각. 재통지 쿨다운 판단에 쓴다.
+// Per-rule last external-notify time. Used for the re-notify cooldown.
 const lastNotifiedAt = new Map<string, number>();
 
-// --- 디스크 영속화 -------------------------------------------------------
-// 알림 로그는 지금까지 프로세스 메모리에만 있어 재시작하면 사라졌다. history.json
-// 과 같은 방식으로 data/alerts.json 에 남겨, 배포/크래시 후에도 최근 알림이 유지된다.
+// --- Disk persistence ----------------------------------------------------
+// Until now the alert log lived only in process memory and was lost on restart.
+// Persist it to data/alerts.json the same way as history.json, so recent alerts
+// survive a redeploy/crash.
 const DATA_DIR = process.env.DATA_DIR || path.join(/*turbopackIgnore: true*/ process.cwd(), 'data');
 const STORE_FILE = process.env.ALERTS_FILE || path.join(DATA_DIR, 'alerts.json');
 const STORE_VERSION = 1;
@@ -102,11 +105,11 @@ function ensureLoaded(): void {
     const raw = fs.readFileSync(/*turbopackIgnore: true*/ STORE_FILE, 'utf-8');
     const parsed = JSON.parse(raw) as StoreShape;
     if (parsed && parsed.v === STORE_VERSION && Array.isArray(parsed.log)) {
-      // 최신순으로 저장돼 있으므로 그대로 복원하되 상한을 지킨다.
+      // Stored newest-first, so restore as-is but honor the cap.
       for (const entry of parsed.log.slice(0, MAX_ENTRIES)) log.push(entry);
     }
   } catch {
-    // 파일이 없거나(첫 실행) 읽을 수 없으면 빈 상태로 시작한다.
+    // If the file is missing (first run) or unreadable, start empty.
   }
 }
 
@@ -124,7 +127,7 @@ async function writeStore(): Promise<void> {
     await fs.promises.writeFile(tmp, JSON.stringify(payload), 'utf-8');
     await fs.promises.rename(tmp, STORE_FILE);
   } catch {
-    // 디스크 쓰기 실패는 치명적이지 않다. 다음 저장에서 다시 시도한다.
+    // A disk write failure is not fatal. Retry on the next save.
   } finally {
     writing = false;
   }
@@ -139,15 +142,15 @@ function scheduleSave(): void {
   if (typeof saveTimer.unref === 'function') saveTimer.unref();
 }
 
-// 종료 신호에 마지막 상태를 동기로 한 번 더 남긴다. 예약 저장이 아직 안 돌았어도
-// 최근 알림을 잃지 않는다(history.ts 와 같은 방식).
+// On a shutdown signal, write the final state synchronously once more. Even if
+// the scheduled save hasn't run yet, recent alerts aren't lost (same as history.ts).
 function flushSync(): void {
   try {
     const payload: StoreShape = { v: STORE_VERSION, log };
     fs.mkdirSync(DATA_DIR, { recursive: true });
     fs.writeFileSync(STORE_FILE, JSON.stringify(payload), 'utf-8');
   } catch {
-    // 종료 중 실패는 삼킨다.
+    // Swallow failures during shutdown.
   }
 }
 
@@ -160,11 +163,12 @@ function hookExit(): void {
   process.once('beforeExit', () => flushSync());
 }
 
-// --- 로그/통지 -----------------------------------------------------------
+// --- Log / notify --------------------------------------------------------
 
-// firstEvaluation: 프로세스가 막 떠서 처음 평가하는 순간에는, 이미 임계 상태이거나
-// 이미 붙어 있던 SSH/방화벽 상태를 "방금 일어난 일"처럼 외부로 쏟아내지 않는다.
-// 화면 로그에는 남기되(운영자가 현재 상태를 알 수 있게) 웹훅 통지는 건너뛴다.
+// firstEvaluation: at the very first evaluation right after the process starts,
+// an already-breached value or already-attached SSH/firewall state isn't pushed
+// out as if it "just happened". It's still written to the on-screen log (so the
+// operator sees the current state) but the webhook notify is skipped.
 function push(level: AlertLevel, message: string, at: number, notify: boolean): void {
   sequence += 1;
   const entry: AlertEntry = { id: `${at}-${sequence}`, level, message, at: new Date(at).toISOString() };
@@ -183,7 +187,7 @@ export interface AlertInput {
   temperature: TemperatureValue;
   firewall: FirewallInfo['status'];
   sshSessions: SshSession[];
-  // 인터페이스 다운 감지용. 이름과 상태만 있으면 된다(선택적: 구버전 입력 호환).
+  // For interface-down detection. Only the name and state are needed (optional: old-input compatible).
   interfaces?: { name: string; state: 'up' | 'down' | 'unknown' }[];
 }
 
@@ -213,7 +217,7 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
       lastNotifiedAt.delete(rule.key);
       push('ok', rule.onClear(value), at, !firstEvaluation);
     } else if (active.has(rule.key) && RENOTIFY_MS > 0) {
-      // 임계 상태가 지속되면 재통지(외부 웹훅만, 화면 로그는 도배하지 않는다).
+      // While the breach persists, re-notify (external webhook only, doesn't flood the on-screen log).
       const last = lastNotifiedAt.get(rule.key) ?? 0;
       if (at - last >= RENOTIFY_MS) {
         lastNotifiedAt.set(rule.key, at);
@@ -227,10 +231,11 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
     }
   }
 
-  // 새로 생긴 SSH 세션만 기록한다. 첫 평가에서는 이미 붙어 있던 세션을
-  // 방금 로그인한 것처럼 쏟아내지 않도록 조용히 기억만 해둔다.
-  // 키는 user@ip 로만 잡는다. `since` 를 넣으면 타임스탬프가 조금만 흔들려도
-  // 같은 세션이 새 로그인처럼 반복 기록되므로(도배) 세션 지속 동안은 한 번만 남긴다.
+  // Record only newly appeared SSH sessions. On the first evaluation, quietly
+  // remember the already-attached sessions instead of dumping them as fresh
+  // logins. The key is user@ip only. Including `since` would make the same
+  // session reprint as a new login whenever the timestamp jitters slightly
+  // (spam), so record it once for the life of the session.
   const sessionKeys = new Set(input.sshSessions.map(s => `${s.user}@${s.ip}`));
   if (knownSessions === null) {
     knownSessions = sessionKeys;
@@ -242,7 +247,7 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
     knownSessions = sessionKeys;
   }
 
-  // 인터페이스 다운 전이. up→down 은 경고, down→up 은 해제로 남긴다.
+  // Interface-down transitions. up->down is a warning, down->up is a clear.
   if (input.interfaces) {
     const downNow = new Set(input.interfaces.filter(i => i.state === 'down').map(i => i.name));
     if (knownIfaceDown === null) {
@@ -257,7 +262,7 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
       knownIfaceDown = downNow;
     }
   } else if (knownIfaceDown === null) {
-    // 인터페이스 정보가 아직 없으면 첫 평가 플래그만 소진되지 않도록 빈 집합으로 초기화.
+    // If interface info isn't available yet, initialize to an empty set so the first-evaluation flag isn't left unconsumed.
     knownIfaceDown = new Set();
   }
 

--- a/src/utils/collectors/battery.ts
+++ b/src/utils/collectors/battery.ts
@@ -3,18 +3,19 @@ import { readdir } from 'fs/promises';
 import { BatteryInfo } from '@/types/system';
 import { readSys, withTtl } from '@/utils/collectors/shell';
 
-// /sys/class/power_supply 의 배터리/UPS 를 읽는다. 라즈베리파이 UPS HAT,
-// 노트북, USB UPS 등에서 채워지고, 없으면(대부분의 서버) null 이라 대시보드는
-// N/A 로 남긴다. 충전율은 급히 변하지 않으니 조금 캐시한다.
+// Reads the battery/UPS under /sys/class/power_supply. Populated on Raspberry
+// Pi UPS HATs, laptops, USB UPSes, etc.; absent on most servers, where it
+// stays null so the dashboard shows N/A. The charge level changes slowly, so
+// cache it a little.
 //
-// 전원 공급 장치는 Battery/UPS 외에 Mains(AC 어댑터)도 있어, type 이 Battery 이거나
-// capacity 를 노출하는 것만 배터리로 취급한다.
+// Besides Battery/UPS the power-supply class also has Mains (AC adapters), so
+// only treat entries whose type is Battery or that expose a capacity as batteries.
 export const getBatteryInfo = withTtl(15_000, async (): Promise<BatteryInfo | null> => {
   let entries: string[];
   try {
     entries = await readdir('/sys/class/power_supply');
   } catch {
-    return null; // 리눅스 아님 또는 전원 클래스 없음
+    return null; // not Linux, or no power-supply class
   }
 
   for (const name of entries) {

--- a/src/utils/collectors/cpu.ts
+++ b/src/utils/collectors/cpu.ts
@@ -12,19 +12,20 @@ interface CpuTimes {
 export interface CpuUsage {
   total: number;
   perCore: number[];
-  // I/O 대기 비율: 디스크 병목 신호. steal: 하이퍼바이저에 뺏긴 시간으로 VPS
-  // 과판매 신호. /proc/stat 를 못 읽는 OS 에서는 각각 0/무의미.
+  // iowait: I/O wait ratio, a disk-bottleneck signal. steal: time taken by the
+  // hypervisor, a VPS-oversubscription signal. On an OS without /proc/stat both
+  // are 0/meaningless.
   iowait: number;
   steal: number;
-  // 논리 코어들의 현재 클럭 평균(MHz). cpufreq 가 없으면 'N/A'.
+  // Average current clock of the logical cores (MHz). 'N/A' when cpufreq is absent.
   frequencyMhz: number | 'N/A';
 }
 
-// `top -bn1` 의 첫 샘플은 부팅 이후 누적 평균이라 항상 0에 가깝게 나온다.
-// /proc/stat 를 두 번 읽어 그 사이의 변화량으로 계산한다.
+// The first `top -bn1` sample is the average since boot, so it's always near 0.
+// Read /proc/stat twice and compute from the delta between them.
 let previousSample: { total: CpuTimes; perCore: CpuTimes[] } | null = null;
 
-// /proc/stat cpu 필드: user nice system idle iowait irq softirq steal ...
+// /proc/stat cpu fields: user nice system idle iowait irq softirq steal ...
 function parseCpuLine(line: string): CpuTimes {
   const values = line.trim().split(/\s+/).slice(1).map(Number);
   if (values.length < 4 || values.some(Number.isNaN)) {
@@ -34,15 +35,16 @@ function parseCpuLine(line: string): CpuTimes {
   const iowait = values[4] ?? 0;
   const steal = values[7] ?? 0;
   return {
-    idle: values[3] + iowait, // idle + iowait 는 "일 안 한 시간"
+    idle: values[3] + iowait, // idle + iowait is "time not working"
     iowait,
     steal,
     total: values.reduce((sum, value) => sum + value, 0)
   };
 }
 
-// 각 코어의 현재 동작 주파수(kHz)를 평균내 MHz 로 돌려준다. cpufreq 거버너가
-// 없는 환경(가상화 등)에서는 파일이 없어 'N/A'.
+// Averages each core's current operating frequency (kHz) and returns it in MHz.
+// On an environment without a cpufreq governor (virtualization, etc.) the file
+// is missing, so 'N/A'.
 async function readFrequencyMhz(): Promise<number | 'N/A'> {
   let cpus: string[];
   try {
@@ -73,7 +75,7 @@ async function readCpuStat(): Promise<{ total: CpuTimes; perCore: CpuTimes[] }> 
   const aggregate = lines.find(line => line.startsWith('cpu '));
   if (!aggregate) throw new Error('no "cpu" line in /proc/stat');
 
-  // cpu0, cpu1, ... 은 논리 코어 순서대로 나온다.
+  // cpu0, cpu1, ... come out in logical-core order.
   const perCore = lines.filter(line => /^cpu\d+ /.test(line)).map(parseCpuLine);
   return { total: parseCpuLine(aggregate), perCore };
 }
@@ -88,7 +90,7 @@ function usageBetween(previous: CpuTimes, current: CpuTimes): number {
 export async function getCpuUsage(): Promise<CpuUsage> {
   let previous = previousSample;
 
-  // 첫 호출이면 짧게 두 번 재서 0% 를 반환하지 않도록 한다.
+  // On the first call, take two quick samples so we don't return 0%.
   if (!previous) {
     previous = await readCpuStat();
     await new Promise(resolve => setTimeout(resolve, 200));
@@ -97,13 +99,13 @@ export async function getCpuUsage(): Promise<CpuUsage> {
   const [current, frequencyMhz] = await Promise.all([readCpuStat(), readFrequencyMhz()]);
   previousSample = current;
 
-  // 코어가 오프라인이 되면 개수가 달라질 수 있으므로 짧은 쪽에 맞춘다.
+  // The core count can change if a core goes offline, so use the shorter one.
   const coreCount = Math.min(previous.perCore.length, current.perCore.length);
   const perCore = Array.from({ length: coreCount }, (_, index) =>
     usageBetween(previous.perCore[index], current.perCore[index])
   );
 
-  // iowait/steal 은 전체 시간 대비 비율(%)로. 델타가 0이면(첫 샘플 등) 0.
+  // iowait/steal as a ratio (%) of total time. If the delta is 0 (first sample, etc.), 0.
   const totalDelta = current.total.total - previous.total.total;
   const share = (deltaField: number) =>
     totalDelta > 0 ? round(clamp((deltaField / totalDelta) * 100, 0, 100), 1) : 0;

--- a/src/utils/collectors/df.test.ts
+++ b/src/utils/collectors/df.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { parseDf } from '@/utils/collectors/df';
 
-// `df -Pk` 출력 예시. 헤더 + 실 블록 장치 + 의사 파일시스템이 섞여 있다.
+// Example `df -Pk` output. Header + real block devices + pseudo filesystems mixed together.
 const SAMPLE = `Filesystem     1024-blocks      Used  Available Capacity Mounted on
 udev              8123456         0    8123456       0% /dev
 tmpfs             1638400      2048    1636352       1% /run
@@ -12,7 +12,7 @@ overlay          50000000  25000000   25000000      50% /var/lib/docker/overlay2
 /dev/sda1        50000000  25000000   25000000      50% /`;
 
 describe('parseDf', () => {
-  it('실 블록 장치(/dev/*)만 남기고 의사 파일시스템은 버린다', () => {
+  it('keeps only real block devices (/dev/*) and drops pseudo filesystems', () => {
     const disks = parseDf(SAMPLE);
     const mounts = disks.map(d => d.mount);
     expect(mounts).toContain('/');
@@ -22,12 +22,12 @@ describe('parseDf', () => {
     expect(mounts.some(m => m.includes('overlay'))).toBe(false);
   });
 
-  it('중복 마운트는 한 번만 센다', () => {
+  it('counts a duplicate mount only once', () => {
     const roots = parseDf(SAMPLE).filter(d => d.mount === '/');
     expect(roots).toHaveLength(1);
   });
 
-  it('루트를 맨 앞에 두고 GB/퍼센트를 계산한다', () => {
+  it('puts root first and computes GB/percentage', () => {
     const disks = parseDf(SAMPLE);
     expect(disks[0].mount).toBe('/');
     expect(disks[0].percentage).toBe(50);
@@ -35,7 +35,7 @@ describe('parseDf', () => {
     expect(disks[0].total).toBeCloseTo(47.68, 1);
   });
 
-  it('빈/깨진 출력에도 죽지 않는다', () => {
+  it('does not crash on empty/broken output', () => {
     expect(parseDf('')).toEqual([]);
     expect(parseDf('garbage header only')).toEqual([]);
   });

--- a/src/utils/collectors/df.ts
+++ b/src/utils/collectors/df.ts
@@ -1,16 +1,18 @@
 import { DiskMount } from '@/types/system';
 import { round } from '@/utils/collectors/shell';
 
-// `df -Pk` 한 번으로 모든 마운트를 읽어, 루트(/) 외에 데이터 볼륨이 따로 붙은
-// 서버에서도 실제 사용량을 볼 수 있게 한다. 파싱은 순수 함수로 떼어 테스트한다.
+// A single `df -Pk` reads every mount, so servers with a separate data volume
+// besides root (/) can see their real usage too. The parsing is split into a
+// pure function so it can be tested.
 //
-// 실 블록 장치(첫 컬럼이 /dev/ 로 시작)만 남긴다. tmpfs/devtmpfs/overlay/proc
-// 같은 의사 파일시스템은 사용량이 의미가 없거나 중복 집계되므로 버린다.
+// Keep only real block devices (first column starts with /dev/). Pseudo
+// filesystems like tmpfs/devtmpfs/overlay/proc have meaningless or
+// double-counted usage, so drop them.
 
 const toGb = (kb: number) => round(kb / 1024 / 1024);
 
 export function parseDf(stdout: string): DiskMount[] {
-  const lines = stdout.split('\n').slice(1); // 헤더 제거
+  const lines = stdout.split('\n').slice(1); // drop the header
   const byMount = new Map<string, DiskMount>();
 
   for (const raw of lines) {
@@ -27,12 +29,12 @@ export function parseDf(stdout: string): DiskMount[] {
     const totalKb = parseInt(parts[1], 10);
     const usedKb = parseInt(parts[2], 10);
     const capacity = parseInt(parts[4].replace('%', ''), 10);
-    // 마운트 경로에 공백이 들어갈 수 있어 6번째 이후를 다시 합친다.
+    // A mount path can contain spaces, so rejoin from the 6th field onward.
     const mount = parts.slice(5).join(' ');
 
     if (Number.isNaN(totalKb) || Number.isNaN(usedKb) || totalKb <= 0) continue;
 
-    // bind 마운트 등으로 같은 장치가 여러 번 나오면 첫(대개 최상위) 것만 쓴다.
+    // If the same device appears twice (bind mounts, etc.) keep only the first (usually top-level) one.
     if (byMount.has(mount)) continue;
 
     byMount.set(mount, {
@@ -43,7 +45,7 @@ export function parseDf(stdout: string): DiskMount[] {
     });
   }
 
-  // 루트를 맨 앞에, 나머지는 사용률 높은 순으로.
+  // Root first, then the rest by descending usage.
   return [...byMount.values()].sort((a, b) => {
     if (a.mount === '/') return -1;
     if (b.mount === '/') return 1;

--- a/src/utils/collectors/diskTrend.test.ts
+++ b/src/utils/collectors/diskTrend.test.ts
@@ -5,9 +5,9 @@ import { predictHoursToFull } from '@/utils/collectors/diskTrend';
 const HOUR = 3_600_000;
 
 describe('predictHoursToFull', () => {
-  it('일정하게 차오르면 남은 시간을 추정한다', () => {
+  it('estimates the time left when it fills steadily', () => {
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
-    // 4시간 동안 80% → 84% (시간당 1%p). 남은 16%p → 16시간.
+    // 80% -> 84% over 4 hours (1%p/hour). 16%p left -> 16 hours.
     const samples = [
       { at: now - 4 * HOUR, percent: 80 },
       { at: now, percent: 84 }
@@ -15,7 +15,7 @@ describe('predictHoursToFull', () => {
     expect(predictHoursToFull(samples, now)).toBe(16);
   });
 
-  it('정체/감소 중이면 예측하지 않는다', () => {
+  it('does not forecast when flat/shrinking', () => {
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
     expect(
       predictHoursToFull(
@@ -37,12 +37,12 @@ describe('predictHoursToFull', () => {
     ).toBeNull();
   });
 
-  it('샘플이 하나뿐이면 예측할 수 없다', () => {
+  it('cannot forecast with only one sample', () => {
     const now = Date.now();
     expect(predictHoursToFull([{ at: now, percent: 90 }], now)).toBeNull();
   });
 
-  it('이미 가득 찼으면 0을 준다', () => {
+  it('returns 0 when already full', () => {
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
     const samples = [
       { at: now - 2 * HOUR, percent: 99 },

--- a/src/utils/collectors/diskTrend.ts
+++ b/src/utils/collectors/diskTrend.ts
@@ -1,15 +1,17 @@
-// 루트 디스크 사용률의 최근 추세로 "이 속도면 언제 가득 차는가" 를 추정한다.
-// 히스토리 버킷(load/cpu)과 달리 라이브 추정이라 디스크에 남기지 않는다 —
-// 재시작하면 창이 다시 차오른다. 예측이 목적이라 그걸로 충분하다.
+// Estimates "at this rate, when does it fill?" from the recent trend of root
+// disk usage. Unlike the history buckets (load/cpu) this is a live estimate,
+// so it is not persisted to disk — the window refills after a restart. That is
+// enough for a forecast.
 
 export interface DiskSample {
   at: number;
   percent: number;
 }
 
-// 창 안의 첫/끝 샘플로 선형 증가율을 내, 100% 까지 남은 시간을 시간 단위로 준다.
-// 채워질 만큼 오르고 있지 않으면(감소/정체) null — "곧 가득 참" 이 아닐 때 숫자를
-// 억지로 만들지 않는다.
+// Derive a linear growth rate from the first/last sample in the window and
+// return the hours left until 100%. If it isn't rising enough to fill
+// (shrinking/flat) return null — don't invent a number when "filling soon"
+// isn't true.
 export function predictHoursToFull(samples: DiskSample[], at: number): number | null {
   if (samples.length < 2) return null;
 
@@ -19,7 +21,7 @@ export function predictHoursToFull(samples: DiskSample[], at: number): number | 
   if (spanHours <= 0) return null;
 
   const ratePerHour = (last.percent - first.percent) / spanHours;
-  // 시간당 0.1%p 미만 증가는 노이즈로 보고 예측하지 않는다(먼 미래의 헛수).
+  // Treat growth below 0.1%p/hour as noise and don't forecast (a pointless far future).
   if (ratePerHour < 0.1) return null;
 
   const remaining = 100 - last.percent;
@@ -29,7 +31,7 @@ export function predictHoursToFull(samples: DiskSample[], at: number): number | 
   return Math.round((remaining / ratePerHour) * 10) / 10;
 }
 
-const WINDOW_MS = 6 * 60 * 60 * 1000; // 최근 6시간의 추세만 본다
+const WINDOW_MS = 6 * 60 * 60 * 1000; // only the last 6 hours of trend
 const samples: DiskSample[] = [];
 
 export function recordDiskSample(percent: number, at: number = Date.now()): void {

--- a/src/utils/collectors/diskio.ts
+++ b/src/utils/collectors/diskio.ts
@@ -3,10 +3,10 @@ import { readFile } from 'fs/promises';
 import { DiskIoInfo } from '@/types/system';
 import { round } from '@/utils/collectors/shell';
 
-// 파티션(sda1, nvme0n1p2)까지 세면 같은 I/O 를 두 번 더하게 된다. 전체 디스크만 센다.
+// Counting partitions (sda1, nvme0n1p2) too would double-count the same I/O. Count whole disks only.
 const WHOLE_DISK_PATTERN = /^(sd[a-z]+|nvme\d+n\d+|mmcblk\d+|vd[a-z]+|xvd[a-z]+|hd[a-z]+)$/;
 
-// /proc/diskstats 의 섹터는 장치의 물리 섹터 크기와 무관하게 항상 512 바이트다.
+// A /proc/diskstats sector is always 512 bytes, regardless of the device's physical sector size.
 const SECTOR_BYTES = 512;
 
 let previousSample: { read: number; write: number; at: number } | null = null;
@@ -44,7 +44,7 @@ export async function getDiskIo(): Promise<DiskIoInfo> {
   const previous = previousSample;
   previousSample = { ...totals, at: now };
 
-  // 첫 샘플은 비교 대상이 없다. 누적 바이트를 그대로 쓰면 수백 MB/s 로 보인다.
+  // The first sample has nothing to compare against. Using cumulative bytes as-is would look like hundreds of MB/s.
   if (!previous) return { read: 0, write: 0 };
 
   const elapsedSeconds = (now - previous.at) / 1000;

--- a/src/utils/collectors/gpu.ts
+++ b/src/utils/collectors/gpu.ts
@@ -5,7 +5,7 @@ import { clamp, readSys, round, run, withTtl } from '@/utils/collectors/shell';
 
 const UNAVAILABLE: GpuInfo = { name: null, usage: 'N/A', temperature: 'N/A' };
 
-// amdgpu 는 사용률을 sysfs 로 그대로 노출한다. 외부 명령이 필요 없다.
+// amdgpu exposes utilization directly via sysfs. No external command needed.
 async function readAmdGpu(): Promise<GpuInfo | null> {
   let cards: string[];
   try {
@@ -49,7 +49,7 @@ async function readAmdTemperature(card: string): Promise<number | 'N/A'> {
   return 'N/A';
 }
 
-// nvidia-smi 는 프로세스를 띄우고 200ms 가까이 걸린다. 매 초 호출하지 않는다.
+// nvidia-smi spawns a process and takes close to 200ms. Don't call it every second.
 const readNvidiaGpu = withTtl(5000, async (): Promise<GpuInfo | null> => {
   let output: string;
   try {
@@ -57,7 +57,7 @@ const readNvidiaGpu = withTtl(5000, async (): Promise<GpuInfo | null> => {
       'nvidia-smi --query-gpu=name,utilization.gpu,temperature.gpu --format=csv,noheader,nounits'
     );
   } catch {
-    return null; // 드라이버/도구 미설치
+    return null; // driver/tool not installed
   }
 
   const [line] = output.split('\n');
@@ -75,7 +75,7 @@ const readNvidiaGpu = withTtl(5000, async (): Promise<GpuInfo | null> => {
 });
 
 export async function getGpuInfo(): Promise<GpuInfo> {
-  // 인텔 내장 그래픽은 커널이 사용률을 퍼센트로 노출하지 않아
-  // (i915 는 perf 이벤트로만 얻을 수 있다) N/A 로 남는다.
+  // Intel integrated graphics leaves N/A: the kernel doesn't expose utilization
+  // as a percentage (i915 only offers it via perf events).
   return (await readAmdGpu()) ?? (await readNvidiaGpu()) ?? UNAVAILABLE;
 }

--- a/src/utils/collectors/history.test.ts
+++ b/src/utils/collectors/history.test.ts
@@ -4,8 +4,8 @@ import { join } from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// history 는 모듈 스코프에 버킷을 들고 있어서 테스트마다 새로 불러와야 한다.
-// 저장 파일도 테스트별 임시 디렉터리로 돌려 서로 간섭하지 않게 한다.
+// history holds its buckets in module scope, so it must be reimported per test.
+// The store file is also given a per-test temp directory so they don't interfere.
 async function freshHistory() {
   vi.resetModules();
   const dir = mkdtempSync(join(tmpdir(), 'history-test-'));
@@ -28,7 +28,7 @@ describe('load history buckets', () => {
     delete process.env.HISTORY_FILE;
   });
 
-  it('48시간을 1시간 버킷 48칸으로 돌려준다', async () => {
+  it('returns 48 hours as 48 one-hour buckets', async () => {
     const { recordSample, getHistory } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 
@@ -36,12 +36,12 @@ describe('load history buckets', () => {
     const { load } = getHistory(now);
 
     expect(load).toHaveLength(48);
-    // 가장 오래된 칸과 최신 칸이 정확히 47시간 떨어져 있어야 48시간을 덮는다.
+    // The oldest and newest cells must be exactly 47 hours apart to cover 48 hours.
     const span = new Date(load.at(-1)!.at).getTime() - new Date(load[0].at).getTime();
     expect(span).toBe(47 * HOUR);
   });
 
-  it('같은 시간대의 샘플은 평균으로 합쳐진다', async () => {
+  it('samples in the same hour are merged into an average', async () => {
     const { recordSample, getHistory } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 
@@ -51,7 +51,7 @@ describe('load history buckets', () => {
     expect(getHistory(now).load.at(-1)!.avg1).toBe(3);
   });
 
-  it('서버가 꺼져 있던 구간은 null 로 남는다', async () => {
+  it('leaves null for the stretch the server was down', async () => {
     const { recordSample, getHistory } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 
@@ -59,35 +59,35 @@ describe('load history buckets', () => {
     recordSample(0, 1, now);
 
     const { load } = getHistory(now);
-    // 최신 칸과 3시간 전 칸에만 값이 있고 그 사이는 비어 있다.
+    // Only the newest cell and the cell 3 hours ago have values; the gap is empty.
     expect(load.at(-1)!.avg1).toBe(1);
     expect(load.at(-2)!.avg1).toBeNull();
     expect(load.at(-4)!.avg1).toBe(1);
   });
 
-  it('표시 창(48h) 밖이라도 7일 안의 데이터는 보관한다', async () => {
+  it('retains data within 7 days even outside the display window (48h)', async () => {
     const first = await freshHistory();
-    // prune 은 마지막 샘플 시각 기준으로 자르므로 실제 시계에 맞춘다.
+    // prune trims relative to the last sample time, so align to the real clock.
     const now = Math.floor(Date.now() / HOUR) * HOUR;
 
-    // 48시간 표시 창보다는 오래됐지만 7일 보관 창 안이다.
+    // Older than the 48-hour display window, but inside the 7-day retention window.
     first.recordSample(0, 7, now - 100 * HOUR);
     first.recordSample(0, 1, now);
 
     process.emit('SIGTERM');
     const saved = JSON.parse(readFileSync(first.file, 'utf-8'));
     const keys = saved.loadBuckets.map((row: [number, number, number]) => row[0]);
-    // 100시간 전 버킷이 디스크에 남아 있어야 한다(prune 되지 않았다).
+    // The bucket from 100 hours ago must remain on disk (not pruned).
     expect(keys).toContain(now - 100 * HOUR);
-    // 그래프는 예전처럼 48칸만 그린다 — 오래된 데이터는 보관만 되고 표시되지 않는다.
+    // The graph still draws only 48 cells — old data is retained but not displayed.
     expect(first.getHistory(now).load).toHaveLength(48);
   });
 
-  it('7일보다 오래된 버킷은 버린다', async () => {
+  it('drops buckets older than 7 days', async () => {
     const first = await freshHistory();
     const now = Math.floor(Date.now() / HOUR) * HOUR;
 
-    first.recordSample(0, 9, now - 200 * HOUR); // 7일(168h) 밖
+    first.recordSample(0, 9, now - 200 * HOUR); // outside 7 days (168h)
     first.recordSample(0, 1, now);
 
     process.emit('SIGTERM');
@@ -96,19 +96,19 @@ describe('load history buckets', () => {
     expect(keys).not.toContain(now - 200 * HOUR);
   });
 
-  it('재시작해도 디스크에서 복구된다', async () => {
+  it('recovers from disk across a restart', async () => {
     const first = await freshHistory();
-    // 복구는 실제 시계 기준으로 오래된 버킷을 버린다. 고정 과거 시각을 쓰면
-    // 저장한 버킷이 곧바로 "48시간 밖" 으로 판정되므로 지금 시각에 맞춘다.
+    // Recovery drops buckets old relative to the real clock. Using a fixed past
+    // time would immediately judge the stored bucket as "outside 48 hours", so align to now.
     const now = Math.floor(Date.now() / HOUR) * HOUR;
     first.recordSample(0, 2.5, now);
 
-    // 예약 저장을 기다리지 않고 종료 경로와 같은 동기 저장을 태운다.
+    // Trigger the same synchronous save as the shutdown path instead of waiting for the scheduled save.
     process.emit('SIGTERM');
     const saved = JSON.parse(readFileSync(first.file, 'utf-8'));
     expect(saved.loadBuckets.length).toBeGreaterThan(0);
 
-    // 같은 파일을 가리키는 새 모듈 인스턴스가 값을 다시 읽어야 한다.
+    // A new module instance pointing at the same file must re-read the values.
     vi.resetModules();
     process.env.DATA_DIR = first.dir;
     process.env.HISTORY_FILE = first.file;
@@ -116,7 +116,7 @@ describe('load history buckets', () => {
     expect(second.getHistory(now).load.at(-1)!.avg1).toBe(2.5);
   });
 
-  it('저장 포맷 버전이 다르면 통째로 무시한다', async () => {
+  it('ignores the whole store when the format version differs', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'history-test-'));
     const file = join(dir, 'history.json');
     writeFileSync(file, JSON.stringify({ v: 99, loadBuckets: [[0, 5, 1]], cpuBuckets: [] }));
@@ -130,7 +130,7 @@ describe('load history buckets', () => {
     expect(load.every(sample => sample.avg1 === null)).toBe(true);
   });
 
-  it('깨진 파일에도 죽지 않고 빈 상태로 뜬다', async () => {
+  it('starts empty without crashing on a corrupt file', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'history-test-'));
     const file = join(dir, 'history.json');
     writeFileSync(file, '{ this is not json');
@@ -145,12 +145,12 @@ describe('load history buckets', () => {
 });
 
 describe('getLoad30mAverage', () => {
-  it('샘플이 없으면 값이 없다고 알린다', async () => {
+  it('reports no value when there are no samples', async () => {
     const { getLoad30mAverage } = await freshHistory();
     expect(getLoad30mAverage(Date.now())).toEqual({ value: null, windowSeconds: 0 });
   });
 
-  it('창 안의 샘플을 평균낸다', async () => {
+  it('averages the samples inside the window', async () => {
     const { recordSample, getLoad30mAverage } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 
@@ -160,18 +160,18 @@ describe('getLoad30mAverage', () => {
     expect(getLoad30mAverage(now).value).toBe(2);
   });
 
-  it('창이 덜 찼으면 덮은 구간을 초로 알려준다', async () => {
+  it('reports the covered span in seconds when the window is not full', async () => {
     const { recordSample, getLoad30mAverage } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 
     recordSample(0, 1, now - 90_000);
     recordSample(0, 1, now);
 
-    // 분으로 반올림하면 시작 직후 "0분 평균" 이 되어버린다.
+    // Rounding to minutes would read "0-minute average" right after start.
     expect(getLoad30mAverage(now).windowSeconds).toBe(90);
   });
 
-  it('30분보다 오래된 샘플은 평균에서 빠진다', async () => {
+  it('excludes samples older than 30 minutes from the average', async () => {
     const { recordSample, getLoad30mAverage } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 
@@ -183,7 +183,7 @@ describe('getLoad30mAverage', () => {
     expect(rolling.windowSeconds).toBe(0);
   });
 
-  it('창 길이는 30분에서 멈춘다', async () => {
+  it('caps the window length at 30 minutes', async () => {
     const { recordSample, getLoad30mAverage } = await freshHistory();
     const now = Date.UTC(2026, 0, 2, 12, 0, 0);
 

--- a/src/utils/collectors/history.ts
+++ b/src/utils/collectors/history.ts
@@ -4,29 +4,30 @@ import path from 'path';
 import { CpuHourSample, HistoryInfo, LoadSample } from '@/types/system';
 import { round } from '@/utils/collectors/shell';
 
-// 히스토리 버킷은 프로세스 메모리에 두되, 디스크에도 영속화한다. 그래야
-// 배포(git pull) 후 재시작이나 크래시로 서버가 다시 떠도 그래프가 리셋되지
-// 않는다. 저장 파일은 gitignore 된 data 디렉터리에 있어 pull/build 가 건드리지
-// 않는다.
+// History buckets live in process memory but are also persisted to disk, so a
+// restart after a deploy (git pull) or a crash doesn't reset the graphs. The
+// store file lives in the gitignored data directory, so pull/build don't touch
+// it.
 //
-// 보관과 표시를 분리한다. 버킷은 1시간 단위로 7일치(168칸)를 남기지만(prune·
-// 디스크 복구의 창), 그래프는 예전 그대로 로드 48시간·CPU 24시간만 그린다.
-// getHistory 가 표시 창만큼만 잘라 돌려주므로, 데이터는 7일치 쌓여도 화면은
-// 바뀌지 않는다.
+// Retention and display are separated. Buckets keep 7 days at 1-hour
+// granularity (168 cells) — the window for pruning/disk recovery — but the
+// graphs still draw only 48h of load and 24h of CPU as before. getHistory slices
+// to just the display window, so the screen doesn't change even as 7 days of
+// data accumulate.
 const LOAD_BUCKET_MS = 60 * 60 * 1000;
 const HOUR_BUCKET_MS = 60 * 60 * 1000;
 
-// 보관(prune·디스크 복구)의 창 — 두 버킷 모두 7일치를 남긴다.
+// The retention (prune / disk recovery) window — both buckets keep 7 days.
 const RETENTION_HOURS = 7 * 24;
 const LOAD_RETENTION = RETENTION_HOURS;
 const CPU_RETENTION = RETENTION_HOURS;
 
-// 그래프에 실제로 그리는 창 — 예전과 동일하다.
-const LOAD_DISPLAY = 48; // 48시간
-const CPU_DISPLAY = 24; // 24시간
+// The window actually drawn on the graphs — unchanged from before.
+const LOAD_DISPLAY = 48; // 48 hours
+const CPU_DISPLAY = 24; // 24 hours
 
-// 디스크에 너무 자주 쓰지 않도록 최소 저장 간격을 둔다. 버킷은 작아서(수십 개)
-// 손실되는 최악의 구간도 이 간격만큼뿐이다.
+// A minimum save interval keeps disk writes from being too frequent. The
+// buckets are small (a few dozen), so the worst-case data loss is just this interval.
 const SAVE_INTERVAL_MS = 30 * 1000;
 
 // process.cwd() resolves to the project root at runtime; without this ignore,
@@ -44,10 +45,11 @@ interface Bucket {
 const loadBuckets = new Map<number, Bucket>();
 const cpuBuckets = new Map<number, Bucket>();
 
-// --- 30분 이동평균 -------------------------------------------------------
-// 커널이 주는 부하 평균은 1/5/15분뿐이라, 30분은 매 샘플을 짧은 창에 담아 직접
-// 낸다. 1초 간격(유휴 시 15초)이라 창에 최대 1800개가 들어간다 — 메모리 부담이
-// 없고, 버킷과 달리 디스크에 남기지 않는다(재시작하면 다시 차오른다).
+// --- 30-minute moving average --------------------------------------------
+// The kernel only gives 1/5/15-minute load averages, so we compute the 30-minute
+// one ourselves by keeping each sample in a short window. At a 1s interval (15s
+// when idle) the window holds at most 1800 entries — no memory burden — and,
+// unlike the buckets, it isn't persisted (it refills after a restart).
 const ROLLING_WINDOW_MS = 30 * 60 * 1000;
 
 interface Sample {
@@ -59,12 +61,13 @@ const recentLoad: Sample[] = [];
 
 export interface RollingAverage {
   value: number | null;
-  // 실제로 덮은 구간(초). 창이 덜 찼는지 호출부가 알 수 있어야 한다.
-  // 분으로 주면 시작 직후 "0분 평균" 이 되어버려 초로 준다.
+  // The span actually covered (seconds). The caller must be able to tell if the
+  // window is only partly filled. Reporting minutes would read "0-minute average"
+  // right after start, so it's given in seconds.
   windowSeconds: number;
 }
 
-// 창 밖으로 나간 샘플을 앞에서 덜어낸다. 시간순으로 들어오므로 앞쪽만 보면 된다.
+// Trim samples that fell out of the window from the front. They arrive in time order, so only the front needs checking.
 function pruneRecent(now: number): void {
   const oldest = now - ROLLING_WINDOW_MS;
   let drop = 0;
@@ -100,7 +103,7 @@ function prune(buckets: Map<number, Bucket>, oldestKey: number): void {
   }
 }
 
-// --- 영속화 --------------------------------------------------------------
+// --- Persistence ---------------------------------------------------------
 
 type SerializedBucket = [key: number, sum: number, count: number];
 interface StoreShape {
@@ -119,7 +122,7 @@ function hydrate(buckets: Map<number, Bucket>, rows: unknown, bucketMs: number, 
   for (const row of rows) {
     if (!Array.isArray(row) || row.length !== 3) continue;
     const [key, sum, cnt] = row;
-    // 손상/오래된 버킷은 조용히 버린다. 화면에 "데이터 없음" 으로 보일 뿐이다.
+    // Silently drop corrupt/stale buckets. They just show as "no data" on screen.
     if (typeof key !== 'number' || typeof sum !== 'number' || typeof cnt !== 'number') continue;
     if (!Number.isFinite(key) || cnt <= 0 || key < oldest) continue;
     buckets.set(key, { sum, count: cnt });
@@ -128,8 +131,8 @@ function hydrate(buckets: Map<number, Bucket>, rows: unknown, bucketMs: number, 
 
 let loaded = false;
 
-// 최초 접근 시 한 번만 디스크에서 읽어들인다. top-level await 를 피하려고
-// 동기 읽기를 쓴다(파일이 작아 부담 없다).
+// Read from disk once on first access. Uses a synchronous read to avoid a
+// top-level await (the file is small, so it's fine).
 function ensureLoaded(): void {
   if (loaded) return;
   loaded = true;
@@ -141,7 +144,7 @@ function ensureLoaded(): void {
       hydrate(cpuBuckets, parsed.cpuBuckets, HOUR_BUCKET_MS, CPU_RETENTION);
     }
   } catch {
-    // 파일이 없거나(첫 실행) 읽을 수 없으면 빈 상태로 시작한다.
+    // If the file is missing (first run) or unreadable, start empty.
   }
 }
 
@@ -160,18 +163,18 @@ async function writeStore(): Promise<void> {
   };
   try {
     await fs.promises.mkdir(DATA_DIR, { recursive: true });
-    // 임시 파일에 쓰고 rename 해서, 쓰다 만 파일이 남지 않게(원자적 교체) 한다.
+    // Write to a temp file and rename so no half-written file remains (atomic replace).
     const tmp = `${STORE_FILE}.tmp`;
     await fs.promises.writeFile(tmp, JSON.stringify(payload), 'utf-8');
     await fs.promises.rename(tmp, STORE_FILE);
   } catch {
-    // 디스크 쓰기 실패는 치명적이지 않다. 다음 저장에서 다시 시도한다.
+    // A disk write failure is not fatal. Retry on the next save.
   } finally {
     writing = false;
   }
 }
 
-// 매 샘플마다 쓰지 않고, 최소 간격을 두어 예약한다.
+// Rather than writing every sample, schedule with a minimum interval.
 function scheduleSave(): void {
   if (saveTimer) return;
   const elapsed = Date.now() - lastSaveAt;
@@ -180,12 +183,12 @@ function scheduleSave(): void {
     saveTimer = null;
     void writeStore();
   }, delay);
-  // 이 타이머 하나 때문에 프로세스가 종료를 미루지 않도록 한다.
+  // Don't let this one timer keep the process from exiting.
   if (typeof saveTimer.unref === 'function') saveTimer.unref();
 }
 
-// 종료 신호를 받으면 마지막 상태를 동기로 한 번 더 남긴다. 예약된 저장이
-// 아직 안 돌았어도 최근 구간을 잃지 않는다.
+// On a shutdown signal, write the final state synchronously once more. Even if
+// the scheduled save hasn't run yet, the recent window isn't lost.
 function flushSync(): void {
   try {
     const payload: StoreShape = {
@@ -196,7 +199,7 @@ function flushSync(): void {
     fs.mkdirSync(DATA_DIR, { recursive: true });
     fs.writeFileSync(STORE_FILE, JSON.stringify(payload), 'utf-8');
   } catch {
-    // 종료 중 실패는 삼킨다.
+    // Swallow failures during shutdown.
   }
 }
 
@@ -209,7 +212,7 @@ function hookExit(): void {
   process.once('beforeExit', () => flushSync());
 }
 
-// --- 공개 API ------------------------------------------------------------
+// --- Public API ----------------------------------------------------------
 
 export function recordSample(cpuUsage: number, load1: number, at: number = Date.now()): void {
   ensureLoaded();

--- a/src/utils/collectors/host.ts
+++ b/src/utils/collectors/host.ts
@@ -13,26 +13,27 @@ function parseOsRelease(contents: string): Record<string, string> {
   return fields;
 }
 
-// 배포판 이름은 부팅 중에 바뀌지 않는다. 한 번 읽으면 충분하다.
+// The distro name doesn't change while booted. Reading it once is enough.
 const readDistro = withTtl(60 * 60 * 1000, async (): Promise<string> => {
   const contents = (await readSys('/etc/os-release')) ?? (await readSys('/usr/lib/os-release'));
   if (!contents) return `${os.type()} ${os.release()}`;
 
   const fields = parseOsRelease(contents);
-  // PRETTY_NAME 은 "Ubuntu 22.04.4 LTS" 처럼 길어서 좁은 헤더에 안 들어간다.
-  // NAME + VERSION_ID 조합("Ubuntu 22.04")이 더 짧고 정보량은 같다.
+  // PRETTY_NAME like "Ubuntu 22.04.4 LTS" is too long for the narrow header.
+  // NAME + VERSION_ID ("Ubuntu 22.04") is shorter with the same information.
   if (fields.NAME && fields.VERSION_ID) return `${fields.NAME} ${fields.VERSION_ID}`;
   return fields.PRETTY_NAME || fields.NAME || `${os.type()} ${os.release()}`;
 });
 
-// wtmp 를 뒤져 마지막 재부팅 직전에 정상 종료(shutdown) 기록이 있었는지 본다.
-// 있으면 계획된 재부팅, 없으면 커널 패닉/정전처럼 예기치 못한 종료다.
+// Scans wtmp to see whether there was a clean shutdown record right before the
+// last reboot. If so it was a planned reboot; if not it was an unexpected
+// shutdown like a kernel panic or power loss.
 const readRebootReason = withTtl(5 * 60 * 1000, async (): Promise<string | null> => {
   let output: string;
   try {
     output = await run('last -x -F -n 20 reboot shutdown 2>/dev/null || true');
   } catch {
-    return null; // last 미설치(busybox 등) 또는 wtmp 권한 없음
+    return null; // `last` not installed (busybox, etc.) or no wtmp permission
   }
 
   const lines = output
@@ -47,14 +48,15 @@ const readRebootReason = withTtl(5 * 60 * 1000, async (): Promise<string | null>
   return previous.startsWith('shutdown') ? 'clean shutdown' : 'unexpected shutdown';
 });
 
-// 가상화/컨테이너 종류. 일부 지표(steal, 온도, 팬)의 해석이 베어메탈과 달라지므로
-// 어떤 환경에서 도는지 표기한다. systemd-detect-virt 는 없으면 exit 1 이라 || true.
-// 값은 부팅 중 바뀌지 않으니 오래 캐시한다.
+// Virtualization/container kind. Some metrics (steal, temperature, fan) read
+// differently from bare metal, so note the environment it runs in.
+// systemd-detect-virt exits 1 when there's none, hence || true. The value
+// doesn't change while booted, so cache it for a long time.
 const readVirtualization = withTtl(60 * 60 * 1000, async (): Promise<string | null> => {
   try {
     const output = await run('systemd-detect-virt 2>/dev/null || true');
     const value = output.trim();
-    // "none" 은 베어메탈. 빈 문자열은 도구 미설치 — 둘 다 표기하지 않는다.
+    // "none" is bare metal. An empty string means the tool isn't installed — neither is shown.
     if (!value || value === 'none') return null;
     return value;
   } catch {

--- a/src/utils/collectors/load.test.ts
+++ b/src/utils/collectors/load.test.ts
@@ -2,30 +2,30 @@ import { describe, expect, it } from 'vitest';
 
 import { parseRunningEntities } from '@/utils/collectors/load';
 
-// 이 파서는 /proc 이 있는 리눅스에서만 실제로 돌아간다. 개발 장비(macOS)에서는
-// 경로가 없어 그냥 null 로 빠지므로, 형식 검증은 여기서만 할 수 있다.
+// This parser only really runs on Linux with /proc. On a dev machine (macOS)
+// the path is absent so it just falls back to null, so format validation can only happen here.
 describe('parseRunningEntities', () => {
-  it('4번째 필드의 실행 중 태스크 수를 읽는다', () => {
+  it('reads the running-task count from the 4th field', () => {
     expect(parseRunningEntities('0.42 0.38 0.35 2/1234 5678\n')).toBe(2);
   });
 
-  it('두 자리 이상도 읽는다', () => {
+  it('reads two or more digits', () => {
     expect(parseRunningEntities('12.00 9.51 8.20 137/2048 99\n')).toBe(137);
   });
 
-  it('유휴 상태의 1 도 그대로 읽는다', () => {
-    // 자기 자신(읽는 프로세스)이 항상 실행 중이라 최소값은 보통 1 이다.
+  it('reads an idle value of 1 as-is', () => {
+    // The reading process itself is always running, so the minimum is usually 1.
     expect(parseRunningEntities('0.00 0.00 0.00 1/128 42\n')).toBe(1);
   });
 
-  it('총 태스크 수를 실행 수로 착각하지 않는다', () => {
+  it('does not mistake the total task count for the running count', () => {
     expect(parseRunningEntities('0.10 0.10 0.10 3/900 12')).not.toBe(900);
   });
 
-  it('형식이 다르면 null 이다', () => {
+  it('returns null on a different format', () => {
     expect(parseRunningEntities('')).toBeNull();
     expect(parseRunningEntities('nonsense')).toBeNull();
-    // 앞의 세 필드가 모자란 경우 — 4번째를 잘못 집으면 안 된다.
+    // When the first three fields are missing — it must not grab the 4th by mistake.
     expect(parseRunningEntities('0.42 0.38 2/1234')).toBeNull();
   });
 });

--- a/src/utils/collectors/load.ts
+++ b/src/utils/collectors/load.ts
@@ -4,9 +4,10 @@ import { readFile } from 'fs/promises';
 import { LoadInfo, SwapInfo } from '@/types/system';
 import { round } from '@/utils/collectors/shell';
 
-// /proc/loadavg 는 "0.42 0.38 0.35 2/1234 5678" 꼴이다. 4번째 필드 앞쪽 숫자가
-// 지금 실행 중이거나 실행 대기 중인 커널 엔티티 수 — 부하 평균의 순간값에 해당한다.
-// os.loadavg() 로는 얻을 수 없어 파일을 직접 읽는다.
+// /proc/loadavg looks like "0.42 0.38 0.35 2/1234 5678". The number before the
+// slash in the 4th field is the count of kernel entities running or waiting to
+// run right now — the instantaneous counterpart of the load average.
+// os.loadavg() can't give it, so read the file directly.
 export function parseRunningEntities(contents: string): number | null {
   const match = contents.match(/^\S+\s+\S+\s+\S+\s+(\d+)\/\d+/);
   if (!match) return null;
@@ -18,17 +19,18 @@ async function getRunningEntities(): Promise<number | null> {
   try {
     return parseRunningEntities(await readFile('/proc/loadavg', 'utf-8'));
   } catch {
-    // /proc 가 없는 OS(macOS 등)이거나 읽을 수 없다. 순간값만 비운다.
+    // OS without /proc (macOS, etc.) or unreadable. Leave only the instantaneous value empty.
     return null;
   }
 }
 
-// 30분 이동평균은 뺀 나머지. 호출부가 현재 샘플을 기록한 뒤에 창을 읽어야
-// 방금 값까지 반영되므로, 조립은 systemMonitor 가 맡는다.
+// Everything except the 30-minute moving average. The caller must read the
+// window after recording the current sample so it reflects the latest value,
+// so systemMonitor does the assembly.
 export type LoadAverageBase = Omit<LoadInfo, 'avg30' | 'avg30WindowSeconds'>;
 
 export async function getLoadAverage(): Promise<LoadAverageBase> {
-  // os.loadavg() 는 /proc/loadavg 를 읽는 것과 같지만 파싱이 필요 없다.
+  // os.loadavg() is the same as reading /proc/loadavg but needs no parsing.
   const [avg1, avg5, avg15] = os.loadavg();
   return {
     avg1: round(avg1),
@@ -55,7 +57,7 @@ export async function getSwapInfo(): Promise<SwapInfo> {
   return {
     used: toGb(usedKb),
     total: toGb(totalKb),
-    // 스왑이 없는 서버(총량 0)는 0% 로 둔다. 0/0 은 NaN 이 되어 UI 를 깨뜨린다.
+    // A server with no swap (total 0) stays at 0%. 0/0 would be NaN and break the UI.
     percentage: totalKb > 0 ? round((usedKb / totalKb) * 100, 1) : 0
   };
 }

--- a/src/utils/collectors/netstat.ts
+++ b/src/utils/collectors/netstat.ts
@@ -12,9 +12,9 @@ export const INTERFACE_NAME_PATTERN = /^[a-zA-Z0-9@.:_-]+$/;
 const TCP_ESTABLISHED = '01';
 const TCP_LISTEN = '0A';
 
-// --- /proc/net/tcp 파싱 ---------------------------------------------------
+// --- /proc/net/tcp parsing -----------------------------------------------
 
-// sysfs 의 주소는 4바이트 워드 단위 리틀엔디언 16진수다. "0100007F" 는 127.0.0.1.
+// The sysfs address is little-endian hex in 4-byte words. "0100007F" is 127.0.0.1.
 function hexToIpv4(hex: string): string {
   const bytes = hex.match(/../g);
   if (!bytes || bytes.length !== 4) return '0.0.0.0';
@@ -28,11 +28,11 @@ function hexToIpv6(hex: string): string {
   const words = hex.match(/.{8}/g);
   if (!words || words.length !== 4) return '::';
 
-  // 각 32비트 워드가 개별적으로 리틀엔디언이라 워드 안에서만 바이트를 뒤집는다.
+  // Each 32-bit word is individually little-endian, so reverse bytes within a word only.
   const bytes = words.flatMap(word => (word.match(/../g) ?? []).reverse().map(b => parseInt(b, 16)));
   if (bytes.length !== 16) return '::';
 
-  // IPv4-mapped(::ffff:a.b.c.d)는 IPv4 로 보여주는 편이 읽기 쉽다.
+  // IPv4-mapped (::ffff:a.b.c.d) is easier to read shown as IPv4.
   const isMapped = bytes.slice(0, 10).every(b => b === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
   if (isMapped) return bytes.slice(12).join('.');
 
@@ -41,7 +41,7 @@ function hexToIpv6(hex: string): string {
     groups.push(((bytes[i] << 8) | bytes[i + 1]).toString(16));
   }
 
-  // 가장 긴 0 구간 하나를 "::" 로 줄인다 (RFC 5952).
+  // Collapse the single longest run of zeros to "::" (RFC 5952).
   let bestStart = -1;
   let bestLength = 0;
   let start = -1;
@@ -65,8 +65,9 @@ interface Socket {
   localPort: number;
   remoteIp: string;
   state: string;
-  // 소켓을 소유한 UID 와 inode. SSH 세션을 프로세스와 연결(inode)하거나
-  // 사용자를 추정(uid)할 때 쓴다. 커널마다 컬럼이 빠질 수 있어 기본값을 둔다.
+  // The owning UID and inode of the socket. Used to link an SSH session to a
+  // process (inode) or infer the user (uid). Columns may be missing on some
+  // kernels, so defaults are provided.
   uid: number;
   inode: string;
 }
@@ -76,12 +77,12 @@ async function readSockets(path: string, ipv6: boolean): Promise<Socket[]> {
   try {
     contents = await readFile(path, 'utf-8');
   } catch {
-    return []; // tcp6 는 IPv6 가 꺼진 커널에 없다
+    return []; // tcp6 is absent on kernels with IPv6 disabled
   }
 
   const sockets: Socket[] = [];
   for (const line of contents.split('\n').slice(1)) {
-    // /proc/net/tcp 컬럼: sl local rem st tx:rx tr:when retr uid timeout inode ...
+    // /proc/net/tcp columns: sl local rem st tx:rx tr:when retr uid timeout inode ...
     const fields = line.trim().split(/\s+/);
     if (fields.length < 4) continue;
 
@@ -131,7 +132,7 @@ export async function getSocketSummary(): Promise<SocketSummary> {
     if (socket.state !== TCP_ESTABLISHED) continue;
 
     connections += 1;
-    // 로컬 프로세스끼리의 연결(127.0.0.1)은 "누가 트래픽을 쓰는가" 관점에서 잡음이다.
+    // Connections between local processes (127.0.0.1) are noise for "who is using traffic".
     if (isLoopback(socket.remoteIp)) continue;
     peers.set(socket.remoteIp, (peers.get(socket.remoteIp) ?? 0) + 1);
   }
@@ -150,8 +151,8 @@ export interface EstablishedConnection {
   inode: string;
 }
 
-// 확립된(ESTABLISHED) TCP 연결 전부. 보안 수집기가 SSH 포트로 들어온 연결만
-// 걸러 세션을 재구성할 때 쓴다.
+// All ESTABLISHED TCP connections. The security collector filters these to the
+// SSH ports to reconstruct sessions.
 export async function getEstablishedConnections(): Promise<EstablishedConnection[]> {
   const sockets = await readAllSockets();
   return sockets
@@ -159,10 +160,10 @@ export async function getEstablishedConnections(): Promise<EstablishedConnection
     .map(({ localPort, remoteIp, uid, inode }) => ({ localPort, remoteIp, uid, inode }));
 }
 
-// --- 인터페이스 ------------------------------------------------------------
+// --- Interfaces ----------------------------------------------------------
 
-// `ip route` 는 /usr/sbin 에 있어 서비스 PATH 에서 빠지기 쉽다.
-// /proc/net/route 를 직접 읽으면 외부 바이너리가 전혀 필요 없다.
+// `ip route` lives in /usr/sbin and is easily missing from a service PATH.
+// Reading /proc/net/route directly needs no external binary at all.
 export async function getDefaultInterface(): Promise<string> {
   const contents = await readFile('/proc/net/route', 'utf-8');
   const lines = contents.split('\n').slice(1);
@@ -174,7 +175,7 @@ export async function getDefaultInterface(): Promise<string> {
     }
   }
 
-  // 기본 경로가 없으면(컨테이너 등) 트래픽이 가장 많은 물리 인터페이스로 대체한다.
+  // With no default route (containers, etc.), fall back to the physical interface with the most traffic.
   const candidates = await listInterfaceNames();
   let best = '';
   let bestBytes = -1;
@@ -201,7 +202,7 @@ export async function readInterfaceStat(interfaceName: string, stat: string): Pr
 }
 
 async function readLinkSpeed(interfaceName: string): Promise<number | null> {
-  // 가상/무선 장치는 speed 파일이 없거나 읽으면 EINVAL 이고, 링크가 내려가 있으면 -1 이다.
+  // Virtual/wireless devices have no speed file or return EINVAL, and it's -1 when the link is down.
   const raw = await readSys(`/sys/class/net/${interfaceName}/speed`);
   if (raw === null) return null;
   const speed = parseInt(raw, 10);
@@ -227,7 +228,7 @@ export async function getInterfaces(defaultInterface: string): Promise<NetworkIn
     })
   );
 
-  // 기본 경로를 쓰는 인터페이스가 맨 위, 그다음 링크가 올라온 것들 순.
+  // The default-route interface first, then the ones whose link is up.
   return interfaces.sort((a, b) => {
     if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
     if ((a.state === 'up') !== (b.state === 'up')) return a.state === 'up' ? -1 : 1;
@@ -235,7 +236,7 @@ export async function getInterfaces(defaultInterface: string): Promise<NetworkIn
   });
 }
 
-// --- 상위 트래픽 피어 ------------------------------------------------------
+// --- Top traffic peers ---------------------------------------------------
 
 function localAddresses(): Set<string> {
   const addresses = new Set<string>();
@@ -245,25 +246,25 @@ function localAddresses(): Set<string> {
   return addresses;
 }
 
-// conntrack 은 커널이 이미 세고 있는 연결별 바이트 수를 준다.
-// 단 net.netfilter.nf_conntrack_acct=1 일 때만 bytes= 필드가 붙는다.
+// conntrack gives per-connection byte counts the kernel already tracks.
+// The bytes= field is only present when net.netfilter.nf_conntrack_acct=1.
 async function readConntrackBytes(): Promise<Map<string, number> | null> {
   let contents: string;
   try {
     contents = await readFile('/proc/net/nf_conntrack', 'utf-8');
   } catch {
-    return null; // conntrack 모듈이 없거나 읽을 권한이 없다
+    return null; // conntrack module absent or no read permission
   }
 
   const locals = localAddresses();
   const totals = new Map<string, number>();
 
   for (const line of contents.split('\n')) {
-    if (!line.includes('bytes=')) return null; // 바이트 계정이 꺼져 있다
+    if (!line.includes('bytes=')) return null; // byte accounting is off
     const bytes = [...line.matchAll(/bytes=(\d+)/g)].reduce((sum, m) => sum + Number(m[1]), 0);
     const addresses = [...line.matchAll(/(?:src|dst)=([0-9a-fA-F.:]+)/g)].map(m => m[1]);
 
-    // 튜플 양쪽 중 우리 주소가 아닌 쪽이 상대 피어다.
+    // The side of the tuple that isn't our address is the remote peer.
     const peer = addresses.find(address => !locals.has(address) && !isLoopback(address));
     if (!peer) continue;
 
@@ -283,7 +284,7 @@ export async function getTopTraffic(peers: Map<string, number>, limit = 4): Prom
       .map(([ip, bytes]) => ({ ip, bytes, connections: peers.get(ip) ?? 0 }));
   }
 
-  // conntrack 을 못 쓰면 열려 있는 연결 수로 순위를 매긴다. 바이트는 알 수 없다.
+  // Without conntrack, rank by open connection count. Bytes are unknown.
   return [...peers.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, limit)

--- a/src/utils/collectors/notify.ts
+++ b/src/utils/collectors/notify.ts
@@ -1,22 +1,23 @@
 import { AlertEntry } from '@/types/system';
 import { logger } from '@/utils/logger';
 
-// 알림은 지금까지 화면(대시보드 alerts 카드)에만 표시됐다. 벽에 걸어둔 패널을
-// 24/7 쳐다보지 않는 한 임계값을 넘겨도 아무도 모른다. 여기서 임계 전이가 생길
-// 때마다 외부로 한 번 밀어준다. ALERT_WEBHOOK_URL 이 설정돼 있을 때만 동작하고,
-// 미설정이면(기본값) 완전히 무동작이라 기존 배포에 영향이 없다.
+// Until now alerts only showed on the dashboard's alert card. Unless someone
+// watches a wall panel 24/7, a threshold breach goes unnoticed. Here we push
+// once per alert transition to an external endpoint. It only acts when
+// ALERT_WEBHOOK_URL is set; unset (the default) is a complete no-op, so
+// existing deployments are unaffected.
 
 const WEBHOOK_URL = process.env.ALERT_WEBHOOK_URL;
-// json  — AlertEntry 를 그대로 POST (자체 수신기/웹훅 브리지용)
-// slack — Slack Incoming Webhook 의 { text } 형태
-// discord — Discord Webhook 의 { content } 형태
+// json    — POST the AlertEntry as-is (for a custom receiver / webhook bridge)
+// slack   — Slack Incoming Webhook shape, { text }
+// discord — Discord Webhook shape, { content }
 const WEBHOOK_FORMAT = (process.env.ALERT_WEBHOOK_FORMAT || 'json').toLowerCase();
 
-// 수집 루프는 매초 도는 민감한 경로다. 웹훅이 느리거나 죽어 있어도 루프를
-// 붙잡지 않도록 짧게 끊는다(클러스터 fetch 와 같은 방식).
+// The collection loop runs every second on a sensitive path. Cap the request
+// so a slow or dead webhook can't hold the loop up (same approach as the cluster fetch).
 const TIMEOUT_MS = 5000;
 
-// UI 에서 쓰는 레벨을 사람이 읽는 접두사로. Slack/Discord 메시지 앞머리에 붙는다.
+// Maps the UI levels to a human-readable prefix, shown at the head of Slack/Discord messages.
 const LEVEL_PREFIX: Record<AlertEntry['level'], string> = {
   ok: '✅',
   info: 'ℹ️',
@@ -40,9 +41,10 @@ function formatPayload(entry: AlertEntry): string {
 }
 
 /**
- * 새 알림 하나를 설정된 웹훅으로 밀어준다. 발송 여부/성공에 호출부가 기대지
- * 않도록 항상 resolve 하며(실패는 로그만), fire-and-forget 으로 부르면 된다.
- * 스팸 억제(히스테리시스·부팅 직후 무통지)는 호출부(alerts.ts)가 이미 처리한다.
+ * Pushes a single new alert to the configured webhook. Always resolves (a
+ * failure is only logged) so the caller can fire-and-forget without depending
+ * on delivery/success. Spam suppression (hysteresis / no notify on first
+ * evaluation) is already handled by the caller (alerts.ts).
  */
 export async function dispatchAlert(entry: AlertEntry): Promise<void> {
   if (!WEBHOOK_URL) return;
@@ -58,7 +60,7 @@ export async function dispatchAlert(entry: AlertEntry): Promise<void> {
       signal: controller.signal
     });
   } catch (error) {
-    // 웹훅 실패는 치명적이지 않다. 대시보드/로그에는 알림이 그대로 남는다.
+    // A webhook failure is not fatal; the alert still lives on the dashboard/log.
     const message = error instanceof Error ? error.message : String(error);
     logger.error('alerts webhook dispatch failed:', message);
   } finally {

--- a/src/utils/collectors/security.ts
+++ b/src/utils/collectors/security.ts
@@ -5,30 +5,30 @@ import { FirewallInfo, SshSession } from '@/types/system';
 import { readSys, run, withTtl } from '@/utils/collectors/shell';
 import { getEstablishedConnections } from '@/utils/collectors/netstat';
 
-// --- SSH 세션 --------------------------------------------------------------
+// --- SSH sessions ----------------------------------------------------------
 //
-// `who` 는 utmp 를 읽는데, utmp 는 여러 환경에서 비어 있다: 컨테이너, busybox,
-// `UsePAM no`, PTY 를 안 붙이는 세션(scp/sftp/`ssh host cmd`). 그래서 `who` 하나로는
-// 세션을 놓치기 일쑤다.
+// `who` reads utmp, which is empty in many environments: containers, busybox,
+// `UsePAM no`, and sessions with no PTY (scp/sftp/`ssh host cmd`). So `who`
+// alone often misses sessions.
 //
-// 대신 두 신뢰할 수 있는 소스를 합친다. 둘 다 root 도 utmp 도 필요 없다.
-//   1) sshd 세션 프로세스 — /proc/<pid>/comm 이 sshd(또는 sshd-session)이고
-//      cmdline 이 "sshd: user@pts/0" 인 것. 로그인 사용자와 tty, 시작 시각을 준다.
-//      PTY 없는 세션은 "user@notty" 로 잡힌다.
-//   2) SSH 포트로 확립된 TCP 연결 — /proc/net/tcp 에서 원격 IP 를 준다.
-//      각 sshd 프로세스의 소켓 inode 로 연결과 짝지어 IP 를 채운다.
-// 마지막으로 `who` 결과를 tty 기준으로 병합해, utmp 가 있을 때의 IP/시각을 보탠다.
+// Instead we merge two reliable sources. Neither needs root or utmp.
+//   1) sshd session processes — /proc/<pid>/comm is sshd (or sshd-session) and
+//      cmdline is "sshd: user@pts/0". Gives the login user, tty, and start time.
+//      A PTY-less session shows up as "user@notty".
+//   2) TCP connections established to an SSH port — /proc/net/tcp gives the
+//      remote IP, matched to each sshd process by socket inode.
+// Finally we merge `who` by tty to add the IP/time when utmp is present.
 
-// setproctitle 로 덮인 sshd 세션 프로세스의 cmdline.
+// The cmdline of an sshd session process, overwritten by setproctitle.
 //   sshd: deploy@pts/1   /  sshd-session: deploy@pts/1   /  sshd: deploy@notty
 const SSHD_SESSION = /^(?:sshd|sshd-session):\s+(\S+?)@(pts\/\d+|tty\S+|notty)\b/;
-const USER_HZ = 100; // 리눅스에서 사실상 항상 100. /proc/<pid>/stat 의 tick 단위.
+const USER_HZ = 100; // effectively always 100 on Linux; the tick unit of /proc/<pid>/stat.
 
 interface Session extends SshSession {
   tty?: string;
 }
 
-// 수집기 안에서만 쓰는 SSH 포트 목록. sshd_config 의 Port + 환경변수 + 기본 22.
+// SSH port list used only inside this collector. sshd_config Port + env var + default 22.
 async function sshPorts(): Promise<Set<number>> {
   const ports = new Set<number>();
 
@@ -49,14 +49,15 @@ function isLoopbackIp(ip: string): boolean {
   return ip.startsWith('127.') || ip === '::1' || ip === '0.0.0.0' || ip === '::';
 }
 
-// 부팅 시각(epoch ms)은 한 번만 계산해 고정한다. 매번 Date.now()-os.uptime()
-// 으로 다시 구하면 os.uptime() 의 10ms 양자화 때문에 값이 수 ms 씩 흔들리고,
-// 그러면 같은 세션의 `since` 가 갱신마다 달라져 alerts 가 "SSH login" 을
-// 무한히 다시 찍는다(도배의 진짜 원인). 부팅 시각은 변하지 않으므로 캐시가 맞다.
+// Compute the boot time (epoch ms) once and freeze it. Recomputing it every
+// time as Date.now()-os.uptime() jitters by a few ms because os.uptime() is
+// quantized to 10ms, which makes the same session's `since` change every
+// refresh and causes alerts to reprint "SSH login" endlessly (the real cause of
+// the spam). The boot time never changes, so caching it is correct.
 const BOOT_MS = Date.now() - os.uptime() * 1000;
 
-// /proc/<pid>/stat 22번째 필드(부팅 후 tick)로 프로세스 시작 시각을 복원한다.
-// comm 에 공백/괄호가 들어갈 수 있어 마지막 ')' 이후부터 센다.
+// Reconstruct the process start time from the 22nd field of /proc/<pid>/stat
+// (ticks since boot). comm can contain spaces/parens, so count from the last ')'.
 async function processStart(pid: string): Promise<string> {
   try {
     const stat = await readFile(`/proc/${pid}/stat`, 'utf-8');
@@ -64,7 +65,7 @@ async function processStart(pid: string): Promise<string> {
       .slice(stat.lastIndexOf(')') + 2)
       .trim()
       .split(/\s+/);
-    const startTicks = Number(afterComm[19]); // 필드22 = state(3) 기준 인덱스 19
+    const startTicks = Number(afterComm[19]); // field 22 = index 19 relative to state(3)
     if (!Number.isFinite(startTicks)) return new Date().toISOString();
 
     return new Date(BOOT_MS + (startTicks / USER_HZ) * 1000).toISOString();
@@ -79,13 +80,13 @@ interface SshdProc {
   tty: string;
 }
 
-// /proc 를 훑어 sshd 세션 프로세스만 고른다. ps 플래그에 기대지 않는다.
+// Walk /proc and pick only sshd session processes. Doesn't rely on ps flags.
 async function sshdSessionProcesses(): Promise<SshdProc[]> {
   let entries: string[];
   try {
     entries = await readdir('/proc');
   } catch {
-    return []; // /proc 없음(리눅스 아님)
+    return []; // no /proc (not Linux)
   }
 
   const found: SshdProc[] = [];
@@ -103,15 +104,16 @@ async function sshdSessionProcesses(): Promise<SshdProc[]> {
     }
 
     const match = cmdline.match(SSHD_SESSION);
-    if (!match) continue; // 마스터/[priv]/[listener] 등 세션이 아닌 프로세스는 건너뛴다
+    if (!match) continue; // skip non-session processes like the master/[priv]/[listener]
 
     found.push({ pid, user: match[1], tty: match[2] });
   }
   return found;
 }
 
-// sshd 프로세스가 들고 있는 소켓 inode 를 established 연결과 짝지어 원격 IP 를 찾는다.
-// /proc/<pid>/fd 는 소유자(또는 root)만 읽을 수 있어, 권한이 없으면 null.
+// Matches a socket inode held by the sshd process to an established connection
+// to find the remote IP. /proc/<pid>/fd is readable only by the owner (or
+// root), so null without permission.
 async function correlateIp(pid: string, inodeToIp: Map<string, string>): Promise<string | null> {
   let fds: string[];
   try {
@@ -152,7 +154,7 @@ async function sessionsFromProcesses(): Promise<Session[]> {
     }))
   );
 
-  // inode 로 IP 를 못 붙였는데(권한 등) SSH 연결이 딱 하나뿐이면 그걸로 채운다.
+  // If the IP couldn't be matched by inode (permissions, etc.) but there is exactly one SSH connection, use it.
   const unresolved = sessions.filter(s => s.ip === '—');
   if (unresolved.length > 0 && sshConnections.length === 1) {
     for (const session of unresolved) session.ip = sshConnections[0].remoteIp;
@@ -161,7 +163,7 @@ async function sessionsFromProcesses(): Promise<Session[]> {
   return sessions;
 }
 
-// utmp 가 살아 있을 때의 보조 소스. IP 와 정확한 로그인 시각을 준다.
+// A secondary source for when utmp is alive. Gives the IP and exact login time.
 //   deploy   pts/1        2024-07-20 14:35 (192.168.0.5)
 const WHO_LINE = /^(\S+)\s+(\S+)\s+(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})(?::\d{2})?\s*(?:\(([^)]*)\))?/;
 
@@ -175,7 +177,7 @@ async function sessionsFromWho(): Promise<Session[]> {
     if (!match) continue;
 
     const [, user, tty, date, time, host] = match;
-    if (!host) continue; // 접속지가 없으면 로컬 콘솔이라 SSH 가 아니다
+    if (!host) continue; // no origin means a local console, not SSH
 
     const since = new Date(`${date}T${time}`);
     sessions.push({
@@ -188,7 +190,7 @@ async function sessionsFromWho(): Promise<Session[]> {
   return sessions;
 }
 
-// tty 기준으로 두 소스를 합친다. 같은 세션이면 실제 IP 와 이른(=진짜) 로그인 시각을 취한다.
+// Merge the two sources by tty. For the same session, take the real IP and the earliest (= true) login time.
 function mergeSessions(...lists: Session[][]): SshSession[] {
   const byKey = new Map<string, Session>();
 
@@ -209,7 +211,7 @@ function mergeSessions(...lists: Session[][]): SshSession[] {
 
   return [...byKey.values()]
     .map(({ user, ip, since }) => ({ user, ip, since }))
-    .sort((a, b) => b.since.localeCompare(a.since)); // 최근 접속이 위로
+    .sort((a, b) => b.since.localeCompare(a.since)); // most recent login on top
 }
 
 export const getSshSessions = withTtl(15_000, async (): Promise<SshSession[]> => {
@@ -217,16 +219,16 @@ export const getSshSessions = withTtl(15_000, async (): Promise<SshSession[]> =>
   return mergeSessions(fromProcesses, fromWho);
 });
 
-// --- 방화벽 ----------------------------------------------------------------
+// --- Firewall --------------------------------------------------------------
 
 async function isServiceActive(name: string): Promise<boolean> {
-  // systemctl is-active 는 비활성일 때 종료 코드가 3 이라 `|| true` 가 필요하다.
+  // systemctl is-active exits 3 when inactive, so `|| true` is needed.
   const output = await run(`systemctl is-active ${name} 2>/dev/null || true`);
   return output === 'active';
 }
 
 async function detectFirewall(): Promise<{ status: FirewallInfo['status']; backend: string | null }> {
-  // ufw status 는 root 를 요구하지만, 설정 파일은 보통 누구나 읽을 수 있다.
+  // ufw status requires root, but the config file is usually world-readable.
   const ufwConf = await readSys('/etc/ufw/ufw.conf');
   if (ufwConf !== null) {
     const enabled = /^ENABLED=yes$/im.test(ufwConf);
@@ -237,18 +239,18 @@ async function detectFirewall(): Promise<{ status: FirewallInfo['status']; backe
     try {
       if (await isServiceActive(service)) return { status: 'active', backend: service };
     } catch {
-      // systemctl 이 없는 환경(컨테이너 등). 다음 후보로 넘어간다.
+      // environment without systemctl (containers, etc.). Move to the next candidate.
     }
   }
 
   return { status: 'unknown', backend: null };
 }
 
-// 커널 로그 한 번 훑는 비용이 크므로 1분에 한 번만 센다.
+// Scanning the kernel log once is expensive, so count only once a minute.
 const countBlockedAttempts = withTtl(60_000, async (): Promise<number | null> => {
   let output: string;
   try {
-    // NR 이 0 이면 저널을 읽을 권한이 없다는 뜻이라, "차단 0건" 과 구분한다.
+    // NR of 0 means no permission to read the journal, distinct from "0 blocks".
     output = await run(
       `journalctl -k --since=-24h --no-pager 2>/dev/null | awk '/UFW BLOCK|nft.*drop|DPT=.*DROP/ {c++} END {print NR" "(c+0)}'`,
       10_000

--- a/src/utils/collectors/shell.ts
+++ b/src/utils/collectors/shell.ts
@@ -6,13 +6,13 @@ import { logger } from '@/utils/logger';
 
 const execAsync = promisify(exec);
 
-// `ip`, `sensors`, `ps` 등은 /usr/sbin, /sbin 에 설치되는 경우가 많은데
-// 비-root 사용자로 뜬 systemd/pm2 서비스의 PATH 에는 그 경로가 빠져 있다.
-// 그래서 명령이 "not found" 로 끝나고, 지표가 통째로 0 이 된다.
+// `ip`, `sensors`, `ps`, etc. are often installed in /usr/sbin or /sbin, but a
+// systemd/pm2 service running as a non-root user has those paths missing from
+// its PATH. The command then ends in "not found" and the metric drops to 0.
 export const EXEC_ENV = {
   ...process.env,
   PATH: [process.env.PATH, '/usr/local/sbin', '/usr/sbin', '/sbin'].filter(Boolean).join(':'),
-  LC_ALL: 'C', // 로케일에 따라 소수점이 ','가 되면 parseFloat가 잘라먹는다
+  LC_ALL: 'C', // if the locale makes the decimal separator ',', parseFloat truncates it
   LANG: 'C'
 };
 
@@ -29,7 +29,7 @@ export async function readSys(filePath: string): Promise<string | null> {
   }
 }
 
-// 수집기 하나가 실패해도 나머지 지표는 살려 보낸다.
+// If one collector fails, still return the rest of the metrics.
 export async function collect<T>(
   name: string,
   fn: () => Promise<T>,
@@ -46,9 +46,9 @@ export async function collect<T>(
   }
 }
 
-// 대시보드는 1초마다 폴링한다. `who`, `last`, `nvidia-smi` 처럼 프로세스를
-// 띄우는 수집기까지 매 초 돌리면 측정 대상 서버가 더 바빠지므로,
-// 잘 변하지 않는 값은 TTL 동안 캐시해서 재사용한다.
+// The dashboard polls once a second. Running process-spawning collectors like
+// `who`, `last`, `nvidia-smi` every second would make the monitored server
+// busier, so values that rarely change are cached and reused for a TTL.
 export function withTtl<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
   let value: T;
   let expiresAt = 0;
@@ -56,7 +56,7 @@ export function withTtl<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T
 
   return async () => {
     if (expiresAt > Date.now()) return value;
-    // 같은 틱에 여러 수집기가 부르더라도 프로세스는 한 번만 띄운다.
+    // Even if several collectors call within the same tick, spawn the process only once.
     if (inflight) return inflight;
 
     inflight = fn()

--- a/src/utils/cors.test.ts
+++ b/src/utils/cors.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// allowedOrigins 는 모듈 로드 시점에 env 를 읽는다. 케이스마다 새로 불러온다.
+// allowedOrigins reads env at module load time. Reimport per case.
 async function withOrigins(value: string | undefined) {
   vi.resetModules();
   if (value === undefined) delete process.env.ALLOWED_ORIGINS;
@@ -17,45 +17,45 @@ describe('corsHeaders', () => {
     delete process.env.ALLOWED_ORIGINS;
   });
 
-  it('허용된 오리진에만 ACAO 를 붙인다', async () => {
+  it('attaches ACAO only to allowed origins', async () => {
     const { corsHeaders } = await withOrigins('https://a.example,https://b.example');
 
     expect(corsHeaders('https://a.example')['Access-Control-Allow-Origin']).toBe('https://a.example');
     expect(corsHeaders('https://evil.example')['Access-Control-Allow-Origin']).toBeUndefined();
   });
 
-  it('오리진이 허용되지 않아도 Vary: Origin 은 항상 붙인다', async () => {
+  it('always attaches Vary: Origin even when the origin is not allowed', async () => {
     const { corsHeaders } = await withOrigins('https://a.example');
 
-    // 응답이 Origin 에 따라 달라지므로, 캐시가 오리진 간에 섞지 않도록
-    // ACAO 를 붙이지 않는 경우에도 Vary 가 필요하다.
+    // The response varies by Origin, so Vary is needed even when ACAO isn't
+    // attached, to keep caches from mixing across origins.
     expect(corsHeaders('https://evil.example').Vary).toBe('Origin');
     expect(corsHeaders(undefined).Vary).toBe('Origin');
     expect(corsHeaders('https://a.example').Vary).toBe('Origin');
   });
 
-  it('설정한 뒤 슬래시는 무시한다', async () => {
-    // Origin 헤더에는 뒤 슬래시가 없어서, .env 에 붙어 있으면 매칭이 어긋난다.
+  it('ignores a trailing slash in the config', async () => {
+    // The Origin header has no trailing slash, so one in .env would break matching.
     const { corsHeaders } = await withOrigins('https://a.example/');
     expect(corsHeaders('https://a.example')['Access-Control-Allow-Origin']).toBe('https://a.example');
   });
 
-  it('콤마 주변 공백과 빈 항목을 견딘다', async () => {
+  it('tolerates whitespace around commas and empty entries', async () => {
     const { corsHeaders } = await withOrigins(' https://a.example ,, https://b.example ');
 
     expect(corsHeaders('https://b.example')['Access-Control-Allow-Origin']).toBe('https://b.example');
-    // 빈 항목이 살아남으면 Origin 없는 요청이 통과해버린다.
+    // If an empty entry survived, a request with no Origin would pass through.
     expect(corsHeaders('')['Access-Control-Allow-Origin']).toBeUndefined();
   });
 
-  it('설정이 없으면 로컬 개발 오리진만 허용한다', async () => {
+  it('allows only the local dev origin when unconfigured', async () => {
     const { corsHeaders } = await withOrigins(undefined);
 
     expect(corsHeaders('http://localhost:3000')['Access-Control-Allow-Origin']).toBe('http://localhost:3000');
     expect(corsHeaders('https://a.example')['Access-Control-Allow-Origin']).toBeUndefined();
   });
 
-  it('넘긴 기본 헤더를 그대로 보존한다', async () => {
+  it('preserves the passed-in base headers as-is', async () => {
     const { corsHeaders } = await withOrigins('https://a.example');
     const headers = corsHeaders('https://a.example', { 'Content-Type': 'text/event-stream' });
 

--- a/src/utils/cors.ts
+++ b/src/utils/cors.ts
@@ -1,6 +1,6 @@
-// /api/system 과 /api/system/stream 이 같은 규칙으로 CORS 를 다루도록 한곳에 모은다.
+// Centralized so /api/system and /api/system/stream handle CORS by the same rules.
 
-// .env 의 ALLOWED_ORIGINS(콤마 구분). 뒤에 붙은 슬래시는 Origin 헤더에 없으므로 떼어낸다.
+// ALLOWED_ORIGINS from .env (comma-separated). A trailing slash isn't in the Origin header, so strip it.
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
   .split(',')
   .map(origin => origin.trim().replace(/\/+$/, ''))
@@ -10,11 +10,11 @@ export function isAllowedOrigin(origin: string | undefined): origin is string {
   return Boolean(origin) && allowedOrigins.includes(origin as string);
 }
 
-// 응답의 Access-Control-Allow-Origin 이 요청 Origin 에 따라 달라지므로 Vary: Origin 이
-// 반드시 필요하다. 없으면 앞단 캐시(리버스 프록시/CDN)가 A 오리진에 내준 응답을
-// B 오리진에 그대로 재사용해, 허용되지 않은 오리진이 읽어 가거나 그 반대가 된다.
-// 오리진이 허용되지 않아 ACAO 를 안 붙이는 경우에도 응답은 Origin 에 의존하므로
-// 항상 붙인다.
+// The response's Access-Control-Allow-Origin varies by the request Origin, so
+// Vary: Origin is required. Without it an upstream cache (reverse proxy/CDN)
+// would reuse the response served to origin A for origin B, letting a
+// disallowed origin read it or vice versa. Even when the origin isn't allowed
+// and ACAO isn't attached, the response still depends on Origin, so always attach it.
 export function corsHeaders(
   origin: string | undefined,
   base: Record<string, string> = {}

--- a/src/utils/dashboardData.ts
+++ b/src/utils/dashboardData.ts
@@ -17,8 +17,8 @@ import {
   TemperatureValue
 } from '@/types/system';
 
-// API 의 새 필드들은 전부 optional 이다(구버전 노드 호환). 컴포넌트마다
-// `?? 0` 을 흩뿌리는 대신, 화면에 넘기기 직전 한 번만 기본값을 채운다.
+// The API's new fields are all optional (old-node compatible). Rather than
+// scattering `?? 0` across every component, fill defaults once, right before handing off to the screen.
 export interface DashboardData {
   cpu: {
     usage: number;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,5 @@
-// 대시보드 표기 전용 포맷터. 수집기는 항상 같은 단위(네트워크는 KB/s, 디스크는 GB)로
-// 보내고, 사람이 읽기 좋은 단위 변환은 전부 여기서 한다.
+// Display-only formatters for the dashboard. Collectors always send the same
+// unit (KB/s for network, GB for disk), and all human-readable unit conversion happens here.
 
 export function formatRate(kbPerSecond: number): string {
   if (!Number.isFinite(kbPerSecond)) return '0 KB/s';
@@ -7,14 +7,14 @@ export function formatRate(kbPerSecond: number): string {
   return `${kbPerSecond.toFixed(kbPerSecond >= 10 ? 0 : 1)} KB/s`;
 }
 
-// 축 눈금처럼 단위를 따로 붙여야 할 때 쓴다.
+// Used when the unit needs to be attached separately, like on an axis tick.
 export function rateUnit(maxKbPerSecond: number): { unit: string; divisor: number } {
   return maxKbPerSecond >= 1024 ? { unit: 'MB/s', divisor: 1024 } : { unit: 'KB/s', divisor: 1 };
 }
 
-// 디스크 I/O 는 MB/s 로 들어온다. 유휴에 가까운 서버는 값이 1 MB/s 를 한참 밑돌아
-// MB/s 로 반올림하면 계속 0.0 으로만 보인다. 두 값 중 큰 쪽이 1 MB/s 미만이면
-// 둘 다 KB/s 로 바꿔, 단위 하나는 공유하되 실제 값이 드러나게 한다.
+// Disk I/O arrives in MB/s. A near-idle server sits far below 1 MB/s, so
+// rounding to MB/s keeps showing 0.0. If the larger of the two is under 1 MB/s,
+// switch both to KB/s — one shared unit, but the real value shows.
 export function formatMbPair(readMb: number, writeMb: number): { read: string; write: string; unit: string } {
   const useKb = Math.max(readMb, writeMb) < 1;
   if (useKb) {
@@ -62,7 +62,7 @@ export function formatClock(date: Date): string {
   return `${day} ${time}`;
 }
 
-// "07-20 14:32" — 좁은 카드에 넣기 위해 연도는 뺀다.
+// "07-20 14:32" — the year is dropped to fit a narrow card.
 export function formatShortDateTime(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return '—';
@@ -71,7 +71,7 @@ export function formatShortDateTime(iso: string): string {
   return `${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
-// 커널 릴리스는 "5.15.0-101-generic" 처럼 길다. 헤더에는 버전만 남긴다.
+// A kernel release like "5.15.0-101-generic" is long. Keep only the version in the header.
 export function shortKernel(release: string): string {
   return release.split('-')[0];
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -3,12 +3,14 @@ import { promisify } from 'util';
 
 const gzipAsync = promisify(gzip);
 
-// Next 는 라우트 핸들러가 돌려주는 Response 를 자동으로 압축하지 않는다.
-// /api/system 응답은 history + processes 로 수십 KB 에 이르고 클러스터가 매초
-// 폴링하므로, 클라이언트가 gzip 을 받는다고 알릴 때만 압축해서 돌려준다.
+// Next does not automatically compress the Response a route handler returns.
+// The /api/system payload reaches tens of KB with history + processes and the
+// cluster polls it every second, so compress it only when the client says it
+// accepts gzip.
 //
-// 스트리밍(SSE)에는 쓰면 안 된다 — 그쪽은 연결을 열어둔 채 흘려보내므로 압축이
-// 실시간성을 깨뜨린다. 이 헬퍼는 완결된 JSON 바디에만 쓴다.
+// Do NOT use this for streaming (SSE): that keeps the connection open and
+// streams as it goes, so compression breaks its real-time behaviour. This
+// helper is for complete JSON bodies only.
 export async function jsonResponse(
   request: Request,
   payload: unknown,
@@ -17,15 +19,16 @@ export async function jsonResponse(
   const body = JSON.stringify(payload);
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    // 같은 URL 이 Accept-Encoding 에 따라 다른 바디를 내므로 캐시가 섞이지 않게 한다.
+    // The same URL returns different bodies depending on Accept-Encoding, so
+    // keep caches from mixing them up.
     Vary: mergeVary(init.headers?.['Vary'], 'Accept-Encoding'),
     ...init.headers
   };
-  // 위에서 ...init.headers 가 Vary 를 덮으므로, 병합한 값을 다시 확정한다.
+  // ...init.headers above can overwrite Vary, so set the merged value again.
   headers['Vary'] = mergeVary(init.headers?.['Vary'], 'Accept-Encoding');
 
   const accepts = (request.headers.get('accept-encoding') || '').toLowerCase().includes('gzip');
-  // 아주 작은 바디는 압축 이득이 없다(헤더/CPU 오버헤드가 더 크다).
+  // Very small bodies gain nothing from compression (the header/CPU overhead costs more).
   if (accepts && body.length > 1024) {
     const compressed = await gzipAsync(body);
     return new Response(compressed, {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
-// 흩어져 있던 console.warn/error 를 레벨 있는 로거 하나로 모은다. LOG_LEVEL 로
-// 출력량을 조절한다(error < warn < info < debug). 기본은 info — 수집기 실패
-// 경고까지는 보이고, 상세 디버그는 감춘다. 의존성 없이 console 위에 얇게 얹는다.
+// Collects the scattered console.warn/error calls into one leveled logger.
+// LOG_LEVEL tunes the volume (error < warn < info < debug). The default is
+// info — collector-failure warnings show, verbose debug is hidden. A thin
+// wrapper over console with no dependencies.
 
 type Level = 'error' | 'warn' | 'info' | 'debug';
 
@@ -14,7 +15,7 @@ function threshold(): number {
 function emit(level: Level, args: unknown[]): void {
   if (ORDER[level] > threshold()) return;
   const prefix = `[${new Date().toISOString()}] ${level.toUpperCase()}`;
-  // error/warn 은 stderr, 나머지는 stdout 으로 나가도록 대응 console 메서드를 쓴다.
+  // error/warn go to stderr, everything else to stdout via the matching console method.
   const sink = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
   sink(prefix, ...args);
 }

--- a/src/utils/statusColors.test.ts
+++ b/src/utils/statusColors.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { COLORS, heatColor, loadCellColor, loadColor, statusColor, tempColor } from '@/utils/statusColors';
 
-// rgb(r, g, b) 를 [r,g,b] 로. 색 자체보다 "초록→빨강 방향" 을 확인하려는 것이다.
+// rgb(r, g, b) to [r,g,b]. The point is checking the "green->red direction" rather than the exact color.
 function channels(color: string): [number, number, number] {
   const match = color.match(/rgb\((\d+), (\d+), (\d+)\)/);
   if (!match) throw new Error(`not an rgb() color: ${color}`);
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
-// 색상환 각도(0=빨강, 120=초록). 채널값으로는 단조성을 볼 수 없다 — 주황의 빨강
-// 채널(249)이 빨강(239)보다 오히려 크기 때문이다. 심각도는 hue 회전으로 읽어야 한다.
+// Color-wheel angle (0=red, 120=green). Channel values can't show monotonicity —
+// orange's red channel (249) is actually larger than red's (239). Severity must be read via hue rotation.
 function hue([r, g, b]: [number, number, number]): number {
   const max = Math.max(r, g, b);
   const min = Math.min(r, g, b);
@@ -22,18 +22,18 @@ function hue([r, g, b]: [number, number, number]): number {
 }
 
 describe('heatColor', () => {
-  it('부하가 오를수록 색이 초록에서 빨강 쪽으로만 돈다', () => {
+  it('rotates color only from green toward red as load rises', () => {
     const hues = [0, 0.25, 0.5, 0.75, 1].map(r => hue(channels(heatColor(r))));
 
-    // 단조 감소(초록 120도대 → 빨강 0도). 되돌아가는 구간이 있으면 추세가
-    // 잘못 읽힌다 — 예를 들어 더 바쁜 구간이 덜 심각해 보인다.
+    // Monotonic decrease (green ~120deg -> red 0deg). A reversal would misread the
+    // trend — e.g. a busier stretch would look less severe.
     for (let i = 1; i < hues.length; i += 1) {
       expect(hues[i]).toBeLessThan(hues[i - 1]);
     }
     expect(hues.at(-1)).toBe(0);
   });
 
-  it('양 끝은 초록과 빨강이다', () => {
+  it('the two ends are green and red', () => {
     const [lowR, lowG] = channels(heatColor(0));
     expect(lowG).toBeGreaterThan(lowR);
 
@@ -41,49 +41,49 @@ describe('heatColor', () => {
     expect(highR).toBeGreaterThan(highG);
   });
 
-  it('범위를 벗어난 값은 양 끝으로 고정된다', () => {
+  it('clamps out-of-range values to the ends', () => {
     expect(heatColor(-5)).toBe(heatColor(0));
     expect(heatColor(9)).toBe(heatColor(1));
   });
 
-  it('유한하지 않은 값에 rgb(NaN) 을 내지 않는다', () => {
-    // clamp 만 있으면 NaN 이 그대로 통과해 rgb(NaN, NaN, NaN) 이 된다.
+  it('does not emit rgb(NaN) for non-finite values', () => {
+    // With clamp alone, NaN passes through and becomes rgb(NaN, NaN, NaN).
     expect(heatColor(NaN)).toBe(COLORS.muted);
     expect(heatColor(Infinity)).toBe(heatColor(1));
   });
 });
 
 describe('loadCellColor', () => {
-  it('값이 없는 구간은 배경색으로 비운다', () => {
+  it('leaves sections with no value in the background color', () => {
     expect(loadCellColor(null, 8)).toBe(COLORS.empty);
   });
 
-  it('코어 수로 나눈 뒤 색을 고른다', () => {
-    // 8코어의 8.0 과 1코어의 1.0 은 둘 다 코어당 1.0 이라 같은 색이어야 한다.
+  it('picks the color after dividing by the core count', () => {
+    // 8.0 on 8 cores and 1.0 on 1 core are both 1.0 per core, so the color must match.
     expect(loadCellColor(8, 8)).toBe(loadCellColor(1, 1));
-    // 같은 로드라도 코어가 많으면 덜 빨갛다.
+    // For the same load, more cores means less red.
     expect(channels(loadCellColor(4, 8))[0]).toBeLessThan(channels(loadCellColor(4, 2))[0]);
   });
 
-  it('코어 수를 모르면(0) 로드를 그대로 쓴다', () => {
+  it('uses the load as-is when the core count is unknown (0)', () => {
     expect(loadCellColor(1, 0)).toBe(heatColor(1));
   });
 });
 
 describe('loadColor', () => {
-  it('유휴 상태에서도 어두운 초록으로 떨어지지 않는다', () => {
-    // 다크 배경 위 글자라 그라데이션의 제일 어두운 끝은 읽히지 않는다.
+  it('does not fall to dark green even when idle', () => {
+    // As text on a dark background, the darkest end of the gradient isn't readable.
     expect(loadColor(0, 8)).not.toBe(heatColor(0));
     expect(loadColor(0, 8)).toBe(heatColor(0.35));
   });
 
-  it('포화 구간에서는 격자와 같은 빨강이다', () => {
+  it('is the same red as the grid in the saturated range', () => {
     expect(loadColor(8, 8)).toBe(heatColor(1));
   });
 });
 
 describe('statusColor', () => {
-  it('50/80 을 경계로 초록·주황·빨강을 고른다', () => {
+  it('picks green/orange/red at the 50/80 boundaries', () => {
     expect(statusColor(49)).toBe(COLORS.ok);
     expect(statusColor(50)).toBe(COLORS.warn);
     expect(statusColor(79)).toBe(COLORS.warn);
@@ -92,11 +92,11 @@ describe('statusColor', () => {
 });
 
 describe('tempColor', () => {
-  it('센서가 없으면 회색이다', () => {
+  it('is gray when there is no sensor', () => {
     expect(tempColor('N/A')).toBe('#9ca3af');
   });
 
-  it('온도가 오를수록 단계가 올라간다', () => {
+  it('steps up as the temperature rises', () => {
     const steps = [tempColor(40), tempColor(60), tempColor(70), tempColor(80)];
     expect(new Set(steps).size).toBe(4);
   });

--- a/src/utils/statusColors.ts
+++ b/src/utils/statusColors.ts
@@ -1,4 +1,4 @@
-// 대시보드 전체가 같은 기준으로 색을 고르도록 한곳에 모아둔다.
+// Centralized so the whole dashboard picks colors by the same rules.
 
 export const COLORS = {
   ok: '#10b981',
@@ -23,30 +23,32 @@ export function tempColor(temperature: number | 'N/A'): string {
   return '#f87171';
 }
 
-// 로드는 코어 수로 나눠야 의미가 있다. 4코어의 4.0 과 1코어의 4.0 은 다르다.
-// 격자와 같은 그라데이션을 쓰되, 글자라서 어두운 쪽 끝은 잘라 가독성을 지킨다.
+// Load is only meaningful divided by the core count. 4.0 on 4 cores differs
+// from 4.0 on 1 core. Uses the same gradient as the grid, but clips the dark
+// end for text readability.
 export function loadColor(load: number, cores: number): string {
   const perCore = cores > 0 ? load / cores : load;
   return heatColor(Math.max(TEXT_HEAT_FLOOR, perCore));
 }
 
-// 부하가 낮으면 초록, 높아질수록 노랑 → 주황 → 빨강으로 이어지는 연속 그라데이션.
-// 단계식으로 끊으면 0.59 와 0.61 이 완전히 다른 색이 되어 추세가 안 보인다.
+// A continuous gradient: green when load is low, then yellow -> orange -> red
+// as it rises. Stepping it discretely would make 0.59 and 0.61 completely
+// different colors and hide the trend.
 const HEAT_STOPS: ReadonlyArray<readonly [number, readonly [number, number, number]]> = [
-  [0, [14, 68, 41]], // 거의 유휴 — 어두운 초록
+  [0, [14, 68, 41]], // nearly idle — dark green
   [0.35, [38, 166, 65]],
   [0.6, [250, 204, 21]],
   [0.8, [249, 115, 22]],
-  [1, [239, 68, 68]] // 포화 — 빨강
+  [1, [239, 68, 68]] // saturated — red
 ];
 
-// 어두운 배경 위 글자에는 그라데이션의 제일 어두운 초록이 너무 안 읽힌다.
+// The gradient's darkest green is too hard to read as text on a dark background.
 const TEXT_HEAT_FLOOR = 0.35;
 
-// ratio 는 0(유휴)~1(포화)로 정규화된 부하. 범위를 벗어나면 양 끝 색으로 고정된다.
+// ratio is load normalized to 0 (idle)-1 (saturated). Out of range clamps to the end colors.
 export function heatColor(ratio: number): string {
-  // NaN 은 clamp 를 그대로 통과해 rgb(NaN,…) 가 되므로 먼저 막는다. ±Infinity 는
-  // 막지 않는다 — 아래 clamp 가 양 끝(유휴/포화)으로 접어 주는 편이 자연스럽다.
+  // NaN passes clamp through and becomes rgb(NaN,...), so block it first. Don't
+  // block +/-Infinity — the clamp below folding it to an end (idle/saturated) is more natural.
   if (Number.isNaN(ratio)) return COLORS.muted;
   const t = Math.min(1, Math.max(0, ratio));
   for (let i = 1; i < HEAT_STOPS.length; i++) {
@@ -61,7 +63,7 @@ export function heatColor(ratio: number): string {
   return COLORS.critical;
 }
 
-// 값이 없는 구간은 배경색으로 비워 둔다. 코어당 로드 1.0 을 포화로 본다.
+// Sections with no value are left empty in the background color. Treats a per-core load of 1.0 as saturation.
 export function loadCellColor(load: number | null, cores: number): string {
   if (load === null) return COLORS.empty;
   const perCore = cores > 0 ? load / cores : load;

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -35,10 +35,10 @@ import { getFirewallInfo, getSshSessions } from '@/utils/collectors/security';
 import { getHistory, getLoad30mAverage, recordSample } from '@/utils/collectors/history';
 import { evaluateAlerts } from '@/utils/collectors/alerts';
 
-// 캐시된 시스템 정보
+// Cached system info
 let cachedData: ServerData | null = null;
 let lastUpdateTime = 0;
-const UPDATE_INTERVAL = 1000; // 1초마다 업데이트
+const UPDATE_INTERVAL = 1000; // update once per second
 
 interface CpuInfo {
   usage: number;
@@ -75,7 +75,7 @@ interface NetworkInfo {
   interfaces: ServerData['network']['interfaces'];
   linkSpeedMbps: number | null;
   bandwidthPercentage: number;
-  // 부팅 이후 기본 인터페이스의 누적 수신/송신 바이트. 월 대역폭 관리에 쓴다.
+  // Cumulative rx/tx bytes on the default interface since boot. Used for monthly bandwidth budgeting.
   totalRxBytes: number;
   totalTxBytes: number;
 }
@@ -135,7 +135,7 @@ async function getMemoryInfo(): Promise<MemoryInfo> {
   const totalKb = field('MemTotal');
   if (!totalKb) throw new Error('MemTotal missing from /proc/meminfo');
 
-  // MemAvailable 이 커널에 없으면(3.14 미만) free + buffers + cached 로 근사한다.
+  // If the kernel lacks MemAvailable (< 3.14), approximate with free + buffers + cached.
   const availableKb =
     field('MemAvailable') ?? (field('MemFree') ?? 0) + (field('Buffers') ?? 0) + (field('Cached') ?? 0);
 
@@ -154,9 +154,9 @@ interface DiskReport extends DiskInfo {
 }
 
 async function getDiskInfo(): Promise<DiskReport> {
-  // -P 는 긴 장치명 때문에 줄이 두 줄로 접히는 것을 막고,
-  // -k 는 1K 블록으로 고정해 "20G"/"1.5T"/"800M" 단위 파싱을 없앤다.
-  // 경로 인자 없이 전체 마운트를 읽어 루트 외 파일시스템도 함께 돌려준다.
+  // -P stops long device names from wrapping a row onto two lines, and -k pins
+  // 1K blocks so we don't have to parse "20G"/"1.5T"/"800M" units.
+  // With no path argument it reads every mount, returning non-root filesystems too.
   const stdout = await run('df -Pk');
   const mounts = parseDf(stdout);
 
@@ -178,7 +178,7 @@ async function getPing(): Promise<number> {
     throw new Error(`invalid PING_HOST: ${host}`);
   }
 
-  // -W 1: 응답이 없을 때 기본 10초를 기다리며 요청 전체를 붙잡는 것을 막는다.
+  // -W 1: stops it from waiting the default 10s and holding up the whole request when there's no reply.
   const stdout = await run(`ping -c 1 -W 1 ${host} || true`);
   const match = stdout.match(/time[=<]\s*([\d.]+)\s*ms/);
   return match ? parseFloat(match[1]) : 0;
@@ -200,20 +200,20 @@ async function getNetworkInfo(warnings: string[], sockets: SocketSummary): Promi
   const previous = prevNetSample;
   prevNetSample = { rx: rxBytes, tx: txBytes, at: now };
 
-  // 이전 샘플과의 실제 경과 시간으로 나눈다. 폴링 간격이 정확히 1초라고
-  // 가정하면 요청이 밀릴 때마다 속도가 부풀려진다.
+  // Divide by the actual elapsed time since the previous sample. Assuming the
+  // polling interval is exactly 1s would inflate the rate whenever requests lag.
   let download = 0;
   let upload = 0;
   if (previous) {
     const elapsedSeconds = (now - previous.at) / 1000;
     if (elapsedSeconds > 0) {
-      // 카운터가 리셋(재부팅/인터페이스 교체)되면 음수가 나오므로 0으로 막는다.
+      // If the counter resets (reboot / interface swap) the result goes negative, so clamp to 0.
       download = Math.max(0, (rxBytes - previous.rx) / 1024 / elapsedSeconds);
       upload = Math.max(0, (txBytes - previous.tx) / 1024 / elapsedSeconds);
     }
   }
 
-  // 에러율은 바이트가 아니라 패킷 대비로 계산해야 의미가 있다.
+  // The error rate is only meaningful against packets, not bytes.
   const rate = (errors: number, packets: number) =>
     packets > 0 ? ((errors / packets) * 100).toFixed(2) : '0.00';
 
@@ -223,7 +223,7 @@ async function getNetworkInfo(warnings: string[], sockets: SocketSummary): Promi
   ]);
 
   const linkSpeedMbps = interfaces.find(entry => entry.isDefault)?.speedMbps ?? null;
-  // 링크 속도(Mbps)를 KB/s 로 바꿔 현재 처리량과 같은 단위로 비교한다.
+  // Convert the link speed (Mbps) to KB/s to compare against current throughput in the same unit.
   const linkCapacityKbps = linkSpeedMbps === null ? null : (linkSpeedMbps * 1000) / 8;
 
   return {
@@ -251,7 +251,7 @@ async function readSensors(): Promise<string> {
   return run('sensors');
 }
 
-// lm-sensors 가 없는 서버(대부분의 VPS/컨테이너)를 위한 sysfs 대체 경로.
+// The sysfs fallback path for servers without lm-sensors (most VPSes/containers).
 async function readThermalZone(): Promise<number | 'N/A'> {
   let entries: string[];
   try {
@@ -290,7 +290,7 @@ async function getCpuTemperature(): Promise<number | 'N/A'> {
         : sensors.match(/cpu_thermal[\s\S]*?temp1:\s*\+?([\d.]+)°C/);
     if (match) return parseFloat(match[1]);
   } catch {
-    // sensors 미설치. 아래 sysfs 경로로 넘어간다.
+    // sensors not installed. Fall through to the sysfs path below.
   }
 
   return readThermalZone();
@@ -329,7 +329,7 @@ async function getTemperature(): Promise<TemperatureInfo> {
   return arm;
 }
 
-// lm-sensors 가 없으면 hwmon 의 fan*_input 을 직접 읽는다.
+// Without lm-sensors, read hwmon's fan*_input directly.
 async function readHwmonFans(): Promise<number[]> {
   let hwmons: string[];
   try {
@@ -361,7 +361,7 @@ async function getFanSpeed(): Promise<FanInfo> {
     };
     if (fans.cpu || fans.case1 || fans.case2) return fans;
   } catch {
-    // sensors 미설치. hwmon 으로 넘어간다.
+    // sensors not installed. Fall through to hwmon.
   }
 
   const [cpu = 0, case1 = 0, case2 = 0] = await readHwmonFans();
@@ -370,14 +370,15 @@ async function getFanSpeed(): Promise<FanInfo> {
 
 // --- Processes / Uptime ------------------------------------------------
 
-// `args`(전체 명령줄) 대신 `comm`(실행 파일명)만 읽는다. 명령줄 인자에는
-// 비밀번호/토큰이 그대로 노출되는 경우가 많은데(예: `mysql -pSECRET`,
-// `--api-key=...`), 이 목록은 API 로도 나가므로 실행 파일명이면 충분하고 안전하다.
-// 파이프라인의 종료 코드는 head 의 것이라 ps 가 실패해도 0 이 된다.
-// 빈 출력을 그대로 넘기면 원인 없이 목록만 비므로 여기서 에러로 올린다.
+// Read only `comm` (the executable name), not `args` (the full command line).
+// Command-line arguments often expose passwords/tokens directly (e.g. `mysql
+// -pSECRET`, `--api-key=...`), and this list also goes out over the API, so the
+// executable name is enough and safe. The pipeline's exit code is head's, so it
+// stays 0 even if ps fails. Passing empty output through would leave the list
+// blank with no cause, so raise an error here.
 async function getProcessesBy(sort: '-pcpu' | '-pmem'): Promise<Process[]> {
   const stdout = await run(`ps -eo pid,pcpu,pmem,stat,comm --sort=${sort} | head -n 21`);
-  const lines = stdout.split('\n').slice(1); // 헤더 제거
+  const lines = stdout.split('\n').slice(1); // drop the header
   if (lines.length === 0) {
     throw new Error('ps returned no rows (does this ps support --sort?)');
   }
@@ -412,9 +413,10 @@ function getProcesses(): Promise<Process[]> {
   return getProcessesBy('-pcpu');
 }
 
-// 전체 프로세스 규모 요약. 상위 목록(top 20)과 달리 시스템 전체를 센다. 상태 한
-// 글자만 읽어(`stat=`) 가볍게, 좀비(Z) 급증 같은 이상 징후를 드러낸다. 스레드
-// 포함 태스크 수는 /proc/loadavg 분모에서 얻는다.
+// Whole-system process summary. Unlike the top list (top 20) it counts the
+// entire system. Reads just one state character (`stat=`) to stay light, and
+// surfaces anomalies like a zombie (Z) spike. The thread-inclusive task count
+// comes from the denominator in /proc/loadavg.
 async function getProcessSummary(): Promise<ProcessSummary> {
   const stdout = await run('ps -eo stat= 2>/dev/null');
   const states = stdout
@@ -439,14 +441,14 @@ async function getProcessSummary(): Promise<ProcessSummary> {
     const match = loadavg.match(/\d+\/(\d+)/);
     if (match) threads = parseInt(match[1], 10);
   } catch {
-    // /proc 없음(리눅스 아님). 스레드 수는 비운다.
+    // no /proc (not Linux). Leave the thread count empty.
   }
 
   return { total: states.length, running, sleeping, zombie, threads };
 }
 
 async function getUptime(): Promise<UptimeInfo> {
-  // `uptime -p` 는 busybox 에 없고 출력이 로케일을 탄다. os.uptime() 이 안전하다.
+  // `uptime -p` is missing on busybox and its output is locale-dependent. os.uptime() is safe.
   const seconds = os.uptime();
   return {
     days: Math.floor(seconds / 86400),
@@ -489,8 +491,8 @@ export async function getSystemInfo(): Promise<ServerData> {
 
   const warnings: string[] = [];
 
-  // 연결 수, 열린 포트, 상위 트래픽 피어는 모두 같은 소켓 목록에서 나온다.
-  // 한 번만 읽어 네트워크/보안 수집기가 나눠 쓴다.
+  // Connection count, open ports, and top traffic peers all come from the same
+  // socket list. Read it once and share it between the network/security collectors.
   const sockets = await collect(
     'network.sockets',
     getSocketSummary,
@@ -498,8 +500,8 @@ export async function getSystemInfo(): Promise<ServerData> {
     warnings
   );
 
-  // Promise.all 이 아니라 개별 fallback 으로 감싼다. 예전에는 수집기 하나만
-  // 실패해도 전체 응답이 0으로 떨어졌다.
+  // Wrap each with its own fallback rather than a bare Promise.all. Previously a
+  // single collector failure dropped the whole response to zeros.
   const [
     cpu,
     memory,
@@ -576,7 +578,7 @@ export async function getSystemInfo(): Promise<ServerData> {
   recordDiskSample(disk.percentage, now);
   const diskHoursToFull = getHoursToFull(now);
 
-  // 창은 방금 넣은 샘플까지 포함해야 하므로 recordSample 뒤에 읽는다.
+  // The window must include the sample we just added, so read it after recordSample.
   const rolling30m = getLoad30mAverage(now);
   const load: LoadInfo = {
     ...loadBase,

--- a/src/utils/systemStream.ts
+++ b/src/utils/systemStream.ts
@@ -2,27 +2,28 @@ import { ServerData } from '@/types/system';
 import { getSystemInfo } from '@/utils/systemMonitor';
 import { logger } from '@/utils/logger';
 
-// 요청마다 수집기를 돌리는 대신, 프로세스 안에서 딱 하나의 루프만 돌린다.
-// 접속자가 몇 명이든 쉘 프로세스 spawn(sensors/ping/ps/df ...)은 한 번으로
-// 고정되고, 각 SSE 연결은 그 결과를 나눠 받기만 한다.
+// Instead of running the collectors per request, run exactly one loop in the
+// process. No matter how many clients connect, the shell spawns
+// (sensors/ping/ps/df ...) happen once, and each SSE connection just shares the result.
 //
-// 루프는 구독자가 없어도 멈추지 않는다. 아무도 안 보고 있어도 히스토리(48/24시간
-// 그래프)와 임계값 알림은 계속 쌓여야 하기 때문이다("24/7 수집"). 다만 보는 사람이
-// 없을 때는 틱 간격을 늘려 부하를 줄인다 — 히스토리 버킷이 1시간 단위라
-// 유휴 구간을 촘촘히 샘플링할 이유가 없다.
+// The loop does not stop when there are no subscribers. Even with nobody
+// watching, the history (48/24-hour graphs) and threshold alerts must keep
+// accumulating ("24/7 collection"). When no one is watching, though, the tick
+// interval is widened to reduce load — the history buckets are hourly, so
+// there's no reason to sample idle stretches densely.
 
 type Listener = (data: ServerData) => void;
 
-const ACTIVE_TICK_MS = 1000; // 보는 사람이 있을 때: 실시간
-const IDLE_TICK_MS = Number(process.env.IDLE_TICK_MS) || 15000; // 아무도 없을 때: 절약
+const ACTIVE_TICK_MS = 1000; // someone is watching: real-time
+const IDLE_TICK_MS = Number(process.env.IDLE_TICK_MS) || 15000; // nobody watching: save resources
 
 const listeners = new Set<Listener>();
 let running = false;
 let handle: ReturnType<typeof setTimeout> | null = null;
 let lastData: ServerData | null = null;
 
-// 수집 루프 자체의 건강 상태. /api/health 가 읽어, 루프가 멈췄거나 계속 실패하는
-// 상황을 스케줄러/모니터가 감지할 수 있게 한다.
+// Health of the collection loop itself. /api/health reads this so a
+// scheduler/monitor can detect a stalled or continuously-failing loop.
 let lastTickAt = 0;
 let consecutiveFailures = 0;
 
@@ -49,7 +50,7 @@ async function tick(): Promise<void> {
     lastTickAt = Date.now();
     consecutiveFailures = 0;
     for (const listener of listeners) {
-      // 한 구독자의 예외가 다른 구독자에게 번지지 않게 격리한다.
+      // Isolate each subscriber so one's exception doesn't spread to the others.
       try {
         listener(data);
       } catch (error) {
@@ -57,15 +58,16 @@ async function tick(): Promise<void> {
       }
     }
   } catch (error) {
-    // 수집 자체가 실패해도 루프는 살려둔다. 이번 틱만 건너뛰고,
-    // 구독자는 마지막으로 받은 값을 그대로 들고 있는다.
+    // Keep the loop alive even if collection itself fails. Skip just this tick;
+    // subscribers keep holding the last value they received.
     consecutiveFailures += 1;
     logger.error('system collection loop failed:', error);
   }
 }
 
-// setInterval 대신 "완료 후 다음 예약" 방식이라, 수집이 간격보다 오래 걸려도
-// 요청이 겹쳐 쌓이지 않는다. 간격은 구독자 유무에 따라 매 틱 다시 정한다.
+// "Schedule the next after completion" rather than setInterval, so requests
+// don't pile up when collection takes longer than the interval. The interval
+// is re-decided every tick based on whether there are subscribers.
 async function loop(): Promise<void> {
   if (!running) return;
   await tick();
@@ -76,8 +78,9 @@ async function loop(): Promise<void> {
 }
 
 /**
- * 수집 루프가 돌고 있지 않으면 시작한다. 서버 부팅 시(instrumentation) 한 번,
- * 그리고 첫 구독자가 붙을 때 호출된다. 이미 돌고 있으면 아무 것도 하지 않는다.
+ * Starts the collection loop if it isn't running. Called once at server boot
+ * (instrumentation) and when the first subscriber attaches. Does nothing if
+ * already running.
  */
 export function ensureCollecting(): void {
   if (running) return;
@@ -86,9 +89,10 @@ export function ensureCollecting(): void {
 }
 
 /**
- * 시스템 데이터 갱신을 구독한다. 구독 즉시(값이 있으면) 마지막 스냅샷을 한 번
- * 전달하므로, 새 연결이 다음 틱까지 기다리지 않는다. 반환된 함수를 호출하면
- * 구독이 해제된다. 마지막 구독자가 빠져도 수집 루프는 계속 돈다(24/7).
+ * Subscribes to system-data updates. On subscribe it delivers the last
+ * snapshot once (if any), so a new connection doesn't wait for the next tick.
+ * Call the returned function to unsubscribe. The loop keeps running even after
+ * the last subscriber leaves (24/7).
  */
 export function subscribe(listener: Listener): () => void {
   listeners.add(listener);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'url';
 import { defineConfig } from 'vitest/config';
 
-// 앱 코드가 '@/...' 로 임포트하므로 테스트에서도 같은 별칭을 풀어 준다.
+// App code imports via '@/...', so resolve the same alias in tests.
 export default defineConfig({
   resolve: {
     alias: {
@@ -9,7 +9,7 @@ export default defineConfig({
     }
   },
   test: {
-    // 수집기는 fs/os/child_process 를 쓴다. 브라우저 환경이 필요 없다.
+    // Collectors use fs/os/child_process. No browser environment is needed.
     environment: 'node',
     include: ['src/**/*.test.ts']
   }


### PR DESCRIPTION
Follow-up to #41. Completes the two 20-list items that had data but no UI surface, and converts the entire codebase to English.

## UI features (were collected but not shown)
- **Per-core normalized load** (20-list #3): LOAD AVG now shows `load1/cores` (1.00 = all cores saturated), colored by severity with an explanatory tooltip. A load of 8 reads very differently on 4 vs 16 cores; this makes that legible next to the absolute averages.
- **CPU/MEM process sort toggle** (20-list #6): TOP PROCESSES gets a small CPU/MEM toggle backed by the memory-sorted list the API already returns (`topProcessesByMemory`), with the active column highlighted.

## English-only translation
The project is now 100% English. Every Korean comment, JSDoc block, test description, and Dockerfile note across **49 files** was translated to English.
- **Comments only** — no code, control flow, or test assertions were changed. Test `it(...)` descriptions were translated (behavior identical; 51/51 still pass).
- Done as exact-string replacements so code was never touched, then re-run through Prettier.

## Verification
- `npm run format:check && npm run lint && npm run typecheck` — all clean.
- `npm test` — 51/51 pass.
- `npm run build` — standalone build succeeds with all routes.
- Full-repo scan confirms zero Hangul remains in any text/source file.

## Notes
- Split into two commits: the Dashboard UI features, then the sweeping translation — review the translation commit as prose-only.
- Still deferred (unchanged from #41): the React 19 upgrade, left for Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014NW1o5A9egFuvNfEAqtqht)_