### PR TITLE
M1: alert engine overhaul — rules, routing, mute, anomaly, /alerts history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,43 @@ ALLOWED_ORIGINS=http://localhost:4000,http://192.168.0.100:4000,http://192.168.0
 # ALERT_TEMP_CLEAR=70
 # ALERT_SWAP_ENTER=80
 # ALERT_SWAP_CLEAR=60
+#
+# Expanded rules (M1). Load is per-core; battery and disk-fill are "low is bad".
+# ALERT_LOAD_ENTER=2
+# ALERT_LOAD_CLEAR=1.5
+# ALERT_GPU_TEMP_ENTER=85
+# ALERT_GPU_TEMP_CLEAR=78
+# ALERT_BATTERY_ENTER=15
+# ALERT_BATTERY_CLEAR=25
+# ALERT_DISKFILL_ENTER_HOURS=24
+# ALERT_DISKFILL_CLEAR_HOURS=48
+# Composite "memory pressure" (RAM and swap both high) → critical.
+# ALERT_MEMPRESSURE_MEM=90
+# ALERT_MEMPRESSURE_SWAP=80
+#
+# Flapping suppression: after THRESHOLD enter/clear transitions within WINDOW
+# minutes, a rule stops paging (still logged on screen) until it settles.
+# ALERT_FLAP_WINDOW_MINUTES=10
+# ALERT_FLAP_THRESHOLD=6
+#
+# Statistical anomaly detection (opt-in): flag CPU far from its own recent
+# baseline even when under the absolute threshold. Off unless set truthy.
+# ALERT_ANOMALY_ENABLE=0
+#
+# Per-severity webhook routing. Each falls back to ALERT_WEBHOOK_URL when unset;
+# each may be a comma-separated list. Lets critical page elsewhere than warnings.
+# ALERT_WEBHOOK_URL_CRITICAL=
+# ALERT_WEBHOOK_URL_WARNING=
+# ALERT_WEBHOOK_URL_INFO=
+# ALERT_WEBHOOK_URL_OK=
+# Batch alerts firing within this many ms into one combined message per channel.
+# 0 (default) sends each immediately.
+# ALERT_BATCH_MS=0
+#
+# Quiet hours "HH:MM-HH:MM" (server local time). During this window outbound
+# webhook notifications are suppressed; the on-screen log still records. Manual
+# muting is also available at runtime via POST /api/alerts/mute.
+# ALERT_QUIET_HOURS=22:00-07:00
 
 # --- History persistence (src/utils/collectors/history.ts) -----------------
 # The load (48h) and CPU (24h) history charts are persisted to disk so a

--- a/README.md
+++ b/README.md
@@ -189,6 +189,34 @@ read on the server.
 Adding, removing, or repointing a cluster node is now a one-line edit in
 `.env` — no code changes or redeploy of the dashboard logic required.
 
+## Alerting
+
+Threshold rules evaluate every collection tick with hysteresis (separate enter/
+clear values) so a value hovering at the line doesn't flood the log. Beyond the
+core CPU/memory/disk/temperature/swap rules, the set covers **load per core**,
+**GPU temperature**, **low battery**, **disk fill-forecast** (hours to full), and
+a composite **memory-pressure** rule (RAM and swap both high). Optional
+**statistical anomaly detection** (`ALERT_ANOMALY_ENABLE`) flags CPU that departs
+sharply from its own recent baseline even under the absolute threshold.
+
+Every alert shows on the dashboard's alert card and is persisted to
+`data/alerts.json`. The **`/alerts`** page is the full history with a level
+filter, text search, and a 48-hour incident timeline.
+
+Outbound notifications (off until `ALERT_WEBHOOK_URL` is set) support `json`,
+`slack`, and `discord` shapes, **per-severity routing** (`ALERT_WEBHOOK_URL_CRITICAL`
+etc.), and optional **batching** (`ALERT_BATCH_MS`). **Flapping suppression** stops
+a rule that toggles rapidly from paging (it stays on the on-screen log). To
+silence notifications during maintenance, set **quiet hours**
+(`ALERT_QUIET_HOURS="22:00-07:00"`) or mute at runtime:
+
+```bash
+curl -X POST localhost:3000/api/alerts/mute -H 'Content-Type: application/json' -d '{"minutes":30}'
+curl -X DELETE localhost:3000/api/alerts/mute   # lift early
+```
+
+All alert tuning lives in environment variables — see `.env.example`.
+
 ## Scripts
 
 - `scripts/diagnose.sh` — prints the raw contents of every source the API

