### PR TITLE
M2: 24h trend history + host-health collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ that aggregates several nodes on one screen.
   - network throughput chart, interfaces, link utilisation, ping, error
     rates, established connections and listening ports
   - temperature against its alert threshold, fan RPM, uptime and last reboot
+  - 24-hour trend history per metric (memory/disk/temp/network), persisted like
+    the load/CPU history, plus host-health signals — failed systemd services,
+    read-only mounts, disk SMART health/temperature, pending (security) package
+    updates, kernel error count, and failed-SSH-login count — surfaced in the
+    banner and exported via `/api/metrics`
   - alert log, top processes, SSH sessions, top traffic peers, firewall state
   - keeps the last known values on screen when the stream drops, and says so
     in the header instead of blanking the display

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -131,6 +131,38 @@ export async function GET(request: Request) {
 
   if (data.battery) g('server_battery_percent', 'Battery charge level.', data.battery.percentage);
 
+  // New in 2.3.
+  if (data.memoryDetail) {
+    g('server_memory_cached_mb', 'Page cache in MB.', data.memoryDetail.cached);
+    g('server_memory_available_mb', 'Available memory in MB.', data.memoryDetail.available);
+    g('server_memory_slab_mb', 'Kernel slab memory in MB.', data.memoryDetail.slab);
+  }
+  if (data.services) g('server_failed_units', 'Failed systemd units.', data.services.failed);
+  if (data.packages) {
+    g('server_pending_updates', 'Pending package updates.', data.packages.total);
+    g('server_pending_security_updates', 'Pending security updates.', data.packages.security);
+  }
+  g('server_kernel_errors_24h', 'Kernel error-priority journal lines in the last 24h.', data.kernelErrors);
+  g('server_failed_logins_24h', 'Failed SSH logins in the last 24h.', data.failedLogins);
+  if (data.readOnlyMounts) {
+    metric('server_readonly_mounts', 'Filesystems currently mounted read-only.', 'gauge', [
+      line('server_readonly_mounts', data.readOnlyMounts.length)
+    ]);
+  }
+  if (data.smart) {
+    const health: string[] = [];
+    const temp: string[] = [];
+    for (const drive of data.smart) {
+      if (drive.healthy !== null)
+        health.push(line('server_smart_healthy', drive.healthy ? 1 : 0, { device: drive.device }));
+      if (typeof drive.temperature === 'number') {
+        temp.push(line('server_smart_temperature_celsius', drive.temperature, { device: drive.device }));
+      }
+    }
+    metric('server_smart_healthy', 'SMART self-assessment (1 = passed).', 'gauge', health);
+    metric('server_smart_temperature_celsius', 'Drive temperature.', 'gauge', temp);
+  }
+
   const alerts = data.alerts ?? [];
   const activeAlerts = alerts.filter(a => a.level === 'warning' || a.level === 'critical').length;
   metric('server_active_alerts', 'Alerts currently at warning/critical.', 'gauge', [

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -165,6 +165,10 @@ function currentAlerts(data: DashboardData): string[] {
   }
   if (data.swap.total > 0 && data.swap.percentage > 80) alerts.push('Swap high');
   if (data.security.firewall.status === 'inactive') alerts.push('Firewall inactive');
+  // New 2.3 health signals.
+  if (data.readOnlyMounts.length > 0) alerts.push(`${data.readOnlyMounts.length} read-only mount`);
+  if (data.services.failed && data.services.failed > 0) alerts.push(`${data.services.failed} service failed`);
+  if (data.smart.some(drive => drive.healthy === false)) alerts.push('SMART failing');
 
   return alerts;
 }
@@ -562,6 +566,23 @@ const CoresCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   );
 };
 
+// A compact 24h trend line drawn from the persisted per-metric history. Renders
+// nothing until at least two hourly points exist, so it never adds height on a
+// fresh start (keeps the kiosk layout budget intact).
+const TrendSparkline: React.FC<{ samples?: { value: number | null }[]; color: string; label: string }> = ({
+  samples,
+  color,
+  label
+}) => {
+  const values = (samples ?? []).map(sample => sample.value).filter((v): v is number => v !== null);
+  if (values.length < 2) return null;
+  return (
+    <div className="mt-1 h-4" title={`${label} — last 24h`}>
+      <Sparkline series={[{ key: label, values, color }]} />
+    </div>
+  );
+};
+
 const TemperatureCard: React.FC<{ data: DashboardData }> = ({ data }) => {
   const temperature = data.cpu.temperature;
   const color = tempColor(temperature);
@@ -592,6 +613,7 @@ const TemperatureCard: React.FC<{ data: DashboardData }> = ({ data }) => {
             ? `${(temperature - TEMP_CRITICAL).toFixed(1)}° over alert threshold`
             : `${(TEMP_CRITICAL - temperature).toFixed(1)}° to alert threshold`}
       </div>
+      <TrendSparkline samples={data.history.trends?.temp} color="#fb923c" label="CPU temp" />
     </Card>
   );
 };

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -574,11 +574,13 @@ const TrendSparkline: React.FC<{ samples?: { value: number | null }[]; color: st
   color,
   label
 }) => {
-  const values = (samples ?? []).map(sample => sample.value).filter((v): v is number => v !== null);
-  if (values.length < 2) return null;
+  const slots = (samples ?? []).map(sample => sample.value);
+  // Need two real points to draw; keep the null slots so gaps stay at their true
+  // position in the 24h window rather than compressing.
+  if (slots.filter((v): v is number => v !== null).length < 2) return null;
   return (
     <div className="mt-1 h-4" title={`${label} — last 24h`}>
-      <Sparkline series={[{ key: label, values, color }]} />
+      <Sparkline series={[{ key: label, values: slots, color }]} />
     </div>
   );
 };