--- a/src/app/alerts/page.tsx
+++ b/src/app/alerts/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+import type { AlertEntry, AlertLevel } from '@/types/system';
+
+// Alert history view. The dashboard card shows only the most recent alerts and
+// scrolls them away; this reads the full persisted log (/api/alerts) with a
+// level filter, a text search, and a 48h incident timeline strip (#60).
+
+const LEVELS: AlertLevel[] = ['critical', 'warning', 'info', 'ok'];
+
+const LEVEL_COLOR: Record<AlertLevel, string> = {
+  critical: '#ef4444',
+  warning: '#f59e0b',
+  info: '#60a5fa',
+  ok: '#34d399'
+};
+
+const WINDOW_MS = 48 * 60 * 60 * 1000;
+
+export default function AlertsPage() {
+  const [alerts, setAlerts] = useState<AlertEntry[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [level, setLevel] = useState<AlertLevel | 'all'>('all');
+  const [query, setQuery] = useState('');
+  // Set on each load (never during render) so the timeline's "now" edge advances
+  // without an impure Date.now() in the render body.
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch('/api/alerts')
+        .then(response => {
+          if (response.status === 401) {
+            window.location.href = '/login?next=/alerts';
+            return null;
+          }
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return response.json();
+        })
+        .then(data => {
+          if (!cancelled && data) {
+            setAlerts(Array.isArray(data.alerts) ? data.alerts : []);
+            setNow(Date.now());
+          }
+        })
+        .catch(err => {
+          if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load');
+        });
+
+    load();
+    const timer = setInterval(load, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return alerts.filter(
+      alert =>
+        (level === 'all' || alert.level === level) &&
+        (needle === '' || alert.message.toLowerCase().includes(needle))
+    );
+  }, [alerts, level, query]);
+
+  return (
+    <div className="min-h-screen bg-gray-900 p-4 text-gray-100 sm:p-6">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-4 flex items-center justify-between">
+          <h1 className="text-lg font-semibold">Alert history</h1>
+          <Link href="/" className="text-xs text-blue-400 hover:underline">
+            ← Dashboard
+          </Link>
+        </header>
+
+        {/* 48h incident timeline */}
+        <Timeline alerts={alerts} now={now} />
+
+        {/* Filters */}
+        <div className="mb-4 mt-4 flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => setLevel('all')}
+            className={`rounded px-2 py-1 text-xs ${level === 'all' ? 'bg-gray-700' : 'bg-gray-800'}`}
+          >
+            all
+          </button>
+          {LEVELS.map(l => (
+            <button
+              key={l}
+              onClick={() => setLevel(l)}
+              className={`rounded px-2 py-1 text-xs ${level === l ? 'bg-gray-700' : 'bg-gray-800'}`}
+              style={{ color: LEVEL_COLOR[l] }}
+            >
+              {l}
+            </button>
+          ))}
+          <input
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            placeholder="Search messages…"
+            className="ml-auto w-48 rounded border border-gray-700 bg-gray-800 px-2 py-1 text-xs outline-none focus:border-blue-500"
+          />
+        </div>
+
+        {error && <div className="mb-3 text-xs text-red-400">Could not load alerts: {error}</div>}
+
+        <ul className="divide-y divide-gray-800 rounded-lg border border-gray-800">
+          {filtered.length === 0 ? (
+            <li className="p-4 text-center text-xs text-gray-500">No alerts match.</li>
+          ) : (
+            filtered.map(alert => (
+              <li key={alert.id} className="flex items-center gap-3 p-3">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: LEVEL_COLOR[alert.level] }}
+                  aria-hidden
+                />
+                <span className="flex-1 text-sm">{alert.message}</span>
+                <time className="shrink-0 text-xs text-gray-500" dateTime={alert.at}>
+                  {new Date(alert.at).toLocaleString()}
+                </time>
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+const Timeline: React.FC<{ alerts: AlertEntry[]; now: number }> = ({ alerts, now }) => {
+  const start = now - WINDOW_MS;
+  const marks = alerts
+    .map(alert => ({ alert, t: new Date(alert.at).getTime() }))
+    .filter(({ t }) => t >= start && t <= now);
+
+  return (
+    <div className="rounded-lg border border-gray-800 bg-gray-950/40 p-3">
+      <div className="mb-1 flex justify-between text-[10px] text-gray-500">
+        <span>48h ago</span>
+        <span>now</span>
+      </div>
+      <div className="relative h-6 w-full rounded bg-gray-800/60">
+        {marks.map(({ alert, t }) => {
+          const left = ((t - start) / WINDOW_MS) * 100;
+          return (
+            <span
+              key={alert.id}
+              className="absolute top-1/2 h-3 w-1 -translate-y-1/2 rounded-sm"
+              style={{ left: `${left}%`, backgroundColor: LEVEL_COLOR[alert.level] }}
+              title={`${new Date(alert.at).toLocaleString()} — ${alert.message}`}
+            />
+          );
+        })}
+        {marks.length === 0 && (
+          <span className="absolute inset-0 flex items-center justify-center text-[10px] text-gray-600">
+            no incidents in the last 48h
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/api/alerts/mute/route.ts
+++ b/src/app/api/alerts/mute/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { clearMute, muteAll, muteKey, muteStatus } from '@/utils/collectors/alertMute';
+
+// Manual alert muting ("snooze"), e.g. during maintenance. Muting suppresses the
+// external webhook only — the on-screen alert log keeps recording. Same-origin
+// control endpoint used by the dashboard; protect it at the network layer along
+// with the rest of the app (see README "Securing the API").
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json(muteStatus(), { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => ({}))) as { minutes?: unknown; key?: unknown };
+  const minutes = typeof body.minutes === 'number' && Number.isFinite(body.minutes) ? body.minutes : 60;
+  if (minutes <= 0) {
+    return NextResponse.json({ error: 'minutes must be positive' }, { status: 400 });
+  }
+
+  if (typeof body.key === 'string' && body.key.trim() !== '') {
+    muteKey(body.key.trim(), minutes);
+  } else {
+    muteAll(minutes);
+  }
+  return NextResponse.json(muteStatus());
+}
+
+export function DELETE() {
+  clearMute();
+  return NextResponse.json(muteStatus());
+}

--- a/src/app/api/alerts/mute/route.ts
+++ b/src/app/api/alerts/mute/route.ts
@@ -14,12 +14,17 @@ export function GET() {
   return NextResponse.json(muteStatus(), { headers: { 'Cache-Control': 'no-store' } });
 }
 
+// Cap so an absurd duration can't push the expiry past the valid Date range
+// (which would make muteStatus() throw on toISOString). 30 days is plenty.
+const MAX_MUTE_MINUTES = 30 * 24 * 60;
+
 export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as { minutes?: unknown; key?: unknown };
-  const minutes = typeof body.minutes === 'number' && Number.isFinite(body.minutes) ? body.minutes : 60;
-  if (minutes <= 0) {
+  const requested = typeof body.minutes === 'number' && Number.isFinite(body.minutes) ? body.minutes : 60;
+  if (requested <= 0) {
     return NextResponse.json({ error: 'minutes must be positive' }, { status: 400 });
   }
+  const minutes = Math.min(requested, MAX_MUTE_MINUTES);
 
   if (typeof body.key === 'string' && body.key.trim() !== '') {
     muteKey(body.key.trim(), minutes);

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+import { getAlertLog } from '@/utils/collectors/alerts';
+
+// The persisted alert log for the /alerts history page. Reads process/on-disk
+// state only (no host collection), so it's cheap and safe to poll.
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json({ alerts: getAlertLog() }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import {
   Activity,
   AlignLeft,
@@ -841,6 +842,9 @@ const AlertsCard: React.FC<{ data: DashboardData; now: number | null }> = ({ dat
         </li>
       ))}
     </ul>
+    <Link href="/alerts" className="t-label mt-1 block text-right text-gray-500 hover:text-gray-300">
+      full history →
+    </Link>
   </Card>
 );
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -49,5 +49,7 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/api/system', '/api/system/:path*']
+  // /api/alerts is gated too: GET can expose SSH usernames/source IPs in alert
+  // messages, and the mute POST/DELETE change notification behaviour.
+  matcher: ['/api/system', '/api/system/:path*', '/api/alerts', '/api/alerts/:path*']
 };

--- a/src/utils/collectors/alertMute.test.ts
+++ b/src/utils/collectors/alertMute.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearMute, inQuietHours, isMuted, muteAll, muteKey } from '@/utils/collectors/alertMute';
+
+afterEach(() => clearMute());
+
+describe('inQuietHours', () => {
+  it('handles a same-day window', () => {
+    const spec = '09:00-17:00';
+    expect(inQuietHours(new Date(2026, 0, 2, 12, 0), spec)).toBe(true);
+    expect(inQuietHours(new Date(2026, 0, 2, 8, 0), spec)).toBe(false);
+    expect(inQuietHours(new Date(2026, 0, 2, 17, 0), spec)).toBe(false); // end exclusive
+  });
+
+  it('wraps past midnight', () => {
+    const spec = '22:00-07:00';
+    expect(inQuietHours(new Date(2026, 0, 2, 23, 30), spec)).toBe(true);
+    expect(inQuietHours(new Date(2026, 0, 2, 3, 0), spec)).toBe(true);
+    expect(inQuietHours(new Date(2026, 0, 2, 12, 0), spec)).toBe(false);
+  });
+
+  it('returns false for no/invalid spec', () => {
+    expect(inQuietHours(new Date(), null)).toBe(false);
+    expect(inQuietHours(new Date(), 'nonsense')).toBe(false);
+  });
+});
+
+describe('mute state', () => {
+  it('mutes globally for a duration', () => {
+    const at = 1_000_000;
+    muteAll(10, at);
+    expect(isMuted(null, at + 5 * 60_000)).toBe(true);
+    expect(isMuted('cpu', at + 5 * 60_000)).toBe(true);
+    expect(isMuted(null, at + 11 * 60_000)).toBe(false);
+  });
+
+  it('mutes a single key without affecting others', () => {
+    const at = 1_000_000;
+    muteKey('cpu', 10, at);
+    expect(isMuted('cpu', at + 60_000)).toBe(true);
+    expect(isMuted('memory', at + 60_000)).toBe(false);
+    expect(isMuted(null, at + 60_000)).toBe(false);
+  });
+
+  it('clearMute lifts everything', () => {
+    const at = 1_000_000;
+    muteAll(10, at);
+    clearMute();
+    expect(isMuted(null, at + 60_000)).toBe(false);
+  });
+});

--- a/src/utils/collectors/alertMute.ts
+++ b/src/utils/collectors/alertMute.ts
@@ -1,0 +1,65 @@
+// Alert muting: a manual "snooze" plus scheduled quiet hours. When muted, the
+// external webhook notification is suppressed — the on-screen alert log still
+// records every event, so nothing is lost, it just doesn't page anyone.
+//
+// Manual mute is process-memory only (a self-hosted single instance); it is set
+// via /api/alerts/mute. Quiet hours come from ALERT_QUIET_HOURS in the server's
+// local timezone.
+
+let globalMuteUntil = 0; // epoch ms; 0 = not muted
+const keyMuteUntil = new Map<string, number>();
+
+const QUIET_HOURS = process.env.ALERT_QUIET_HOURS || null;
+
+export function muteAll(minutes: number, at: number = Date.now()): number {
+  globalMuteUntil = at + Math.max(0, minutes) * 60_000;
+  return globalMuteUntil;
+}
+
+export function muteKey(key: string, minutes: number, at: number = Date.now()): number {
+  const until = at + Math.max(0, minutes) * 60_000;
+  keyMuteUntil.set(key, until);
+  return until;
+}
+
+export function clearMute(): void {
+  globalMuteUntil = 0;
+  keyMuteUntil.clear();
+}
+
+// Pure: is `date` inside the "HH:MM-HH:MM" window (local time)? Wraps past
+// midnight when start > end. Exported for testing and for status.
+export function inQuietHours(date: Date = new Date(), spec: string | null = QUIET_HOURS): boolean {
+  if (!spec) return false;
+  const match = spec.match(/^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$/);
+  if (!match) return false;
+
+  const start = Number(match[1]) * 60 + Number(match[2]);
+  const end = Number(match[3]) * 60 + Number(match[4]);
+  if (start === end) return false;
+
+  const now = date.getHours() * 60 + date.getMinutes();
+  return start < end ? now >= start && now < end : now >= start || now < end;
+}
+
+// Whether a notification for `key` (null = a keyless event) should be muted now.
+export function isMuted(key: string | null = null, at: number = Date.now()): boolean {
+  if (globalMuteUntil > at) return true;
+  if (inQuietHours(new Date(at))) return true;
+  if (key) {
+    const until = keyMuteUntil.get(key);
+    if (until !== undefined && until > at) return true;
+  }
+  return false;
+}
+
+export function muteStatus(at: number = Date.now()) {
+  return {
+    globalMutedUntil: globalMuteUntil > at ? new Date(globalMuteUntil).toISOString() : null,
+    mutedKeys: [...keyMuteUntil.entries()]
+      .filter(([, until]) => until > at)
+      .map(([key, until]) => ({ key, until: new Date(until).toISOString() })),
+    quietHours: QUIET_HOURS,
+    quietNow: inQuietHours(new Date(at))
+  };
+}

--- a/src/utils/collectors/alerts.test.ts
+++ b/src/utils/collectors/alerts.test.ts
@@ -199,6 +199,30 @@ describe('evaluateAlerts', () => {
     expect(entered[0].level).toBe('critical');
   });
 
+  it('clears a disk-fill alert when the forecast becomes null (no longer filling)', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput({ diskHoursToFull: 100 }), t0);
+    evaluateAlerts(baseInput({ diskHoursToFull: 10 }), t0 + 1000); // enter
+    const cleared = evaluateAlerts(baseInput({ diskHoursToFull: null }), t0 + 2000);
+    expect(cleared.some(e => e.message.includes('Disk fill rate eased'))).toBe(true);
+  });
+
+  it('keeps alert history beyond the 30-entry SSE view', async () => {
+    const { evaluateAlerts, getAlertLog } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput(), t0); // init known-session state
+    const sessions: { user: string; ip: string; since: string }[] = [];
+    for (let i = 0; i < 40; i += 1) {
+      sessions.push({ user: `u${i}`, ip: `10.0.0.${i}`, since: new Date(t0 + i * 1000).toISOString() });
+      const view = evaluateAlerts(baseInput({ sshSessions: [...sessions] }), t0 + (i + 1) * 1000);
+      expect(view.length).toBeLessThanOrEqual(30); // SSE view stays capped
+    }
+    expect(getAlertLog().length).toBeGreaterThan(30); // full history is deeper
+  });
+
   it('marks a rule as flapping after repeated transitions', async () => {
     const { evaluateAlerts } = await freshAlerts({ ALERT_FLAP_THRESHOLD: '4' });
     const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);

--- a/src/utils/collectors/alerts.test.ts
+++ b/src/utils/collectors/alerts.test.ts
@@ -45,7 +45,8 @@ const ENV_KEYS = [
   'ALERT_WEBHOOK_FORMAT',
   'ALERT_CPU_ENTER',
   'ALERT_CPU_CLEAR',
-  'ALERT_RENOTIFY_MINUTES'
+  'ALERT_RENOTIFY_MINUTES',
+  'ALERT_FLAP_THRESHOLD'
 ];
 
 describe('evaluateAlerts', () => {
@@ -156,5 +157,57 @@ describe('evaluateAlerts', () => {
     // The recovered log must contain the earlier CPU alert. It persists even after one normal-value evaluation.
     const log = second.evaluateAlerts(baseInput(), t0 + 2000);
     expect(log.some(e => e.message.includes('CPU usage 95%'))).toBe(true);
+  });
+
+  it('alerts on a low battery (below-direction rule) and clears on recovery', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput({ battery: 50 }), t0);
+    const entered = evaluateAlerts(baseInput({ battery: 10 }), t0 + 1000);
+    expect(entered[0].message).toContain('Battery low 10%');
+
+    const cleared = evaluateAlerts(baseInput({ battery: 30 }), t0 + 2000);
+    expect(cleared[0].message).toContain('Battery recovered');
+  });
+
+  it('alerts when the disk is forecast to fill soon (below-direction rule)', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput({ diskHoursToFull: 100 }), t0);
+    const entered = evaluateAlerts(baseInput({ diskHoursToFull: 10 }), t0 + 1000);
+    expect(entered[0].message).toContain('Disk fills in ~10h');
+  });
+
+  it('alerts on high load per core', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput({ cores: 4, loadAvg1: 1 }), t0);
+    const entered = evaluateAlerts(baseInput({ cores: 4, loadAvg1: 10 }), t0 + 1000);
+    expect(entered[0].message).toContain('Load 2.50 per core');
+  });
+
+  it('alerts critically on high GPU temperature', async () => {
+    const { evaluateAlerts } = await freshAlerts();
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput({ gpuTemp: 50 }), t0);
+    const entered = evaluateAlerts(baseInput({ gpuTemp: 90 }), t0 + 1000);
+    expect(entered[0].message).toContain('GPU temp 90.0°C');
+    expect(entered[0].level).toBe('critical');
+  });
+
+  it('marks a rule as flapping after repeated transitions', async () => {
+    const { evaluateAlerts } = await freshAlerts({ ALERT_FLAP_THRESHOLD: '4' });
+    const t0 = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    evaluateAlerts(baseInput(), t0);
+    evaluateAlerts(baseInput({ cpu: 95 }), t0 + 1000); // enter (1)
+    evaluateAlerts(baseInput({ cpu: 70 }), t0 + 2000); // clear (2)
+    evaluateAlerts(baseInput({ cpu: 95 }), t0 + 3000); // enter (3)
+    const log = evaluateAlerts(baseInput({ cpu: 70 }), t0 + 4000); // clear (4) -> flap
+    expect(log.some(e => e.message.includes('flapping'))).toBe(true);
   });
 });

--- a/src/utils/collectors/alerts.ts
+++ b/src/utils/collectors/alerts.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { AlertEntry, AlertLevel, FirewallInfo, SshSession, TemperatureValue } from '@/types/system';
 import { dispatchAlert } from '@/utils/collectors/notify';
+import { isMuted } from '@/utils/collectors/alertMute';
 
 const MAX_ENTRIES = 30;
 
@@ -16,57 +17,166 @@ function num(key: string, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
 }
 
-// To keep a value hovering around the threshold from flooding the log, the
-// enter value and clear value differ (hysteresis).
+// A threshold rule. `direction` chooses whether "bad" is high or low:
+//   above  → enter when value > enter, clear when value < clear ("high is bad")
+//   below  → enter when value < enter, clear when value > clear ("low is bad")
+// The enter/clear gap is hysteresis, to stop a value hovering at the threshold
+// from flooding. `compute` derives the value from the metric bag (for ratios or
+// composite conditions); when absent, values[key] is used. `when`, if given,
+// gates the rule so it only evaluates while the predicate holds.
+type Values = Record<string, number | null>;
+
 interface Rule {
   key: string;
+  label: string;
   level: AlertLevel;
-  enterAbove: number;
-  clearBelow: number;
+  direction: 'above' | 'below';
+  enter: number;
+  clear: number;
   onEnter: (value: number) => string;
   onClear: (value: number) => string;
+  compute?: (values: Values) => number | null;
+  when?: (values: Values) => boolean;
+}
+
+function breached(direction: Rule['direction'], value: number, enter: number): boolean {
+  return direction === 'above' ? value > enter : value < enter;
+}
+
+function recovered(direction: Rule['direction'], value: number, clear: number): boolean {
+  return direction === 'above' ? value < clear : value > clear;
 }
 
 const RULES: Rule[] = [
   {
     key: 'cpu',
+    label: 'CPU',
     level: 'warning',
-    enterAbove: num('ALERT_CPU_ENTER', 90),
-    clearBelow: num('ALERT_CPU_CLEAR', 80),
+    direction: 'above',
+    enter: num('ALERT_CPU_ENTER', 90),
+    clear: num('ALERT_CPU_CLEAR', 80),
     onEnter: value => `CPU usage ${value.toFixed(0)}%`,
     onClear: () => 'CPU usage back to normal'
   },
   {
     key: 'memory',
+    label: 'Memory',
     level: 'warning',
-    enterAbove: num('ALERT_MEM_ENTER', 90),
-    clearBelow: num('ALERT_MEM_CLEAR', 80),
+    direction: 'above',
+    enter: num('ALERT_MEM_ENTER', 90),
+    clear: num('ALERT_MEM_CLEAR', 80),
     onEnter: value => `Memory usage ${value.toFixed(0)}%`,
     onClear: () => 'Memory usage back to normal'
   },
   {
     key: 'disk',
+    label: 'Disk',
     level: 'warning',
-    enterAbove: num('ALERT_DISK_ENTER', 85),
-    clearBelow: num('ALERT_DISK_CLEAR', 80),
+    direction: 'above',
+    enter: num('ALERT_DISK_ENTER', 85),
+    clear: num('ALERT_DISK_CLEAR', 80),
     onEnter: value => `Disk usage crossed ${value.toFixed(0)}%`,
     onClear: () => 'Disk usage back to normal'
   },
   {
     key: 'temperature',
+    label: 'CPU temp',
     level: 'critical',
-    enterAbove: num('ALERT_TEMP_ENTER', 74),
-    clearBelow: num('ALERT_TEMP_CLEAR', 70),
+    direction: 'above',
+    enter: num('ALERT_TEMP_ENTER', 74),
+    clear: num('ALERT_TEMP_CLEAR', 70),
     onEnter: value => `CPU temp ${value.toFixed(1)}°C`,
     onClear: () => 'CPU temp back to normal'
   },
   {
     key: 'swap',
+    label: 'Swap',
     level: 'warning',
-    enterAbove: num('ALERT_SWAP_ENTER', 80),
-    clearBelow: num('ALERT_SWAP_CLEAR', 60),
+    direction: 'above',
+    enter: num('ALERT_SWAP_ENTER', 80),
+    clear: num('ALERT_SWAP_CLEAR', 60),
     onEnter: value => `Swap usage ${value.toFixed(0)}%`,
     onClear: () => 'Swap usage back to normal'
+  },
+  // Load relative to core count — a portable "is the box overloaded" signal.
+  {
+    key: 'loadPerCore',
+    label: 'Load',
+    level: 'warning',
+    direction: 'above',
+    enter: num('ALERT_LOAD_ENTER', 2),
+    clear: num('ALERT_LOAD_CLEAR', 1.5),
+    compute: v => v.loadPerCore,
+    onEnter: value => `Load ${value.toFixed(2)} per core`,
+    onClear: () => 'Load back to normal'
+  },
+  {
+    key: 'gpuTemp',
+    label: 'GPU temp',
+    level: 'critical',
+    direction: 'above',
+    enter: num('ALERT_GPU_TEMP_ENTER', 85),
+    clear: num('ALERT_GPU_TEMP_CLEAR', 78),
+    compute: v => v.gpuTemp,
+    onEnter: value => `GPU temp ${value.toFixed(1)}°C`,
+    onClear: () => 'GPU temp back to normal'
+  },
+  // "low is bad": battery charge dropping.
+  {
+    key: 'battery',
+    label: 'Battery',
+    level: 'warning',
+    direction: 'below',
+    enter: num('ALERT_BATTERY_ENTER', 15),
+    clear: num('ALERT_BATTERY_CLEAR', 25),
+    compute: v => v.battery,
+    onEnter: value => `Battery low ${value.toFixed(0)}%`,
+    onClear: () => 'Battery recovered'
+  },
+  // "low is bad": estimated hours until the disk fills.
+  {
+    key: 'diskFill',
+    label: 'Disk fill',
+    level: 'warning',
+    direction: 'below',
+    enter: num('ALERT_DISKFILL_ENTER_HOURS', 24),
+    clear: num('ALERT_DISKFILL_CLEAR_HOURS', 48),
+    compute: v => v.diskFill,
+    onEnter: value => `Disk fills in ~${value.toFixed(0)}h at the current rate`,
+    onClear: () => 'Disk fill rate eased'
+  },
+  // Statistical anomaly (opt-in via ALERT_ANOMALY_ENABLE): CPU far from its own
+  // recent baseline even if under the absolute threshold. Passed in as a boolean.
+  {
+    key: 'cpuAnomaly',
+    label: 'CPU anomaly',
+    level: 'warning',
+    direction: 'above',
+    enter: 0.5,
+    clear: 0.5,
+    when: () => ANOMALY_ENABLED,
+    compute: v => v.cpuAnomaly,
+    onEnter: () => 'CPU usage anomalous vs its recent baseline',
+    onClear: () => 'CPU usage back near baseline'
+  },
+  // Composite: RAM and swap both high at once — thrashing, distinct from either
+  // individual warning. Modelled as a boolean (1/0) so it flows through the same
+  // enter/clear machinery.
+  {
+    key: 'memPressure',
+    label: 'Memory pressure',
+    level: 'critical',
+    direction: 'above',
+    enter: 0.5,
+    clear: 0.5,
+    compute: v =>
+      v.memory === null || v.swap === null
+        ? null
+        : v.memory > num('ALERT_MEMPRESSURE_MEM', 90) && v.swap > num('ALERT_MEMPRESSURE_SWAP', 80)
+          ? 1
+          : 0,
+    onEnter: () => 'Memory pressure: RAM and swap both high',
+    onClear: () => 'Memory pressure eased'
   }
 ];
 