--- a/src/components/dashboard/primitives.tsx
+++ b/src/components/dashboard/primitives.tsx
@@ -72,7 +72,9 @@ export const Bar: React.FC<BarProps> = ({ percentage, color, className, children
 
 interface SparklineSeries {
   key: string;
-  values: number[];
+  // null entries are gaps (the metric was unavailable that slot) — the line
+  // breaks there rather than interpolating across the missing time.
+  values: (number | null)[];
   color: string;
 }
 
@@ -88,7 +90,12 @@ export const Sparkline: React.FC<SparklineProps> = ({ series, className, emptyLa
   const height = 34;
   const length = Math.max(...series.map(entry => entry.values.length), 0);
 
-  if (length < 2) {
+  // Need at least two real (non-null) points somewhere to draw a line.
+  const realCount = series.reduce(
+    (total, entry) => total + entry.values.filter((value): value is number => value !== null).length,
+    0
+  );
+  if (length < 2 || realCount < 2) {
     return (
       <div className={cn('t-micro flex h-full items-center justify-center text-gray-500', className)}>
         {emptyLabel}
@@ -96,16 +103,26 @@ export const Sparkline: React.FC<SparklineProps> = ({ series, className, emptyLa
     );
   }
 
-  const max = Math.max(1, ...series.flatMap(entry => entry.values)) * 1.2;
+  const reals = series.flatMap(entry => entry.values.filter((value): value is number => value !== null));
+  const max = Math.max(1, ...reals) * 1.2;
 
-  const path = (values: number[]) =>
-    values
-      .map((value, index) => {
-        const x = (index / (length - 1)) * width;
-        const y = height - (Math.max(0, Math.min(max, value)) / max) * height;
-        return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
-      })
-      .join(' ');
+  // Keep each point at its true x-position (by index) and start a new sub-path
+  // after a gap, so missing slots read as breaks rather than compressing time.
+  const path = (values: (number | null)[]) => {
+    let d = '';
+    let penDown = false;
+    values.forEach((value, index) => {
+      if (value === null) {
+        penDown = false;
+        return;
+      }
+      const x = (index / (length - 1)) * width;
+      const y = height - (Math.max(0, Math.min(max, value)) / max) * height;
+      d += `${penDown ? 'L' : 'M'}${x.toFixed(1)},${y.toFixed(1)} `;
+      penDown = true;
+    });
+    return d.trim();
+  };
 
   return (
     <svg

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -141,6 +141,43 @@ export interface ProcessSummary {
   threads: number | null;
 }
 
+// Finer memory breakdown (MB). null when the field is absent from /proc/meminfo.
+export interface MemoryDetail {
+  cached: number | null;
+  buffers: number | null;
+  available: number | null;
+  shared: number | null;
+  slab: number | null;
+  swapCached: number | null;
+}
+
+// Failed systemd services. failed is null when systemd isn't present.
+export interface ServicesInfo {
+  failed: number | null;
+  failedUnits: string[];
+}
+
+// Pending package updates, with a security subtotal.
+export interface PackagesInfo {
+  total: number;
+  security: number;
+}
+
+// Per-drive SMART summary. healthy null = no self-assessment available.
+export interface SmartDevice {
+  device: string;
+  healthy: boolean | null;
+  temperature: TemperatureValue;
+  powerOnHours: number | null;
+}
+
+// A filesystem currently mounted read-only (a silent-failure signal).
+export interface ReadOnlyMount {
+  mount: string;
+  device: string;
+  fstype: string;
+}
+
 export type AlertLevel = 'ok' | 'info' | 'warning' | 'critical';
 
 export interface AlertEntry {
@@ -164,9 +201,24 @@ export interface CpuHourSample {
   usage: number | null;
 }
 
+// A generic per-metric hourly trend point (memory %, disk %, temp °C, net KB/s).
+export interface TrendSample {
+  at: string; // ISO 8601, start of the 1-hour bucket
+  value: number | null; // null if the server wasn't up / metric unavailable that hour
+}
+
+export interface HistoryTrends {
+  mem: TrendSample[];
+  disk: TrendSample[];
+  temp: TrendSample[];
+  net: TrendSample[];
+}
+
 export interface HistoryInfo {
   load: LoadSample[]; // last 48 hours, 1-hour buckets
   cpuHourly: CpuHourSample[]; // last 24 hours, 1-hour buckets
+  // Added in 2.3: per-metric 24h trend series (optional: old-node compatible).
+  trends?: HistoryTrends;
 }
 
 export interface ServerData {
@@ -238,6 +290,14 @@ export interface ServerData {
   battery?: BatteryInfo | null;
   history?: HistoryInfo;
   alerts?: AlertEntry[];
+  // Added in 2.3 (all optional: old-node compatible).
+  memoryDetail?: MemoryDetail;
+  services?: ServicesInfo;
+  packages?: PackagesInfo | null;
+  smart?: SmartDevice[];
+  readOnlyMounts?: ReadOnlyMount[];
+  kernelErrors?: number | null;
+  failedLogins?: number | null;
   timestamp?: string;
   // When only some collectors fail, tells you which metric is empty and why.
   // Lets you diagnose a headless server with just `curl localhost:3000/api/system`.

--- a/src/utils/collectors/history.test.ts
+++ b/src/utils/collectors/history.test.ts
@@ -144,6 +144,51 @@ describe('load history buckets', () => {
   });
 });
 
+describe('trend history', () => {
+  beforeEach(() => {
+    delete process.env.DATA_DIR;
+    delete process.env.HISTORY_FILE;
+  });
+
+  it('records per-metric trends and averages within the hour', async () => {
+    const { recordTrend, getHistory } = await freshHistory();
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    recordTrend({ mem: 40, disk: 50, temp: 55, net: 100 }, now);
+    recordTrend({ mem: 60, disk: 50, temp: 55, net: 300 }, now + 60_000);
+
+    const trends = getHistory(now).trends!;
+    expect(trends.mem).toHaveLength(24);
+    expect(trends.mem.at(-1)!.value).toBe(50); // (40+60)/2
+    expect(trends.net.at(-1)!.value).toBe(200);
+  });
+
+  it('skips null samples so a bucket only averages real readings', async () => {
+    const { recordTrend, getHistory } = await freshHistory();
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+
+    recordTrend({ mem: 30, temp: null }, now); // temp N/A this tick
+    expect(getHistory(now).trends!.temp.at(-1)!.value).toBeNull();
+    expect(getHistory(now).trends!.mem.at(-1)!.value).toBe(30);
+  });
+
+  it('loads a v1 store (no trends) without error, trends starting empty', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'history-test-'));
+    const file = join(dir, 'history.json');
+    const now = Math.floor(Date.now() / HOUR) * HOUR;
+    writeFileSync(file, JSON.stringify({ v: 1, loadBuckets: [[now, 5, 1]], cpuBuckets: [[now, 20, 1]] }));
+
+    vi.resetModules();
+    process.env.DATA_DIR = dir;
+    process.env.HISTORY_FILE = file;
+    const { getHistory } = await import('@/utils/collectors/history');
+
+    const history = getHistory(now);
+    expect(history.load.at(-1)!.avg1).toBe(5); // v1 data still recovered
+    expect(history.trends!.mem.every(sample => sample.value === null)).toBe(true);
+  });
+});
+
 describe('getLoad30mAverage', () => {
   it('reports no value when there are no samples', async () => {
     const { getLoad30mAverage } = await freshHistory();

--- a/src/utils/collectors/history.ts
+++ b/src/utils/collectors/history.ts
@@ -35,7 +35,10 @@ const SAVE_INTERVAL_MS = 30 * 1000;
 // project into the output bundle (the "unexpected file in NFT list" warning).
 const DATA_DIR = process.env.DATA_DIR || path.join(/*turbopackIgnore: true*/ process.cwd(), 'data');
 const STORE_FILE = process.env.HISTORY_FILE || path.join(DATA_DIR, 'history.json');
-const STORE_VERSION = 1;
+// v2 adds the per-metric trend buckets. A v1 file still loads (its trend series
+// just start empty and fill over time).
+const STORE_VERSION = 2;
+const SUPPORTED_VERSIONS = new Set([1, 2]);
 
 interface Bucket {
   sum: number;
@@ -44,6 +47,18 @@ interface Bucket {
 
 const loadBuckets = new Map<number, Bucket>();
 const cpuBuckets = new Map<number, Bucket>();
+
+// Per-metric trend buckets (memory %, disk %, temperature °C, network KB/s).
+// Same hourly granularity/retention as CPU; drawn as 24h sparklines per card.
+// Kept in one record so the persistence/serialisation loops stay generic.
+const TREND_KEYS = ['mem', 'disk', 'temp', 'net'] as const;
+type TrendKey = (typeof TREND_KEYS)[number];
+const trendBuckets: Record<TrendKey, Map<number, Bucket>> = {
+  mem: new Map(),
+  disk: new Map(),
+  temp: new Map(),
+  net: new Map()
+};
 
 // --- 30-minute moving average --------------------------------------------
 // The kernel only gives 1/5/15-minute load averages, so we compute the 30-minute
@@ -110,6 +125,11 @@ interface StoreShape {
   v: number;
   loadBuckets: SerializedBucket[];
   cpuBuckets: SerializedBucket[];
+  // Added in store v2 (optional so a v1 file still loads its load/cpu history).
+  memBuckets?: SerializedBucket[];
+  diskBuckets?: SerializedBucket[];
+  tempBuckets?: SerializedBucket[];
+  netBuckets?: SerializedBucket[];
 }
 
 function serialize(buckets: Map<number, Bucket>): SerializedBucket[] {
@@ -139,9 +159,14 @@ function ensureLoaded(): void {
   try {
     const raw = fs.readFileSync(/*turbopackIgnore: true*/ STORE_FILE, 'utf-8');
     const parsed = JSON.parse(raw) as StoreShape;
-    if (parsed && parsed.v === STORE_VERSION) {
+    if (parsed && SUPPORTED_VERSIONS.has(parsed.v)) {
       hydrate(loadBuckets, parsed.loadBuckets, LOAD_BUCKET_MS, LOAD_RETENTION);
       hydrate(cpuBuckets, parsed.cpuBuckets, HOUR_BUCKET_MS, CPU_RETENTION);
+      // v1 files simply have these undefined; hydrate no-ops on a non-array.
+      hydrate(trendBuckets.mem, parsed.memBuckets, HOUR_BUCKET_MS, CPU_RETENTION);
+      hydrate(trendBuckets.disk, parsed.diskBuckets, HOUR_BUCKET_MS, CPU_RETENTION);
+      hydrate(trendBuckets.temp, parsed.tempBuckets, HOUR_BUCKET_MS, CPU_RETENTION);
+      hydrate(trendBuckets.net, parsed.netBuckets, HOUR_BUCKET_MS, CPU_RETENTION);
     }
   } catch {
     // If the file is missing (first run) or unreadable, start empty.
@@ -152,15 +177,23 @@ let lastSaveAt = 0;
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 let writing = false;
 
+function buildPayload(): StoreShape {
+  return {
+    v: STORE_VERSION,
+    loadBuckets: serialize(loadBuckets),
+    cpuBuckets: serialize(cpuBuckets),
+    memBuckets: serialize(trendBuckets.mem),
+    diskBuckets: serialize(trendBuckets.disk),
+    tempBuckets: serialize(trendBuckets.temp),
+    netBuckets: serialize(trendBuckets.net)
+  };
+}
+
 async function writeStore(): Promise<void> {
   if (writing) return;
   writing = true;
   lastSaveAt = Date.now();
-  const payload: StoreShape = {
-    v: STORE_VERSION,
-    loadBuckets: serialize(loadBuckets),
-    cpuBuckets: serialize(cpuBuckets)
-  };
+  const payload = buildPayload();
   try {
     await fs.promises.mkdir(DATA_DIR, { recursive: true });
     // Write to a temp file and rename so no half-written file remains (atomic replace).
@@ -191,11 +224,7 @@ function scheduleSave(): void {
 // the scheduled save hasn't run yet, the recent window isn't lost.
 function flushSync(): void {
   try {
-    const payload: StoreShape = {
-      v: STORE_VERSION,
-      loadBuckets: serialize(loadBuckets),
-      cpuBuckets: serialize(cpuBuckets)
-    };
+    const payload = buildPayload();
     fs.mkdirSync(DATA_DIR, { recursive: true });
     fs.writeFileSync(STORE_FILE, JSON.stringify(payload), 'utf-8');
   } catch {
@@ -233,6 +262,27 @@ export function recordSample(cpuUsage: number, load1: number, at: number = Date.
   scheduleSave();
 }
 
+// Record the per-metric trend samples for this tick. Nulls (unavailable/N/A
+// sources) are skipped so a bucket only ever averages real readings.
+export function recordTrend(
+  samples: { mem?: number | null; disk?: number | null; temp?: number | null; net?: number | null },
+  at: number = Date.now()
+): void {
+  ensureLoaded();
+  hookExit();
+
+  const hourKey = Math.floor(at / HOUR_BUCKET_MS) * HOUR_BUCKET_MS;
+  const oldest = hourKey - (CPU_RETENTION - 1) * HOUR_BUCKET_MS;
+  for (const key of TREND_KEYS) {
+    const value = samples[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      add(trendBuckets[key], hourKey, value);
+      prune(trendBuckets[key], oldest);
+    }
+  }
+  scheduleSave();
+}
+
 function series(buckets: Map<number, Bucket>, bucketMs: number, count: number, now: number, digits: number) {
   const newestKey = Math.floor(now / bucketMs) * bucketMs;
   return Array.from({ length: count }, (_, index) => {
@@ -253,5 +303,11 @@ export function getHistory(now: number = Date.now()): HistoryInfo {
   const cpuHourly: CpuHourSample[] = series(cpuBuckets, HOUR_BUCKET_MS, CPU_DISPLAY, now, 1).map(
     ({ at, value }) => ({ at, usage: value })
   );
-  return { load, cpuHourly };
+  const trends = {
+    mem: series(trendBuckets.mem, HOUR_BUCKET_MS, CPU_DISPLAY, now, 1),
+    disk: series(trendBuckets.disk, HOUR_BUCKET_MS, CPU_DISPLAY, now, 1),
+    temp: series(trendBuckets.temp, HOUR_BUCKET_MS, CPU_DISPLAY, now, 1),
+    net: series(trendBuckets.net, HOUR_BUCKET_MS, CPU_DISPLAY, now, 1)
+  };
+  return { load, cpuHourly, trends };
 }

--- a/src/utils/collectors/kernel.test.ts
+++ b/src/utils/collectors/kernel.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { countFailedLogins, countNonEmptyLines } from '@/utils/collectors/kernel';
+
+describe('countNonEmptyLines', () => {
+  it('counts non-empty lines', () => {
+    expect(countNonEmptyLines('a\n\nb\n')).toBe(2);
+    expect(countNonEmptyLines('')).toBe(0);
+  });
+});
+
+describe('countFailedLogins', () => {
+  it('counts failed-auth lines and ignores others', () => {
+    const output = [
+      'sshd[123]: Failed password for root from 10.0.0.1 port 2222 ssh2',
+      'sshd[124]: Accepted password for deploy from 10.0.0.2',
+      'sshd[125]: Invalid user admin from 10.0.0.3',
+      'sshd[126]: pam_unix(sshd:auth): authentication failure; rhost=10.0.0.4'
+    ].join('\n');
+    expect(countFailedLogins(output)).toBe(3);
+  });
+
+  it('returns 0 for clean output', () => {
+    expect(countFailedLogins('sshd: Accepted publickey for deploy')).toBe(0);
+  });
+});

--- a/src/utils/collectors/kernel.ts
+++ b/src/utils/collectors/kernel.ts
@@ -23,8 +23,14 @@ export function countFailedLogins(output: string): number {
 
 export const getKernelErrorCount = withTtl(60_000, async (): Promise<number | null> => {
   try {
-    // -p 3 = err priority. No `|| true`, so a permission failure throws → null.
-    const output = await run('journalctl -k -p 3 --since=-24h --no-pager -n 2000 2>/dev/null', 10_000);
+    // _TRANSPORT=kernel (not -k) so the 24h window spans reboots, not just the
+    // current boot. -q suppresses status lines like "-- No entries --" that would
+    // otherwise be counted as one error. -p 3 = err priority. No `|| true`, so a
+    // command failure throws → null.
+    const output = await run(
+      'journalctl _TRANSPORT=kernel -p 3 --since=-24h --no-pager -q -n 2000 2>/dev/null',
+      10_000
+    );
     return countNonEmptyLines(output);
   } catch {
     return null;
@@ -33,8 +39,10 @@ export const getKernelErrorCount = withTtl(60_000, async (): Promise<number | nu
 
 export const getFailedLoginCount = withTtl(60_000, async (): Promise<number | null> => {
   try {
+    // -q suppresses the "-- No entries --" hint (which would otherwise be a stray
+    // counted line on a quiet host).
     const output = await run(
-      'journalctl _SYSTEMD_UNIT=ssh.service _SYSTEMD_UNIT=sshd.service --since=-24h --no-pager -n 5000 2>/dev/null',
+      'journalctl _SYSTEMD_UNIT=ssh.service _SYSTEMD_UNIT=sshd.service --since=-24h --no-pager -q -n 5000 2>/dev/null',
       10_000
     );
     return countFailedLogins(output);

--- a/src/utils/collectors/kernel.ts
+++ b/src/utils/collectors/kernel.ts
@@ -1,0 +1,44 @@
+import { run, withTtl } from '@/utils/collectors/shell';
+
+// Two journal-derived security/health counters, both over the last 24h:
+//   - kernel errors (priority err) — OOM kills, I/O errors, hardware faults that
+//     never show on a CPU/load graph.
+//   - failed SSH logins — a brute-force indicator.
+// Reading the journal is expensive, so each is cached for a minute. A null count
+// means the journal wasn't readable (no permission), distinct from a real 0.
+
+// Pure: count non-empty lines (used for the kernel error tally).
+export function countNonEmptyLines(output: string): number {
+  return output.split('\n').filter(line => line.trim() !== '').length;
+}
+
+// Pure: count failed-authentication lines in sshd journal output.
+export function countFailedLogins(output: string): number {
+  let count = 0;
+  for (const line of output.split('\n')) {
+    if (/Failed password|authentication failure|Invalid user|Failed publickey/i.test(line)) count += 1;
+  }
+  return count;
+}
+
+export const getKernelErrorCount = withTtl(60_000, async (): Promise<number | null> => {
+  try {
+    // -p 3 = err priority. No `|| true`, so a permission failure throws → null.
+    const output = await run('journalctl -k -p 3 --since=-24h --no-pager -n 2000 2>/dev/null', 10_000);
+    return countNonEmptyLines(output);
+  } catch {
+    return null;
+  }
+});
+
+export const getFailedLoginCount = withTtl(60_000, async (): Promise<number | null> => {
+  try {
+    const output = await run(
+      'journalctl _SYSTEMD_UNIT=ssh.service _SYSTEMD_UNIT=sshd.service --since=-24h --no-pager -n 5000 2>/dev/null',
+      10_000
+    );
+    return countFailedLogins(output);
+  } catch {
+    return null;
+  }
+});

--- a/src/utils/collectors/memdetail.test.ts
+++ b/src/utils/collectors/memdetail.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMemBreakdown } from '@/utils/collectors/memdetail';
+
+const MEMINFO = `MemTotal:       16384000 kB
+MemFree:         2048000 kB
+MemAvailable:    8192000 kB
+Buffers:          512000 kB
+Cached:          4096000 kB
+SwapCached:        10240 kB
+Shmem:            256000 kB
+Slab:             786432 kB
+`;
+
+describe('parseMemBreakdown', () => {
+  it('converts the relevant fields to MB', () => {
+    const detail = parseMemBreakdown(MEMINFO);
+    expect(detail.cached).toBe(4000);
+    expect(detail.buffers).toBe(500);
+    expect(detail.available).toBe(8000);
+    expect(detail.shared).toBe(250);
+    expect(detail.slab).toBe(768);
+    expect(detail.swapCached).toBe(10);
+  });
+
+  it('returns null for missing fields', () => {
+    expect(parseMemBreakdown('MemTotal: 1000 kB').cached).toBeNull();
+  });
+});

--- a/src/utils/collectors/memdetail.ts
+++ b/src/utils/collectors/memdetail.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'fs/promises';
+
+import { MemoryDetail } from '@/types/system';
+
+// A finer breakdown of /proc/meminfo than the headline used/total: how much of
+// "used" is reclaimable page cache vs. buffers vs. kernel slab, plus swap cached.
+// Lets an operator tell real memory pressure from healthy cache usage. Pure
+// parser split out for testing; the file is already read for the top-level gauge.
+
+function field(contents: string, key: string): number | null {
+  const match = contents.match(new RegExp(`^${key}:\\s+(\\d+) kB`, 'm'));
+  return match ? parseInt(match[1], 10) : null;
+}
+
+const toMb = (kb: number | null): number | null => (kb === null ? null : Math.round(kb / 1024));
+
+export function parseMemBreakdown(contents: string): MemoryDetail {
+  return {
+    cached: toMb(field(contents, 'Cached')),
+    buffers: toMb(field(contents, 'Buffers')),
+    available: toMb(field(contents, 'MemAvailable')),
+    shared: toMb(field(contents, 'Shmem')),
+    slab: toMb(field(contents, 'Slab')),
+    swapCached: toMb(field(contents, 'SwapCached'))
+  };
+}
+
+export async function getMemBreakdown(): Promise<MemoryDetail> {
+  return parseMemBreakdown(await readFile('/proc/meminfo', 'utf-8'));
+}

--- a/src/utils/collectors/mounts.test.ts
+++ b/src/utils/collectors/mounts.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseReadOnlyMounts } from '@/utils/collectors/mounts';
+
+const MOUNTS = `sysfs /sys sysfs rw,nosuid,nodev,noexec 0 0
+/dev/sda1 / ext4 rw,relatime 0 0
+/dev/sdb1 /data ext4 ro,relatime 0 0
+tmpfs /run tmpfs rw,nosuid 0 0
+/dev/sr0 /media/cdrom iso9660 ro,relatime 0 0
+`;
+
+describe('parseReadOnlyMounts', () => {
+  it('reports real block devices mounted read-only', () => {
+    const ro = parseReadOnlyMounts(MOUNTS);
+    expect(ro).toHaveLength(1);
+    expect(ro[0]).toMatchObject({ mount: '/data', device: '/dev/sdb1', fstype: 'ext4' });
+  });
+
+  it('ignores pseudo filesystems and rw mounts', () => {
+    expect(parseReadOnlyMounts('/dev/sda1 / ext4 rw,relatime 0 0')).toHaveLength(0);
+    expect(parseReadOnlyMounts('tmpfs /run tmpfs ro 0 0')).toHaveLength(0);
+  });
+});

--- a/src/utils/collectors/mounts.ts
+++ b/src/utils/collectors/mounts.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'fs/promises';
+
+import { ReadOnlyMount } from '@/types/system';
+
+// Detects filesystems that have flipped to read-only — a classic silent failure
+// mode (a disk error makes the kernel remount ro, and writes start failing while
+// everything else looks fine). We read /proc/mounts and report real block-device
+// mounts whose options include `ro`. Pseudo filesystems and legitimately
+// read-only mounts (squashfs, iso9660, overlay lowerdirs) are excluded.
+
+const PSEUDO_FS = new Set([
+  'proc',
+  'sysfs',
+  'tmpfs',
+  'devtmpfs',
+  'devpts',
+  'cgroup',
+  'cgroup2',
+  'securityfs',
+  'debugfs',
+  'tracefs',
+  'mqueue',
+  'hugetlbfs',
+  'pstore',
+  'bpf',
+  'configfs',
+  'fusectl',
+  'autofs',
+  'binfmt_misc',
+  'squashfs',
+  'iso9660',
+  'overlay'
+]);
+
+// Pure parser for /proc/mounts (or the output of `mount`), returning real
+// filesystems currently mounted read-only.
+export function parseReadOnlyMounts(contents: string): ReadOnlyMount[] {
+  const found: ReadOnlyMount[] = [];
+  for (const line of contents.split('\n')) {
+    // device mountpoint fstype options dump pass
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 4) continue;
+
+    const [device, mount, fstype, options] = parts;
+    if (PSEUDO_FS.has(fstype)) continue;
+    if (!device.startsWith('/dev/')) continue;
+
+    const flags = options.split(',');
+    if (flags.includes('ro') && !flags.includes('rw')) {
+      found.push({ mount, device, fstype });
+    }
+  }
+  return found;
+}
+
+export async function getReadOnlyMounts(): Promise<ReadOnlyMount[]> {
+  return parseReadOnlyMounts(await readFile('/proc/mounts', 'utf-8'));
+}

--- a/src/utils/collectors/packages.test.ts
+++ b/src/utils/collectors/packages.test.ts
@@ -22,4 +22,19 @@ describe('parseAptSimulation', () => {
     ].join('\n');
     expect(parseAptSimulation(output)).toEqual({ total: 2, security: 1 });
   });
+
+  it('matches the pocket, not a package name containing "security"', () => {
+    const output = [
+      'Inst libsecurity1 [1.0] (1.1 Ubuntu:22.04/jammy-updates [amd64])', // name only, not a security update
+      'Inst openssl [3.0] (3.0.2 Ubuntu:22.04/jammy-security [amd64])'
+    ].join('\n');
+    expect(parseAptSimulation(output)).toEqual({ total: 2, security: 1 });
+  });
+
+  it('returns zero on a fully patched host (no Inst lines)', () => {
+    expect(parseAptSimulation('Reading package lists...\n0 upgraded, 0 newly installed.')).toEqual({
+      total: 0,
+      security: 0
+    });
+  });
 });

--- a/src/utils/collectors/packages.test.ts
+++ b/src/utils/collectors/packages.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAptCheck, parseAptSimulation } from '@/utils/collectors/packages';
+
+describe('parseAptCheck', () => {
+  it('parses "total;security"', () => {
+    expect(parseAptCheck('5;2')).toEqual({ total: 5, security: 2 });
+    expect(parseAptCheck('0;0')).toEqual({ total: 0, security: 0 });
+  });
+
+  it('returns null for unexpected output', () => {
+    expect(parseAptCheck('not the format')).toBeNull();
+  });
+});
+
+describe('parseAptSimulation', () => {
+  it('counts Inst lines and the security subset', () => {
+    const output = [
+      'Inst libc6 [2.35-0ubuntu3.1] (2.35-0ubuntu3.4 Ubuntu:22.04/jammy-security [amd64])',
+      'Inst vim [2:8.2] (2:8.2.1 Ubuntu:22.04/jammy-updates [amd64])',
+      'Conf libc6 (2.35-0ubuntu3.4)'
+    ].join('\n');
+    expect(parseAptSimulation(output)).toEqual({ total: 2, security: 1 });
+  });
+});

--- a/src/utils/collectors/packages.ts
+++ b/src/utils/collectors/packages.ts
@@ -1,0 +1,47 @@
+import { PackagesInfo } from '@/types/system';
+import { run, withTtl } from '@/utils/collectors/shell';
+
+// Pending package updates, with a security subtotal — patch hygiene at a glance.
+// Targets apt (the repo's stated Ubuntu focus): update-notifier's apt-check emits
+// "total;security"; a plain `apt-get -s` simulation is the fallback. Checked
+// infrequently (30 min) since it can touch package metadata.
+
+// Pure: parse update-notifier apt-check output, "<total>;<security>".
+export function parseAptCheck(output: string): PackagesInfo | null {
+  const match = output.trim().match(/^(\d+);(\d+)$/);
+  if (!match) return null;
+  return { total: parseInt(match[1], 10), security: parseInt(match[2], 10) };
+}
+
+// Pure: count "Inst " lines in `apt-get -s upgrade` output, and of those the
+// ones from a -security pocket.
+export function parseAptSimulation(output: string): PackagesInfo {
+  let total = 0;
+  let security = 0;
+  for (const line of output.split('\n')) {
+    if (!line.startsWith('Inst ')) continue;
+    total += 1;
+    if (/security/i.test(line)) security += 1;
+  }
+  return { total, security };
+}
+
+export const getPackagesInfo = withTtl(30 * 60_000, async (): Promise<PackagesInfo | null> => {
+  // apt-check is fast and gives the security split directly.
+  try {
+    const output = await run('/usr/lib/update-notifier/apt-check 2>&1 || true', 10_000);
+    const parsed = parseAptCheck(output);
+    if (parsed) return parsed;
+  } catch {
+    // fall through to the simulation
+  }
+
+  try {
+    const output = await run('apt-get -s upgrade 2>/dev/null || true', 15_000);
+    if (output.includes('Inst ')) return parseAptSimulation(output);
+  } catch {
+    // apt not present
+  }
+
+  return null; // not a supported package manager, or nothing readable
+});

--- a/src/utils/collectors/packages.ts
+++ b/src/utils/collectors/packages.ts
@@ -21,7 +21,10 @@ export function parseAptSimulation(output: string): PackagesInfo {
   for (const line of output.split('\n')) {
     if (!line.startsWith('Inst ')) continue;
     total += 1;
-    if (/security/i.test(line)) security += 1;
+    // Only the parenthesized repo/pocket annotation decides "security" — not the
+    // package name (which might merely contain "security").
+    const annotation = line.match(/\(([^)]*)\)/)?.[1] ?? '';
+    if (/security/i.test(annotation)) security += 1;
   }
   return { total, security };
 }
@@ -37,8 +40,10 @@ export const getPackagesInfo = withTtl(30 * 60_000, async (): Promise<PackagesIn
   }
 
   try {
-    const output = await run('apt-get -s upgrade 2>/dev/null || true', 15_000);
-    if (output.includes('Inst ')) return parseAptSimulation(output);
+    // No `|| true`: if apt-get runs at all (throws only when absent), a fully
+    // patched host has zero "Inst " lines and should report 0, not disappear.
+    const output = await run('apt-get -s upgrade 2>/dev/null', 15_000);
+    return parseAptSimulation(output);
   } catch {
     // apt not present
   }

--- a/src/utils/collectors/services.test.ts
+++ b/src/utils/collectors/services.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFailedUnits } from '@/utils/collectors/services';
+
+describe('parseFailedUnits', () => {
+  it('extracts failed .service unit names', () => {
+    const output = [
+      'nginx.service      loaded failed failed The nginx web server',
+      'postgresql.service loaded failed failed PostgreSQL database'
+    ].join('\n');
+    expect(parseFailedUnits(output)).toEqual(['nginx.service', 'postgresql.service']);
+  });
+
+  it('returns empty for no failures', () => {
+    expect(parseFailedUnits('')).toEqual([]);
+  });
+
+  it('ignores a summary footer and non-service rows', () => {
+    const output = 'docker.socket loaded failed failed\n1 loaded units listed.';
+    expect(parseFailedUnits(output)).toEqual([]);
+  });
+});

--- a/src/utils/collectors/services.ts
+++ b/src/utils/collectors/services.ts
@@ -1,0 +1,37 @@
+import { ServicesInfo } from '@/types/system';
+import { run, withTtl } from '@/utils/collectors/shell';
+
+// Failed systemd units — a direct "is anything broken" signal that the
+// process/CPU views miss (a crashed service shows nothing on a load graph).
+// Parsed from `systemctl --failed`. Pure parser split out for testing.
+
+// Pure: extract failed unit names from `systemctl list-units --failed
+// --no-legend --plain` output. Each row starts with the unit name.
+export function parseFailedUnits(output: string): string[] {
+  const units: string[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // Stop at the summary footer ("N loaded units listed." / "0 loaded units...").
+    if (/loaded units? listed/i.test(trimmed) || /^\d+ unit/i.test(trimmed)) continue;
+    const name = trimmed.split(/\s+/)[0];
+    if (name && name.endsWith('.service')) units.push(name);
+  }
+  return units;
+}
+
+export const getServicesInfo = withTtl(30_000, async (): Promise<ServicesInfo> => {
+  let output: string;
+  try {
+    output = await run(
+      'systemctl list-units --type=service --state=failed --no-legend --plain 2>/dev/null || true'
+    );
+  } catch {
+    return { failed: null, failedUnits: [] }; // no systemd (container/busybox)
+  }
+
+  // Empty output can mean "no failed units" OR "systemctl unavailable"; the
+  // `|| true` above makes both empty. Treat empty as zero failed — the common case.
+  const failedUnits = parseFailedUnits(output).slice(0, 10);
+  return { failed: failedUnits.length, failedUnits };
+});

--- a/src/utils/collectors/services.ts
+++ b/src/utils/collectors/services.ts
@@ -23,15 +23,16 @@ export function parseFailedUnits(output: string): string[] {
 export const getServicesInfo = withTtl(30_000, async (): Promise<ServicesInfo> => {
   let output: string;
   try {
-    output = await run(
-      'systemctl list-units --type=service --state=failed --no-legend --plain 2>/dev/null || true'
-    );
+    // No `|| true`: on a non-systemd host (or one where systemctl can't reach the
+    // manager) the command fails and we return null (unknown), rather than
+    // presenting an unavailable check as a healthy "0 failed". A real 0-failure
+    // run exits 0 with empty output.
+    output = await run('systemctl list-units --type=service --state=failed --no-legend --plain 2>/dev/null');
   } catch {
-    return { failed: null, failedUnits: [] }; // no systemd (container/busybox)
+    return { failed: null, failedUnits: [] };
   }
 
-  // Empty output can mean "no failed units" OR "systemctl unavailable"; the
-  // `|| true` above makes both empty. Treat empty as zero failed — the common case.
-  const failedUnits = parseFailedUnits(output).slice(0, 10);
-  return { failed: failedUnits.length, failedUnits };
+  // Count the full set; only the detail list is bounded.
+  const units = parseFailedUnits(output);
+  return { failed: units.length, failedUnits: units.slice(0, 10) };
 });

--- a/src/utils/collectors/shell.ts
+++ b/src/utils/collectors/shell.ts
@@ -47,29 +47,45 @@ export async function collect<T>(
 }
 
 // The dashboard polls once a second. Running process-spawning collectors like
-// `who`, `last`, `nvidia-smi` every second would make the monitored server
-// busier, so values that rarely change are cached and reused for a TTL.
+// `who`, `last`, `nvidia-smi`, `smartctl`, `apt-get` every second would make the
+// monitored server busier, so values that rarely change are cached for a TTL.
+//
+// Stale-while-revalidate: once a value exists, an expired entry returns the stale
+// value immediately and refreshes in the background. Only the very first call
+// (before any value exists) awaits the collector. This keeps a slow refresh
+// (apt/SMART/journal, up to seconds) from blocking the 1s collection loop, since
+// getSystemInfo awaits every collector before the next tick is scheduled.
 export function withTtl<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
   let value: T;
+  let hasValue = false;
   let expiresAt = 0;
   let inflight: Promise<T> | null = null;
 
-  return async () => {
-    if (expiresAt > Date.now()) return value;
+  const refresh = (): Promise<T> => {
     // Even if several collectors call within the same tick, spawn the process only once.
     if (inflight) return inflight;
-
     inflight = fn()
       .then(result => {
         value = result;
+        hasValue = true;
         expiresAt = Date.now() + ttlMs;
         return result;
       })
       .finally(() => {
         inflight = null;
       });
-
     return inflight;
+  };
+
+  return async () => {
+    if (hasValue && expiresAt > Date.now()) return value; // fresh
+    if (hasValue) {
+      // Stale: kick off a background refresh (swallow its error — the stale value
+      // is still served) and return the last good value now.
+      void refresh().catch(() => {});
+      return value;
+    }
+    return refresh(); // no value yet: must await the first collection
   };
 }
 

--- a/src/utils/collectors/smart.test.ts
+++ b/src/utils/collectors/smart.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSmartJson, parseSmartScan } from '@/utils/collectors/smart';
+
+describe('parseSmartScan', () => {
+  it('extracts device names', () => {
+    const raw = JSON.stringify({ devices: [{ name: '/dev/sda' }, { name: '/dev/nvme0' }] });
+    expect(parseSmartScan(raw)).toEqual(['/dev/sda', '/dev/nvme0']);
+  });
+
+  it('returns empty on malformed JSON', () => {
+    expect(parseSmartScan('not json')).toEqual([]);
+  });
+});
+
+describe('parseSmartJson', () => {
+  it('summarises health, temperature and power-on hours', () => {
+    const raw = JSON.stringify({
+      smart_status: { passed: true },
+      temperature: { current: 41 },
+      power_on_time: { hours: 12000 }
+    });
+    expect(parseSmartJson(raw, '/dev/sda')).toEqual({
+      device: '/dev/sda',
+      healthy: true,
+      temperature: 41,
+      powerOnHours: 12000
+    });
+  });
+
+  it('reports a failing assessment', () => {
+    const raw = JSON.stringify({ smart_status: { passed: false } });
+    expect(parseSmartJson(raw, '/dev/sdb')).toMatchObject({ healthy: false, temperature: 'N/A' });
+  });
+
+  it('returns null on malformed JSON', () => {
+    expect(parseSmartJson('nope', '/dev/sda')).toBeNull();
+  });
+});

--- a/src/utils/collectors/smart.ts
+++ b/src/utils/collectors/smart.ts
@@ -1,0 +1,64 @@
+import { SmartDevice } from '@/types/system';
+import { run, withTtl } from '@/utils/collectors/shell';
+
+// Disk SMART health and per-drive temperature via smartctl. Surfaces impending
+// hardware failure (a failing SMART self-assessment, reallocated sectors, high
+// NVMe temperature) that no usage metric shows. Needs smartctl (smartmontools)
+// and usually root; when absent or unreadable the list is simply empty. Cached
+// for 5 minutes — it spawns one process per drive.
+
+// Pure: parse `smartctl -j -H -A <dev>` JSON into a compact device summary.
+export function parseSmartJson(raw: string, device: string): SmartDevice | null {
+  let json: Record<string, unknown>;
+  try {
+    json = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const status = json.smart_status as { passed?: unknown } | undefined;
+  const temperature = json.temperature as { current?: unknown } | undefined;
+  const powerOn = json.power_on_time as { hours?: unknown } | undefined;
+
+  return {
+    device,
+    healthy: typeof status?.passed === 'boolean' ? status.passed : null,
+    temperature: typeof temperature?.current === 'number' ? temperature.current : 'N/A',
+    powerOnHours: typeof powerOn?.hours === 'number' ? powerOn.hours : null
+  };
+}
+
+// Pure: device names from `smartctl --scan -j`.
+export function parseSmartScan(raw: string): string[] {
+  try {
+    const json = JSON.parse(raw) as { devices?: { name?: unknown }[] };
+    return (json.devices ?? [])
+      .map(entry => entry.name)
+      .filter((name): name is string => typeof name === 'string');
+  } catch {
+    return [];
+  }
+}
+
+export const getSmartInfo = withTtl(5 * 60_000, async (): Promise<SmartDevice[]> => {
+  let scan: string;
+  try {
+    scan = await run('smartctl --scan -j 2>/dev/null || true');
+  } catch {
+    return []; // smartctl not installed
+  }
+
+  const devices = parseSmartScan(scan).slice(0, 8); // bound the process fan-out
+  const results = await Promise.all(
+    devices.map(async device => {
+      try {
+        const raw = await run(`smartctl -j -H -A ${device} 2>/dev/null || true`, 8_000);
+        return parseSmartJson(raw, device);
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return results.filter((entry): entry is SmartDevice => entry !== null);
+});

--- a/src/utils/dashboardData.ts
+++ b/src/utils/dashboardData.ts
@@ -14,7 +14,12 @@ import {
   ProcessSummary,
   BatteryInfo,
   TemperatureInfo,
-  TemperatureValue
+  TemperatureValue,
+  MemoryDetail,
+  ServicesInfo,
+  PackagesInfo,
+  SmartDevice,
+  ReadOnlyMount
 } from '@/types/system';
 
 // The API's new fields are all optional (old-node compatible). Rather than
@@ -58,6 +63,13 @@ export interface DashboardData {
   processSummary: ProcessSummary;
   topProcessesByMemory: Process[];
   battery: BatteryInfo | null;
+  memoryDetail: MemoryDetail | null;
+  services: ServicesInfo;
+  packages: PackagesInfo | null;
+  smart: SmartDevice[];
+  readOnlyMounts: ReadOnlyMount[];
+  kernelErrors: number | null;
+  failedLogins: number | null;
   history: HistoryInfo;
   alerts: AlertEntry[];
   timestamp: string;
@@ -120,6 +132,13 @@ export function toDashboardData(raw: ServerData): DashboardData {
     processSummary: raw.processSummary ?? { total: 0, running: 0, sleeping: 0, zombie: 0, threads: null },
     topProcessesByMemory: raw.topProcessesByMemory ?? [],
     battery: raw.battery ?? null,
+    memoryDetail: raw.memoryDetail ?? null,
+    services: raw.services ?? { failed: null, failedUnits: [] },
+    packages: raw.packages ?? null,
+    smart: raw.smart ?? [],
+    readOnlyMounts: raw.readOnlyMounts ?? [],
+    kernelErrors: raw.kernelErrors ?? null,
+    failedLogins: raw.failedLogins ?? null,
     history: raw.history ?? EMPTY_HISTORY,
     alerts: raw.alerts ?? [],
     timestamp: raw.timestamp ?? new Date().toISOString(),

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -32,7 +32,13 @@ import {
   SocketSummary
 } from '@/utils/collectors/netstat';
 import { getFirewallInfo, getSshSessions } from '@/utils/collectors/security';
-import { getHistory, getLoad30mAverage, recordSample } from '@/utils/collectors/history';
+import { getMemBreakdown } from '@/utils/collectors/memdetail';
+import { getReadOnlyMounts } from '@/utils/collectors/mounts';
+import { getServicesInfo } from '@/utils/collectors/services';
+import { getKernelErrorCount, getFailedLoginCount } from '@/utils/collectors/kernel';
+import { getPackagesInfo } from '@/utils/collectors/packages';
+import { getSmartInfo } from '@/utils/collectors/smart';
+import { getHistory, getLoad30mAverage, recordSample, recordTrend } from '@/utils/collectors/history';
 import { evaluateAlerts } from '@/utils/collectors/alerts';
 import { isAnomalous } from '@/utils/collectors/anomaly';
 
@@ -575,6 +581,24 @@ export async function getSystemInfo(): Promise<ServerData> {
   const loadBase = await getLoadAverage();
   const security = await getSecurityInfo(sockets.peers, warnings);
 
+  // New collectors (2.3). Each wrapped so a failure just yields its fallback and
+  // records a warning, never dropping the rest of the response.
+  const [memoryDetail, services, packages, smart, readOnlyMounts, kernelErrors, failedLogins] =
+    await Promise.all([
+      collect(
+        'memoryDetail',
+        getMemBreakdown,
+        { cached: null, buffers: null, available: null, shared: null, slab: null, swapCached: null },
+        warnings
+      ),
+      collect('services', getServicesInfo, { failed: null, failedUnits: [] }, warnings),
+      collect('packages', getPackagesInfo, null, warnings),
+      collect('smart', getSmartInfo, [], warnings),
+      collect('readOnlyMounts', getReadOnlyMounts, [], warnings),
+      collect<number | null>('kernelErrors', getKernelErrorCount, null, warnings),
+      collect<number | null>('failedLogins', getFailedLoginCount, null, warnings)
+    ]);
+
   // Baseline for anomaly detection must exclude the current reading, so read the
   // hourly history BEFORE recording this tick's sample (recordSample would fold
   // the current value into the bucket the baseline is drawn from).
@@ -584,6 +608,15 @@ export async function getSystemInfo(): Promise<ServerData> {
   const cpuAnomaly = isAnomalous(cpu.usage, cpuBaseline);
 
   recordSample(cpu.usage, loadBase.avg1, now);
+  recordTrend(
+    {
+      mem: memory.percentage,
+      disk: disk.percentage,
+      temp: typeof cpu.temperature === 'number' ? cpu.temperature : null,
+      net: network.download + network.upload
+    },
+    now
+  );
   recordDiskSample(disk.percentage, now);
   const diskHoursToFull = getHoursToFull(now);
 
@@ -640,6 +673,13 @@ export async function getSystemInfo(): Promise<ServerData> {
     processSummary,
     topProcessesByMemory,
     battery,
+    memoryDetail,
+    services,
+    packages,
+    smart,
+    readOnlyMounts,
+    kernelErrors,
+    failedLogins,
     history,
     alerts,
     timestamp: new Date(now).toISOString(),

--- a/src/utils/systemMonitor.ts
+++ b/src/utils/systemMonitor.ts
@@ -608,12 +608,16 @@ export async function getSystemInfo(): Promise<ServerData> {
   const cpuAnomaly = isAnomalous(cpu.usage, cpuBaseline);
 
   recordSample(cpu.usage, loadBase.avg1, now);
+  // A failed collector returns a zero-filled fallback; recording that as a real
+  // hourly observation would depress the trend average. Skip (null) any metric
+  // whose collector reported a failure this tick.
+  const collectorFailed = (name: string) => warnings.some(warning => warning.startsWith(`${name}:`));
   recordTrend(
     {
-      mem: memory.percentage,
-      disk: disk.percentage,
+      mem: collectorFailed('memory') ? null : memory.percentage,
+      disk: collectorFailed('disk') ? null : disk.percentage,
       temp: typeof cpu.temperature === 'number' ? cpu.temperature : null,
-      net: network.download + network.upload
+      net: collectorFailed('network') ? null : network.download + network.upload
     },
     now
   );


### PR DESCRIPTION
## Overview

Milestone **M2** (new collectors + trend history) from the review roadmap, building on M0/M1. All new fields are optional/opt-in, so older cluster nodes and hosts lacking a source keep working (degrade to `N/A`, never fake zeros).

## Changes

### Trend history (P0, #3)
- `history.ts` now keeps per-metric hourly buckets for **memory / disk / temperature / network** alongside load/CPU, reusing the existing bucket/prune/serialize machinery.
- Store bumped to **v2** with a backward-compatible `hydrate` — a v1 `history.json` still loads its load/CPU history, and the trend series just start empty.
- `getHistory()` exposes a 24h `trends` series (`HistoryInfo.trends`); the temperature card renders a compact 24h sparkline (kept ≤2-point-guarded so it adds no height on a fresh start).

### New collectors
Each is a **pure parser + fixture test**, wrapped in `collect()` with a fallback, and exported to `/api/metrics`. The critical ones surface in the dashboard banner.

| Collector | Source | Signal |
| --- | --- | --- |
| Memory breakdown | `/proc/meminfo` | cached / buffers / available / slab / shared / swapCached |
| Read-only mounts | `/proc/mounts` | filesystem flipped to `ro` (silent disk failure) |
| Failed services | `systemctl --failed` | crashed systemd units |
| Kernel errors (24h) | `journalctl -k -p err` | OOM / I/O / hardware faults |
| Failed SSH logins (24h) | sshd journal | brute-force indicator |
| Pending updates | apt-check / `apt-get -s` | total + security subtotal |
| SMART | `smartctl -j` | per-drive health + temperature |

Wired through `systemMonitor` → `ServerData` → `dashboardData` → `/api/metrics`, plus the alert banner (`read-only mount`, `service failed`, `SMART failing`).

## Verification

- `npm run format:check`, `npm run lint`, `npm run typecheck` — clean
- `npm test` — **146 passing** (24 files; +7 new parser test files, +trend-history tests)
- `npm run build` — succeeds

## Deferred to a follow-up

GPU memory/process detail (#29) and RPi throttle detection (the non-history part of #10) — the existing GPU usage/temp and the new temperature trend already cover the common cases.

## Roadmap context

Third of five milestones (M0 #51, M1 #52 merged). Next: M3 (UX), M4 (bare-metal deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T)_