@@ -74,6 +184,14 @@ const RULES: Rule[] = [
 // disables re-notification. This never floods the on-screen log — it re-notifies
 // via the external webhook only.
 const RENOTIFY_MS = num('ALERT_RENOTIFY_MINUTES', 0) * 60 * 1000;
+
+// Flapping suppression: if a rule enters/clears too many times in a short
+// window, stop paging for it (the on-screen log still records) until it settles.
+const FLAP_WINDOW_MS = num('ALERT_FLAP_WINDOW_MINUTES', 10) * 60 * 1000;
+const FLAP_THRESHOLD = num('ALERT_FLAP_THRESHOLD', 6);
+
+// Anomaly detection is opt-in — it can be noisy on a bursty host.
+const ANOMALY_ENABLED = /^(1|true|yes)$/i.test(process.env.ALERT_ANOMALY_ENABLE ?? '');
 
 const active = new Set<string>();
 const log: AlertEntry[] = [];
@@ -83,6 +201,18 @@ let knownIfaceDown: Set<string> | null = null;
 let sequence = 0;
 // Per-rule last external-notify time. Used for the re-notify cooldown.
 const lastNotifiedAt = new Map<string, number>();
+// Per-rule recent transition timestamps and current flapping state.
+const transitions = new Map<string, number[]>();
+const flapping = new Set<string>();
+
+// Record an enter/clear transition and report whether the rule is now flapping.
+function recordTransition(key: string, at: number): boolean {
+  const times = transitions.get(key) ?? [];
+  times.push(at);
+  while (times.length > 0 && at - times[0] > FLAP_WINDOW_MS) times.shift();
+  transitions.set(key, times);
+  return times.length >= FLAP_THRESHOLD;
+}
 
 // --- Disk persistence ----------------------------------------------------
 // Until now the alert log lived only in process memory and was lost on restart.
@@ -169,14 +299,29 @@ function hookExit(): void {
 // an already-breached value or already-attached SSH/firewall state isn't pushed
 // out as if it "just happened". It's still written to the on-screen log (so the
 // operator sees the current state) but the webhook notify is skipped.
-function push(level: AlertLevel, message: string, at: number, notify: boolean): void {
+//
+// key: the rule/event key, consulted for per-key muting. A muted event still
+// logs on screen; only the outbound webhook is suppressed.
+function push(
+  level: AlertLevel,
+  message: string,
+  at: number,
+  notify: boolean,
+  key: string | null = null
+): void {
   sequence += 1;
   const entry: AlertEntry = { id: `${at}-${sequence}`, level, message, at: new Date(at).toISOString() };
   log.unshift(entry);
   if (log.length > MAX_ENTRIES) log.length = MAX_ENTRIES;
   scheduleSave();
 
-  if (notify) void dispatchAlert(entry);
+  if (notify && !isMuted(key, at)) void dispatchAlert(entry);
+}
+
+// The full persisted alert log (newest first), for the /alerts history page.
+export function getAlertLog(): AlertEntry[] {
+  ensureLoaded();
+  return [...log];
 }
 
 export interface AlertInput {
@@ -189,6 +334,18 @@ export interface AlertInput {
   sshSessions: SshSession[];
   // For interface-down detection. Only the name and state are needed (optional: old-input compatible).
   interfaces?: { name: string; state: 'up' | 'down' | 'unknown' }[];
+  // Added for the expanded rule set (all optional: old-input compatible).
+  cores?: number;
+  loadAvg1?: number;
+  gpuTemp?: TemperatureValue;
+  battery?: number | null;
+  diskHoursToFull?: number | null;
+  // Precomputed CPU anomaly flag (see anomaly.ts); undefined = not evaluated.
+  cpuAnomaly?: boolean;
+}
+
+function toNumber(value: TemperatureValue | number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 export function evaluateAlerts(input: AlertInput, at: number = Date.now()): AlertEntry[] {
@@ -196,30 +353,42 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
   hookExit();
 
   const firstEvaluation = knownSessions === null && knownFirewall === null && knownIfaceDown === null;
-  const values: Record<string, number | null> = {
+  const loadPerCore =
+    input.loadAvg1 !== undefined && input.cores && input.cores > 0 ? input.loadAvg1 / input.cores : null;
+  const values: Values = {
     cpu: input.cpu,
     memory: input.memory,
     disk: input.disk,
     swap: input.swap,
-    temperature: input.temperature === 'N/A' ? null : input.temperature
+    temperature: toNumber(input.temperature),
+    loadPerCore,
+    gpuTemp: toNumber(input.gpuTemp),
+    battery: input.battery ?? null,
+    diskFill: input.diskHoursToFull ?? null,
+    cpuAnomaly: input.cpuAnomaly === undefined ? null : input.cpuAnomaly ? 1 : 0
   };
 
   for (const rule of RULES) {
-    const value = values[rule.key];
-    if (value === null || Number.isNaN(value)) continue;
+    if (rule.when && !rule.when(values)) continue;
+    const value = rule.compute ? rule.compute(values) : values[rule.key];
+    if (value === null || value === undefined || Number.isNaN(value)) continue;
 
-    if (!active.has(rule.key) && value > rule.enterAbove) {
+    if (!active.has(rule.key) && breached(rule.direction, value, rule.enter)) {
       active.add(rule.key);
       lastNotifiedAt.set(rule.key, at);
-      push(rule.level, rule.onEnter(value), at, !firstEvaluation);
-    } else if (active.has(rule.key) && value < rule.clearBelow) {
+      const flap = recordTransition(rule.key, at);
+      push(rule.level, rule.onEnter(value), at, !firstEvaluation && !flap, rule.key);
+      announceFlap(rule, flap, at, firstEvaluation);
+    } else if (active.has(rule.key) && recovered(rule.direction, value, rule.clear)) {
       active.delete(rule.key);
       lastNotifiedAt.delete(rule.key);
-      push('ok', rule.onClear(value), at, !firstEvaluation);
-    } else if (active.has(rule.key) && RENOTIFY_MS > 0) {
+      const flap = recordTransition(rule.key, at);
+      push('ok', rule.onClear(value), at, !firstEvaluation && !flap, rule.key);
+      announceFlap(rule, flap, at, firstEvaluation);
+    } else if (active.has(rule.key) && RENOTIFY_MS > 0 && !flapping.has(rule.key)) {
       // While the breach persists, re-notify (external webhook only, doesn't flood the on-screen log).
       const last = lastNotifiedAt.get(rule.key) ?? 0;
-      if (at - last >= RENOTIFY_MS) {
+      if (at - last >= RENOTIFY_MS && !isMuted(rule.key, at)) {
         lastNotifiedAt.set(rule.key, at);
         void dispatchAlert({
           id: `${at}-renotify-${rule.key}`,
@@ -242,7 +411,7 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
   } else {
     for (const session of input.sshSessions) {
       const key = `${session.user}@${session.ip}`;
-      if (!knownSessions.has(key)) push('info', `SSH login: ${session.user}@${session.ip}`, at, true);
+      if (!knownSessions.has(key)) push('info', `SSH login: ${session.user}@${session.ip}`, at, true, 'ssh');
     }
     knownSessions = sessionKeys;
   }
@@ -254,10 +423,10 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
       knownIfaceDown = downNow;
     } else {
       for (const name of downNow) {
-        if (!knownIfaceDown.has(name)) push('warning', `Interface ${name} down`, at, true);
+        if (!knownIfaceDown.has(name)) push('warning', `Interface ${name} down`, at, true, 'interface');
       }
       for (const name of knownIfaceDown) {
-        if (!downNow.has(name)) push('ok', `Interface ${name} back up`, at, true);
+        if (!downNow.has(name)) push('ok', `Interface ${name} back up`, at, true, 'interface');
       }
       knownIfaceDown = downNow;
     }
@@ -268,10 +437,26 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
 
   if (input.firewall !== 'unknown' && input.firewall !== knownFirewall) {
     if (knownFirewall !== null) {
-      push(input.firewall === 'active' ? 'ok' : 'critical', `Firewall ${input.firewall}`, at, true);
+      push(
+        input.firewall === 'active' ? 'ok' : 'critical',
+        `Firewall ${input.firewall}`,
+        at,
+        true,
+        'firewall'
+      );
     }
     knownFirewall = input.firewall;
   }
 
   return [...log];
+}
+
+// Emit a one-time notice when a rule starts or stops flapping.
+function announceFlap(rule: Rule, flap: boolean, at: number, firstEvaluation: boolean): void {
+  if (flap && !flapping.has(rule.key)) {
+    flapping.add(rule.key);
+    push('info', `${rule.label} is flapping; suppressing its notifications`, at, !firstEvaluation, rule.key);
+  } else if (!flap && flapping.has(rule.key)) {
+    flapping.delete(rule.key);
+  }
 }

--- a/src/utils/collectors/alerts.ts
+++ b/src/utils/collectors/alerts.ts
@@ -5,6 +5,8 @@ import { AlertEntry, AlertLevel, FirewallInfo, SshSession, TemperatureValue } fr
 import { dispatchAlert } from '@/utils/collectors/notify';
 import { isMuted } from '@/utils/collectors/alertMute';
 
+// The recent view streamed with every /api/system response (kept small so the
+// SSE payload stays light). The dashboard alert card reads this.
 const MAX_ENTRIES = 30;
 
 // Thresholds can be overridden by environment variables. Unset uses the
@@ -37,6 +39,11 @@ interface Rule {
   onClear: (value: number) => string;
   compute?: (values: Values) => number | null;
   when?: (values: Values) => boolean;
+  // How to treat a null computed value while the rule is active. Default is
+  // 'skip' (source temporarily unavailable). 'recovered' means null == no longer
+  // breached (e.g. disk-fill forecast becomes null when the disk stops filling),
+  // so an active alert should clear rather than stay stuck.
+  nullMeans?: 'recovered';
 }
 
 function breached(direction: Rule['direction'], value: number, enter: number): boolean {
@@ -142,6 +149,8 @@ const RULES: Rule[] = [
     enter: num('ALERT_DISKFILL_ENTER_HOURS', 24),
     clear: num('ALERT_DISKFILL_CLEAR_HOURS', 48),
     compute: v => v.diskFill,
+    // A null forecast means the disk is no longer filling → treat as recovered.
+    nullMeans: 'recovered',
     onEnter: value => `Disk fills in ~${value.toFixed(0)}h at the current rate`,
     onClear: () => 'Disk fill rate eased'
   },
@@ -193,6 +202,11 @@ const FLAP_THRESHOLD = num('ALERT_FLAP_THRESHOLD', 6);
 // Anomaly detection is opt-in — it can be noisy on a bursty host.
 const ANOMALY_ENABLED = /^(1|true|yes)$/i.test(process.env.ALERT_ANOMALY_ENABLE ?? '');
 
+// The persisted history the /alerts page reads is deeper than the SSE view: a
+// burst (or flapping) easily exceeds 30 entries within the 48h timeline window.
+const HISTORY_MAX = num('ALERT_HISTORY_MAX', 500);
+const HISTORY_RETENTION_MS = num('ALERT_HISTORY_RETENTION_DAYS', 7) * 24 * 60 * 60 * 1000;
+
 const active = new Set<string>();
 const log: AlertEntry[] = [];
 let knownSessions: Set<string> | null = null;
@@ -235,8 +249,8 @@ function ensureLoaded(): void {
     const raw = fs.readFileSync(/*turbopackIgnore: true*/ STORE_FILE, 'utf-8');
     const parsed = JSON.parse(raw) as StoreShape;
     if (parsed && parsed.v === STORE_VERSION && Array.isArray(parsed.log)) {
-      // Stored newest-first, so restore as-is but honor the cap.
-      for (const entry of parsed.log.slice(0, MAX_ENTRIES)) log.push(entry);
+      // Stored newest-first, so restore as-is but honor the history cap.
+      for (const entry of parsed.log.slice(0, HISTORY_MAX)) log.push(entry);
     }
   } catch {
     // If the file is missing (first run) or unreadable, start empty.
@@ -312,10 +326,18 @@ function push(
   sequence += 1;
   const entry: AlertEntry = { id: `${at}-${sequence}`, level, message, at: new Date(at).toISOString() };
   log.unshift(entry);
-  if (log.length > MAX_ENTRIES) log.length = MAX_ENTRIES;
+  pruneHistory(at);
   scheduleSave();
 
   if (notify && !isMuted(key, at)) void dispatchAlert(entry);
+}
+
+// Keep the persisted history within its cap and retention window. log is
+// newest-first, so stale entries collect at the tail.
+function pruneHistory(now: number): void {
+  if (log.length > HISTORY_MAX) log.length = HISTORY_MAX;
+  const oldest = now - HISTORY_RETENTION_MS;
+  while (log.length > 0 && new Date(log[log.length - 1].at).getTime() < oldest) log.pop();
 }
 
 // The full persisted alert log (newest first), for the /alerts history page.
@@ -368,10 +390,34 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
     cpuAnomaly: input.cpuAnomaly === undefined ? null : input.cpuAnomaly ? 1 : 0
   };
 
+  // Expire flapping for rules that have settled (no transitions left within the
+  // window). Without this, a rule that flapped and then stayed breached would
+  // suppress its re-notifications forever, since flapping was only re-evaluated
+  // on a transition.
+  for (const key of [...flapping]) {
+    const times = transitions.get(key) ?? [];
+    while (times.length > 0 && at - times[0] > FLAP_WINDOW_MS) times.shift();
+    transitions.set(key, times);
+    if (times.length < FLAP_THRESHOLD) flapping.delete(key);
+  }
+
   for (const rule of RULES) {
     if (rule.when && !rule.when(values)) continue;
     const value = rule.compute ? rule.compute(values) : values[rule.key];
-    if (value === null || value === undefined || Number.isNaN(value)) continue;
+    if (value === null || value === undefined || Number.isNaN(value)) {
+      // Normally a null value means the source is temporarily unavailable, so we
+      // hold the current state. For rules where null means "no longer breached"
+      // (e.g. disk-fill forecast disappears when the disk stops filling), clear
+      // an active alert so it isn't stuck and can re-fire later.
+      if (rule.nullMeans === 'recovered' && active.has(rule.key)) {
+        active.delete(rule.key);
+        lastNotifiedAt.delete(rule.key);
+        const flap = recordTransition(rule.key, at);
+        push('ok', rule.onClear(rule.clear), at, !firstEvaluation && !flap, rule.key);
+        announceFlap(rule, flap, at, firstEvaluation);
+      }
+      continue;
+    }
 
     if (!active.has(rule.key) && breached(rule.direction, value, rule.enter)) {
       active.add(rule.key);
@@ -448,7 +494,9 @@ export function evaluateAlerts(input: AlertInput, at: number = Date.now()): Aler
     knownFirewall = input.firewall;
   }
 
-  return [...log];
+  // Return only the recent view for the dashboard/SSE; the full history is read
+  // separately via getAlertLog() (/api/alerts).
+  return log.slice(0, MAX_ENTRIES);
 }
 
 // Emit a one-time notice when a rule starts or stops flapping.

--- a/src/utils/collectors/anomaly.test.ts
+++ b/src/utils/collectors/anomaly.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAnomalous, mean, stddev, zScore } from '@/utils/collectors/anomaly';
+
+describe('mean / stddev', () => {
+  it('computes sample statistics', () => {
+    expect(mean([2, 4, 6])).toBe(4);
+    expect(stddev([2, 4, 6])).toBeCloseTo(2, 5); // sample stddev
+    expect(stddev([5, 5, 5])).toBe(0);
+  });
+});
+
+describe('zScore', () => {
+  it('returns standard deviations from the mean', () => {
+    // series mean 10, sd 5 → value 20 is +2σ
+    const z = zScore(20, [5, 10, 15]);
+    expect(z).toBeCloseTo(2, 5);
+  });
+
+  it('is null for a flat or tiny series', () => {
+    expect(zScore(5, [5, 5, 5])).toBeNull();
+    expect(zScore(5, [5])).toBeNull();
+  });
+});
+
+describe('isAnomalous', () => {
+  const baseline = [8, 9, 8, 10, 9, 8, 9, 10]; // ~9% CPU, low variance
+
+  it('flags a value far from the baseline', () => {
+    expect(isAnomalous(60, baseline)).toBe(true);
+  });
+
+  it('does not flag a value near the baseline', () => {
+    expect(isAnomalous(9, baseline)).toBe(false);
+  });
+
+  it('requires a minimum number of samples', () => {
+    expect(isAnomalous(60, [8, 9])).toBe(false);
+  });
+});

--- a/src/utils/collectors/anomaly.ts
+++ b/src/utils/collectors/anomaly.ts
@@ -1,0 +1,43 @@
+// Simple statistical anomaly detection to complement the fixed thresholds. A
+// value can be "normal" in absolute terms yet wildly out of line with this
+// host's own recent baseline (e.g. CPU steady at 8% for a week, suddenly 45%).
+// We flag that with a z-score against the recent history the process already
+// keeps (history.ts hourly buckets), so it needs no extra storage.
+//
+// All pure functions so the maths is unit-testable.
+
+export function mean(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  return xs.reduce((sum, x) => sum + x, 0) / xs.length;
+}
+
+export function stddev(xs: number[], m: number = mean(xs)): number {
+  if (xs.length < 2) return 0;
+  const variance = xs.reduce((sum, x) => sum + (x - m) ** 2, 0) / (xs.length - 1);
+  return Math.sqrt(variance);
+}
+
+// The number of standard deviations `value` sits from the series mean. null when
+// there isn't enough data or the series is flat (zero variance), where a z-score
+// is undefined/meaningless.
+export function zScore(value: number, series: number[]): number | null {
+  if (series.length < 2) return null;
+  const m = mean(series);
+  const sd = stddev(series, m);
+  if (sd === 0) return null;
+  return (value - m) / sd;
+}
+
+export interface AnomalyOptions {
+  minSamples?: number;
+  threshold?: number; // z-score magnitude to flag
+}
+
+// Whether `value` is anomalous versus its baseline. Requires a minimum number of
+// baseline samples so a brand-new deployment doesn't fire on noise.
+export function isAnomalous(value: number, series: number[], options: AnomalyOptions = {}): boolean {
+  const { minSamples = 6, threshold = 3 } = options;
+  if (series.length < minSamples) return false;
+  const z = zScore(value, series);
+  return z !== null && Math.abs(z) >= threshold;
+}

--- a/src/utils/collectors/notify.test.ts
+++ b/src/utils/collectors/notify.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AlertEntry } from '@/types/system';
+
+const ENV_KEYS = [
+  'ALERT_WEBHOOK_URL',
+  'ALERT_WEBHOOK_URL_CRITICAL',
+  'ALERT_WEBHOOK_URL_WARNING',
+  'ALERT_WEBHOOK_FORMAT',
+  'ALERT_BATCH_MS'
+];
+
+async function load(env: Record<string, string> = {}) {
+  vi.resetModules();
+  ENV_KEYS.forEach(key => delete process.env[key]);
+  for (const [key, value] of Object.entries(env)) process.env[key] = value;
+  return import('@/utils/collectors/notify');
+}
+
+afterEach(() => ENV_KEYS.forEach(key => delete process.env[key]));
+
+const entry = (level: AlertEntry['level']): AlertEntry => ({
+  id: '1',
+  level,
+  message: 'test message',
+  at: '2026-01-02T00:00:00.000Z'
+});
+
+describe('channelsFor', () => {
+  it('routes a level to its override, falling back to the default', async () => {
+    const { channelsFor } = await load({
+      ALERT_WEBHOOK_URL: 'https://default.test',
+      ALERT_WEBHOOK_URL_CRITICAL: 'https://pager.test'
+    });
+    expect(channelsFor('critical')).toEqual(['https://pager.test']);
+    expect(channelsFor('warning')).toEqual(['https://default.test']);
+  });
+
+  it('supports multiple comma-separated default targets', async () => {
+    const { channelsFor } = await load({ ALERT_WEBHOOK_URL: 'https://a.test, https://b.test' });
+    expect(channelsFor('info')).toEqual(['https://a.test', 'https://b.test']);
+  });
+
+  it('is empty when nothing is configured', async () => {
+    const { channelsFor } = await load();
+    expect(channelsFor('warning')).toEqual([]);
+  });
+});
+
+describe('formatPayload', () => {
+  it('emits a single object for one entry and an array for a batch (json)', async () => {
+    const { formatPayload } = await load({ ALERT_WEBHOOK_URL: 'https://x.test' });
+    expect(JSON.parse(formatPayload([entry('warning')]))).toMatchObject({ message: 'test message' });
+    expect(Array.isArray(JSON.parse(formatPayload([entry('warning'), entry('info')])))).toBe(true);
+  });
+
+  it('uses the slack shape when configured', async () => {
+    const { formatPayload } = await load({
+      ALERT_WEBHOOK_URL: 'https://x.test',
+      ALERT_WEBHOOK_FORMAT: 'slack'
+    });
+    const body = JSON.parse(formatPayload([entry('critical')]));
+    expect(body.text).toContain('test message');
+  });
+});

--- a/src/utils/collectors/notify.ts
+++ b/src/utils/collectors/notify.ts
@@ -1,5 +1,6 @@
 import { AlertEntry, AlertLevel } from '@/types/system';
 import { logger } from '@/utils/logger';
+import { isMuted } from '@/utils/collectors/alertMute';
 
 // Alerts only showed on the dashboard's alert card until now. Unless someone
 // watches a wall panel 24/7, a threshold breach goes unnoticed. Here we push
@@ -110,6 +111,12 @@ async function flushQueue(): Promise<void> {
   const batch = queue;
   queue = [];
   if (batch.length === 0) return;
+
+  // Muting (manual or quiet hours) may have started after these were queued.
+  // Re-check the global/time-based mute at flush time so we don't page during a
+  // window that is meant to suppress notifications. (Per-key mute was already
+  // applied when each entry was enqueued in alerts.ts.)
+  if (isMuted(null)) return;
 
   // Group by channel URL so each target receives one combined message, using the
   // highest-severity format of the entries routed to it.

--- a/src/utils/collectors/notify.ts
+++ b/src/utils/collectors/notify.ts
@@ -1,69 +1,142 @@
-import { AlertEntry } from '@/types/system';
+import { AlertEntry, AlertLevel } from '@/types/system';
 import { logger } from '@/utils/logger';
 
-// Until now alerts only showed on the dashboard's alert card. Unless someone
+// Alerts only showed on the dashboard's alert card until now. Unless someone
 // watches a wall panel 24/7, a threshold breach goes unnoticed. Here we push
-// once per alert transition to an external endpoint. It only acts when
-// ALERT_WEBHOOK_URL is set; unset (the default) is a complete no-op, so
-// existing deployments are unaffected.
+// alert transitions to one or more external webhooks. Everything is off by
+// default (no ALERT_WEBHOOK_URL) so existing deployments are unaffected.
+//
+// Channels: ALERT_WEBHOOK_URL is the default target(s), comma-separated. A
+// per-severity override — ALERT_WEBHOOK_URL_CRITICAL / _WARNING / _INFO / _OK —
+// routes that level elsewhere (e.g. critical to PagerDuty, warnings to Slack),
+// falling back to the default when unset.
+//
+// Batching (opt-in): ALERT_BATCH_MS > 0 collects alerts that fire within a short
+// window into one combined message per channel, so a burst doesn't page N times.
+// Left at 0 (default) each alert is sent immediately.
 
-const WEBHOOK_URL = process.env.ALERT_WEBHOOK_URL;
-// json    — POST the AlertEntry as-is (for a custom receiver / webhook bridge)
-// slack   — Slack Incoming Webhook shape, { text }
-// discord — Discord Webhook shape, { content }
 const WEBHOOK_FORMAT = (process.env.ALERT_WEBHOOK_FORMAT || 'json').toLowerCase();
-
-// The collection loop runs every second on a sensitive path. Cap the request
-// so a slow or dead webhook can't hold the loop up (same approach as the cluster fetch).
 const TIMEOUT_MS = 5000;
+const BATCH_MS = Number(process.env.ALERT_BATCH_MS) || 0;
 
-// Maps the UI levels to a human-readable prefix, shown at the head of Slack/Discord messages.
-const LEVEL_PREFIX: Record<AlertEntry['level'], string> = {
+const LEVEL_PREFIX: Record<AlertLevel, string> = {
   ok: '✅',
   info: 'ℹ️',
   warning: '⚠️',
   critical: '🚨'
 };
 
-function formatPayload(entry: AlertEntry): string {
-  const prefix = LEVEL_PREFIX[entry.level] ?? '';
-  const host = process.env.NEXT_PUBLIC_SITE_SHORT_NAME || 'ServerMonitor';
-  const text = `${prefix} [${host}] ${entry.message}`;
+function splitUrls(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map(url => url.trim())
+    .filter(Boolean);
+}
 
+const DEFAULT_URLS = splitUrls(process.env.ALERT_WEBHOOK_URL);
+const LEVEL_ENV: Record<AlertLevel, string> = {
+  ok: 'ALERT_WEBHOOK_URL_OK',
+  info: 'ALERT_WEBHOOK_URL_INFO',
+  warning: 'ALERT_WEBHOOK_URL_WARNING',
+  critical: 'ALERT_WEBHOOK_URL_CRITICAL'
+};
+
+// The webhook targets for a given severity: its per-level override if set,
+// otherwise the default list.
+export function channelsFor(level: AlertLevel): string[] {
+  const override = splitUrls(process.env[LEVEL_ENV[level]]);
+  return override.length > 0 ? override : DEFAULT_URLS;
+}
+
+const HOST = () => process.env.NEXT_PUBLIC_SITE_SHORT_NAME || 'ServerMonitor';
+
+function formatLine(entry: AlertEntry): string {
+  return `${LEVEL_PREFIX[entry.level] ?? ''} [${HOST()}] ${entry.message}`;
+}
+
+// Build the request body for one or more entries in the configured shape.
+export function formatPayload(entries: AlertEntry[]): string {
+  const text = entries.map(formatLine).join('\n');
   switch (WEBHOOK_FORMAT) {
     case 'slack':
       return JSON.stringify({ text });
     case 'discord':
       return JSON.stringify({ content: text });
     default:
-      return JSON.stringify(entry);
+      // Raw JSON: a single entry stays an object (unchanged from before); a
+      // batch becomes an array.
+      return JSON.stringify(entries.length === 1 ? entries[0] : entries);
   }
 }
 
-/**
- * Pushes a single new alert to the configured webhook. Always resolves (a
- * failure is only logged) so the caller can fire-and-forget without depending
- * on delivery/success. Spam suppression (hysteresis / no notify on first
- * evaluation) is already handled by the caller (alerts.ts).
- */
-export async function dispatchAlert(entry: AlertEntry): Promise<void> {
-  if (!WEBHOOK_URL) return;
-
+async function postTo(url: string, body: string): Promise<void> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
   try {
-    await fetch(WEBHOOK_URL, {
+    await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: formatPayload(entry),
+      body,
       signal: controller.signal
     });
   } catch (error) {
-    // A webhook failure is not fatal; the alert still lives on the dashboard/log.
     const message = error instanceof Error ? error.message : String(error);
     logger.error('alerts webhook dispatch failed:', message);
   } finally {
     clearTimeout(timeout);
   }
+}
+
+// Send one entry immediately to every channel configured for its level.
+async function sendNow(entry: AlertEntry): Promise<void> {
+  const body = formatPayload([entry]);
+  await Promise.all(channelsFor(entry.level).map(url => postTo(url, body)));
+}
+
+// --- Batching ------------------------------------------------------------
+let queue: AlertEntry[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleFlush(): void {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    void flushQueue();
+  }, BATCH_MS);
+  if (typeof flushTimer.unref === 'function') flushTimer.unref();
+}
+
+async function flushQueue(): Promise<void> {
+  const batch = queue;
+  queue = [];
+  if (batch.length === 0) return;
+
+  // Group by channel URL so each target receives one combined message, using the
+  // highest-severity format of the entries routed to it.
+  const byUrl = new Map<string, AlertEntry[]>();
+  for (const entry of batch) {
+    for (const url of channelsFor(entry.level)) {
+      const list = byUrl.get(url) ?? [];
+      list.push(entry);
+      byUrl.set(url, list);
+    }
+  }
+  await Promise.all([...byUrl.entries()].map(([url, entries]) => postTo(url, formatPayload(entries))));
+}
+
+/**
+ * Pushes a single new alert to the configured webhook(s). Always resolves (a
+ * failure is only logged) so the caller can fire-and-forget. Spam suppression
+ * (hysteresis / no-notify on first evaluation / flapping / mute) is handled by
+ * the caller (alerts.ts).
+ */
+export async function dispatchAlert(entry: AlertEntry): Promise<void> {
+  if (channelsFor(entry.level).length === 0) return;
+
+  if (BATCH_MS > 0) {
+    queue.push(entry);
+    scheduleFlush();
+    return;
+  }
+  await sendNow(entry);
 }

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -34,6 +34,7 @@ import {
 import { getFirewallInfo, getSshSessions } from '@/utils/collectors/security';
 import { getHistory, getLoad30mAverage, recordSample } from '@/utils/collectors/history';
 import { evaluateAlerts } from '@/utils/collectors/alerts';
+import { isAnomalous } from '@/utils/collectors/anomaly';
 
 // Cached system info
 let cachedData: ServerData | null = null;
@@ -586,6 +587,14 @@ export async function getSystemInfo(): Promise<ServerData> {
     avg30WindowSeconds: rolling30m.windowSeconds
   };
 
+  // Flag CPU that departs sharply from its own recent hourly baseline. The rule
+  // that consumes this is opt-in (ALERT_ANOMALY_ENABLE), so this is cheap otherwise.
+  const history = getHistory(now);
+  const cpuBaseline = history.cpuHourly
+    .map(sample => sample.usage)
+    .filter((usage): usage is number => usage !== null);
+  const cpuAnomaly = isAnomalous(cpu.usage, cpuBaseline);
+
   const alerts = evaluateAlerts(
     {
       cpu: cpu.usage,
@@ -595,7 +604,13 @@ export async function getSystemInfo(): Promise<ServerData> {
       temperature: cpu.temperature,
       firewall: security.firewall.status,
       sshSessions: security.sshSessions,
-      interfaces: (network.interfaces ?? []).map(({ name, state }) => ({ name, state }))
+      interfaces: (network.interfaces ?? []).map(({ name, state }) => ({ name, state })),
+      cores: cpu.cores,
+      loadAvg1: loadBase.avg1,
+      gpuTemp: gpu.temperature,
+      battery: battery?.percentage ?? null,
+      diskHoursToFull,
+      cpuAnomaly
     },
     now
   );
@@ -624,7 +639,7 @@ export async function getSystemInfo(): Promise<ServerData> {
     processSummary,
     topProcessesByMemory,
     battery,
-    history: getHistory(now),
+    history,
     alerts,
     timestamp: new Date(now).toISOString(),
     ...(warnings.length > 0 ? { warnings } : {})

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -575,6 +575,14 @@ export async function getSystemInfo(): Promise<ServerData> {
   const loadBase = await getLoadAverage();
   const security = await getSecurityInfo(sockets.peers, warnings);
 
+  // Baseline for anomaly detection must exclude the current reading, so read the
+  // hourly history BEFORE recording this tick's sample (recordSample would fold
+  // the current value into the bucket the baseline is drawn from).
+  const cpuBaseline = getHistory(now)
+    .cpuHourly.map(sample => sample.usage)
+    .filter((usage): usage is number => usage !== null);
+  const cpuAnomaly = isAnomalous(cpu.usage, cpuBaseline);
+
   recordSample(cpu.usage, loadBase.avg1, now);
   recordDiskSample(disk.percentage, now);
   const diskHoursToFull = getHoursToFull(now);
@@ -586,14 +594,7 @@ export async function getSystemInfo(): Promise<ServerData> {
     avg30: rolling30m.value,
     avg30WindowSeconds: rolling30m.windowSeconds
   };
-
-  // Flag CPU that departs sharply from its own recent hourly baseline. The rule
-  // that consumes this is opt-in (ALERT_ANOMALY_ENABLE), so this is cheap otherwise.
   const history = getHistory(now);
-  const cpuBaseline = history.cpuHourly
-    .map(sample => sample.usage)
-    .filter((usage): usage is number => usage !== null);
-  const cpuAnomaly = isAnomalous(cpu.usage, cpuBaseline);
 
   const alerts = evaluateAlerts(
     {

--- a/src/utils/validateConfig.test.ts
+++ b/src/utils/validateConfig.test.ts
@@ -51,6 +51,18 @@ describe('validateConfig', () => {
     expect(warnings.some(w => w.includes('not above clear (80)'))).toBe(true);
   });
 
+  it('flags an inverted below-direction pair (battery enter must be below clear)', () => {
+    const warnings = validateConfig({ ALERT_BATTERY_ENTER: '30', ALERT_BATTERY_CLEAR: '25' });
+    expect(warnings.some(w => w.includes('not below clear'))).toBe(true);
+  });
+
+  it('accepts a comma-separated webhook list and flags only the bad target', () => {
+    expect(validateConfig({ ALERT_WEBHOOK_URL: 'https://a.test, https://b.test' })).toEqual([]);
+    expect(
+      validateConfig({ ALERT_WEBHOOK_URL: 'https://a.test, nope' }).some(w => w.includes('ALERT_WEBHOOK_URL'))
+    ).toBe(true);
+  });
+
   it('flags a non-positive IDLE_TICK_MS', () => {
     expect(validateConfig({ IDLE_TICK_MS: '-1' }).some(w => w.includes('IDLE_TICK_MS'))).toBe(true);
     expect(validateConfig({ IDLE_TICK_MS: '0' }).some(w => w.includes('IDLE_TICK_MS'))).toBe(true);

--- a/src/utils/validateConfig.ts
+++ b/src/utils/validateConfig.ts
@@ -15,12 +15,15 @@ const WEBHOOK_FORMATS = ['json', 'slack', 'discord'];
 // "high is bad" metric, enter must sit above clear or the hysteresis inverts.
 // Defaults mirror the built-ins in alerts.ts so a one-sided override is checked
 // against the value the other side actually uses at runtime, not skipped.
+// `direction` mirrors alerts.ts: 'above' means enter must sit above clear;
+// 'below' (battery, disk-fill: "low is bad") means enter must sit below clear.
 interface ThresholdPair {
   enterKey: string;
   clearKey: string;
   label: string;
   enterDefault: number;
   clearDefault: number;
+  direction: 'above' | 'below';
 }
 
 const THRESHOLD_PAIRS: ThresholdPair[] = [
@@ -29,35 +32,72 @@ const THRESHOLD_PAIRS: ThresholdPair[] = [
     clearKey: 'ALERT_CPU_CLEAR',
     label: 'CPU',
     enterDefault: 90,
-    clearDefault: 80
+    clearDefault: 80,
+    direction: 'above'
   },
   {
     enterKey: 'ALERT_MEM_ENTER',
     clearKey: 'ALERT_MEM_CLEAR',
     label: 'memory',
     enterDefault: 90,
-    clearDefault: 80
+    clearDefault: 80,
+    direction: 'above'
   },
   {
     enterKey: 'ALERT_DISK_ENTER',
     clearKey: 'ALERT_DISK_CLEAR',
     label: 'disk',
     enterDefault: 85,
-    clearDefault: 80
+    clearDefault: 80,
+    direction: 'above'
   },
   {
     enterKey: 'ALERT_TEMP_ENTER',
     clearKey: 'ALERT_TEMP_CLEAR',
     label: 'temperature',
     enterDefault: 74,
-    clearDefault: 70
+    clearDefault: 70,
+    direction: 'above'
   },
   {
     enterKey: 'ALERT_SWAP_ENTER',
     clearKey: 'ALERT_SWAP_CLEAR',
     label: 'swap',
     enterDefault: 80,
-    clearDefault: 60
+    clearDefault: 60,
+    direction: 'above'
+  },
+  {
+    enterKey: 'ALERT_LOAD_ENTER',
+    clearKey: 'ALERT_LOAD_CLEAR',
+    label: 'load per core',
+    enterDefault: 2,
+    clearDefault: 1.5,
+    direction: 'above'
+  },
+  {
+    enterKey: 'ALERT_GPU_TEMP_ENTER',
+    clearKey: 'ALERT_GPU_TEMP_CLEAR',
+    label: 'GPU temperature',
+    enterDefault: 85,
+    clearDefault: 78,
+    direction: 'above'
+  },
+  {
+    enterKey: 'ALERT_BATTERY_ENTER',
+    clearKey: 'ALERT_BATTERY_CLEAR',
+    label: 'battery',
+    enterDefault: 15,
+    clearDefault: 25,
+    direction: 'below'
+  },
+  {
+    enterKey: 'ALERT_DISKFILL_ENTER_HOURS',
+    clearKey: 'ALERT_DISKFILL_CLEAR_HOURS',
+    label: 'disk-fill',
+    enterDefault: 24,
+    clearDefault: 48,
+    direction: 'below'
   }
 ];
 
@@ -109,7 +149,7 @@ export function validateConfig(env: Env = process.env): string[] {
   // Alert thresholds — numeric, and enter above clear so hysteresis is sane.
   // The check uses effective values (override or built-in default), so a
   // one-sided override that inverts against the other side's default is caught.
-  for (const { enterKey, clearKey, label, enterDefault, clearDefault } of THRESHOLD_PAIRS) {
+  for (const { enterKey, clearKey, label, enterDefault, clearDefault, direction } of THRESHOLD_PAIRS) {
     const enter = env[enterKey];
     const clear = env[clearKey];
     if (isSet(enter) && !isNumeric(enter))
@@ -119,20 +159,36 @@ export function validateConfig(env: Env = process.env): string[] {
 
     const effectiveEnter = isSet(enter) && isNumeric(enter) ? Number(enter) : enterDefault;
     const effectiveClear = isSet(clear) && isNumeric(clear) ? Number(clear) : clearDefault;
-    // Only warn when an override actually caused the inversion (all-default is fine by construction).
-    if ((isSet(enter) || isSet(clear)) && effectiveEnter <= effectiveClear) {
+    // Only warn when an override actually caused the inversion (all-default is
+    // fine by construction). 'above' needs enter > clear; 'below' needs enter < clear.
+    const inverted =
+      direction === 'above' ? effectiveEnter <= effectiveClear : effectiveEnter >= effectiveClear;
+    if ((isSet(enter) || isSet(clear)) && inverted) {
+      const relation = direction === 'above' ? 'above' : 'below';
       warnings.push(
-        `${label} alert enter (${effectiveEnter}) is not above clear (${effectiveClear}); the alert will flap or never clear.`
+        `${label} alert enter (${effectiveEnter}) is not ${relation} clear (${effectiveClear}); the alert will flap or never clear.`
       );
     }
   }
 
-  // Webhook config.
+  // Webhook config. The dispatcher accepts a comma-separated list, so validate
+  // each target the same way it splits them.
   if (isSet(env.ALERT_WEBHOOK_URL)) {
-    try {
-      new URL(env.ALERT_WEBHOOK_URL);
-    } catch {
-      warnings.push('ALERT_WEBHOOK_URL is not a valid URL; alert notifications will not be delivered.');
+    const urls = env.ALERT_WEBHOOK_URL.split(',')
+      .map(url => url.trim())
+      .filter(Boolean);
+    const invalid = urls.filter(url => {
+      try {
+        new URL(url);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+    if (invalid.length > 0) {
+      warnings.push(
+        `ALERT_WEBHOOK_URL has invalid target(s): ${invalid.join(', ')}; those notifications will not be delivered.`
+      );
     }
   }
   if (isSet(env.ALERT_WEBHOOK_FORMAT) && !WEBHOOK_FORMATS.includes(env.ALERT_WEBHOOK_FORMAT.toLowerCase())) {


### PR DESCRIPTION
## Overview

Milestone **M1** (alert engine) from the review roadmap, building on M0. Every addition is **opt-in via env** — the existing default behavior (CPU/mem/disk/temp/swap thresholds, single webhook) is unchanged.

## Changes

### Expanded rules (#4, #34)
- Rule engine gains a `direction` (`above`/`below`), a `compute` hook (derived values), and an optional `when` predicate.
- New rules: **load per core**, **GPU temperature**, **low battery** (below), **disk fill-forecast** hours-to-full (below), and a composite **memory-pressure** rule (RAM and swap both high → critical).
- Wired new inputs (`cores`, `loadAvg1`, `gpuTemp`, `battery`, `diskHoursToFull`) from `systemMonitor.ts`.

### Flapping suppression (#56)
A rule that toggles enter/clear too often within a window stops paging (still recorded on the on-screen log) until it settles, and posts a one-time "flapping" notice.

### Anomaly detection (#31, opt-in)
New pure `anomaly.ts` (z-score); `ALERT_ANOMALY_ENABLE` flags CPU that departs sharply from its own recent hourly baseline even under the absolute threshold.

### Notification routing & batching (#57, #3)
`notify.ts` now supports multiple targets, **per-severity routing** (`ALERT_WEBHOOK_URL_CRITICAL/_WARNING/_INFO/_OK`, each falling back to the default), and opt-in **batching** (`ALERT_BATCH_MS`) that combines a burst into one message per channel.

### Muting & quiet hours (#17, #32)
New `alertMute.ts`: manual snooze + scheduled quiet hours (`ALERT_QUIET_HOURS`), consulted on the notify path (the on-screen log still records). Runtime control via `POST`/`DELETE /api/alerts/mute`.

### Alert history page + timeline (#33, #60)
`GET /api/alerts` exposes the persisted log; new **`/alerts`** page with a level filter, text search, and a 48-hour incident timeline strip. The dashboard alert card links to it.

## Verification

- `npm run format:check`, `npm run lint`, `npm run typecheck` — clean
- `npm test` — **121 passing** (18 files; +4 new test files: alertMute, anomaly, notify, plus expanded alerts)
- `npm run build` — succeeds; `/alerts`, `/api/alerts`, `/api/alerts/mute` routes present

## Roadmap context

Second of five milestones (M0 merged in #51). Next: M2 (new collectors + trend history), M3 (UX), M4 (bare-metal deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T)_