### PR TITLE
M3: dashboard UX + public status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ that aggregates several nodes on one screen.
   nodes) side by side. The browser polls a single same-origin endpoint
   (`/api/cluster`); the server fans out to each node, so node IPs stay
   server-side and nodes no longer need to CORS-allow the dashboard origin.
+- **Public status page** (`/status`) — a sanitised, uptime-style summary safe to
+  share externally: a status word, rounded CPU/memory/disk, uptime, and an
+  active-alert count. It exposes **no** reconnaissance data (no IPs, process
+  names, ports, or alert messages) and stays reachable even when `/api/system`
+  is token-gated.
+- **Kiosk & wall-panel touches** — optional desktop notifications + a beep on a
+  new critical alert (toggle in the corner), a one-click JSON snapshot export,
+  gauge tiles that pulse when a metric is critical, `?rotate=<seconds>` to
+  auto-cycle between the dashboard and cluster views, and a click-through /
+  deep-linkable (`/cluster?node=<name>`) node detail modal on the cluster view.
 - **JSON API** (`/api/system`) — returns the current metrics for the host,
   with a configurable CORS allow-list for cross-node requests.
 - **Kiosk launch script** — boots the dashboard full-screen in Firefox for

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+import { getSystemInfo } from '@/utils/systemMonitor';
+import { enforceRateLimit } from '@/utils/rateLimit';
+
+// A deliberately public, sanitised status endpoint for the /status page — an
+// uptime-style summary safe to share externally. It exposes only coarse health
+// (a status word, rounded CPU/memory/disk, uptime, an active-alert COUNT) and
+// never any reconnaissance data: no IPs, process names, ports, alert messages,
+// firewall or SSH detail. It stays outside the proxy token gate on purpose so a
+// public status page works even when /api/system is locked down.
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const limited = enforceRateLimit(request);
+  if (limited) return limited;
+
+  const data = await getSystemInfo();
+  const activeAlerts = (data.alerts ?? []).filter(
+    alert => alert.level === 'warning' || alert.level === 'critical'
+  ).length;
+
+  return NextResponse.json(
+    {
+      status: activeAlerts > 0 ? 'degraded' : 'operational',
+      activeAlerts,
+      uptime: data.uptime,
+      cpu: Math.round(data.cpu.usage),
+      memory: Math.round(data.memory.percentage),
+      disk: Math.round(data.disk.percentage),
+      load1: data.load?.avg1 ?? null,
+      timestamp: new Date().toISOString()
+    },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -18,19 +18,41 @@ export async function GET(request: Request) {
   if (limited) return limited;
 
   const data = await getSystemInfo();
-  const activeAlerts = (data.alerts ?? []).filter(
-    alert => alert.level === 'warning' || alert.level === 'critical'
-  ).length;
+  const warnings = data.warnings ?? [];
+  const collectorFailed = (name: string) => warnings.some(warning => warning.startsWith(`${name}:`));
+
+  // Derive "active" from CURRENT metric conditions, not the persisted alert log
+  // (which retains earlier warning/critical entries after a rule recovers and
+  // would otherwise pin the page to "degraded" indefinitely).
+  const temperature = data.cpu.temperature;
+  const conditions = [
+    data.cpu.usage > 85,
+    data.memory.percentage > 90,
+    data.disk.percentage > 90,
+    typeof temperature === 'number' && temperature > 74,
+    (data.swap?.total ?? 0) > 0 && (data.swap?.percentage ?? 0) > 80,
+    data.security?.firewall.status === 'inactive',
+    (data.readOnlyMounts?.length ?? 0) > 0,
+    (data.services?.failed ?? 0) > 0,
+    (data.smart ?? []).some(drive => drive.healthy === false)
+  ];
+  const activeAlerts = conditions.filter(Boolean).length;
+
+  // A failed core collector returns a zero-filled fallback; treat that as
+  // unavailable telemetry (report the metric as null and degrade), not a healthy 0.
+  const cpuFailed = collectorFailed('cpu.usage') || collectorFailed('cpu');
+  const memFailed = collectorFailed('memory');
+  const diskFailed = collectorFailed('disk');
+  const coreUnavailable = cpuFailed || memFailed || diskFailed;
 
   return NextResponse.json(
     {
-      status: activeAlerts > 0 ? 'degraded' : 'operational',
+      status: coreUnavailable || activeAlerts > 0 ? 'degraded' : 'operational',
       activeAlerts,
       uptime: data.uptime,
-      cpu: Math.round(data.cpu.usage),
-      memory: Math.round(data.memory.percentage),
-      disk: Math.round(data.disk.percentage),
-      load1: data.load?.avg1 ?? null,
+      cpu: cpuFailed ? null : Math.round(data.cpu.usage),
+      memory: memFailed ? null : Math.round(data.memory.percentage),
+      disk: diskFailed ? null : Math.round(data.disk.percentage),
       timestamp: new Date().toISOString()
     },
     { headers: { 'Cache-Control': 'no-store' } }

--- a/src/app/cluster/page.tsx
+++ b/src/app/cluster/page.tsx
@@ -17,6 +17,7 @@ import {
 
 import { Gauge, Sparkline } from '@/components/dashboard/primitives';
 import { useNow } from '@/hooks/useNow';
+import { useKioskRotate } from '@/hooks/useKioskRotate';
 import { cn } from '@/lib/utils';
 import { NetworkHistoryEntry, ServerData } from '@/types/system';
 import { formatClock, formatRate } from '@/utils/format';
@@ -48,7 +49,32 @@ export default function ClusterPage() {
   // null = before the first response (connecting), [] = the server confirmed there are no nodes.
   const [nodes, setNodes] = useState<ClusterNode[] | null>(null);
   const [networkHistory, setNetworkHistory] = useState<Record<string, NetworkHistoryEntry[]>>({});
+  // Which node's detail modal is open. Initialised lazily from ?node= for
+  // deep-linking (safe against hydration: the modal only renders once nodes have
+  // loaded client-side, so it isn't in the initial SSR HTML).
+  const [selected, setSelected] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    try {
+      return new URLSearchParams(window.location.search).get('node');
+    } catch {
+      return null;
+    }
+  });
   const now = useNow();
+  useKioskRotate('/');
+
+  // Keep the URL in sync so the open node is shareable/bookmarkable.
+  const openNode = useCallback((name: string | null) => {
+    setSelected(name);
+    try {
+      const url = new URL(window.location.href);
+      if (name) url.searchParams.set('node', name);
+      else url.searchParams.delete('node');
+      window.history.replaceState(null, '', url.toString());
+    } catch {
+      /* ignore */
+    }
+  }, []);
 
   const refresh = useCallback(async () => {
     let received: ClusterNode[] = [];
@@ -115,13 +141,113 @@ export default function ClusterPage() {
       ) : (
         <div className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-2 lg:grid-cols-4">
           {(nodes ?? []).map(node => (
-            <ServerCard key={node.name} node={node} history={networkHistory[node.name] ?? []} />
+            <ServerCard
+              key={node.name}
+              node={node}
+              history={networkHistory[node.name] ?? []}
+              onSelect={() => openNode(node.name)}
+            />
           ))}
         </div>
       )}
+
+      {selected &&
+        (() => {
+          const node = (nodes ?? []).find(candidate => candidate.name === selected);
+          return node ? <NodeModal node={node} onClose={() => openNode(null)} /> : null;
+        })()}
     </div>
   );
 }
+
+// --- Node detail modal -----------------------------------------------------
+
+const NodeModal: React.FC<{ node: ClusterNode; onClose: () => void }> = ({ node, onClose }) => {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => event.key === 'Escape' && onClose();
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const rows: [string, string][] = [];
+  if (node.result.ok) {
+    const d = node.result.data;
+    rows.push(['CPU', `${d.cpu.usage.toFixed(1)}% · ${d.cpu.cores} cores`]);
+    rows.push(['Memory', `${d.memory.percentage.toFixed(1)}%`]);
+    rows.push(['Disk', `${d.disk.percentage.toFixed(1)}%`]);
+    rows.push(['Temp', d.cpu.temperature === 'N/A' ? 'N/A' : `${d.cpu.temperature.toFixed(1)}°C`]);
+    if (d.load)
+      rows.push([
+        'Load',
+        `${d.load.avg1.toFixed(2)} / ${d.load.avg5.toFixed(2)} / ${d.load.avg15.toFixed(2)}`
+      ]);
+    if (d.swap) rows.push(['Swap', `${d.swap.percentage.toFixed(1)}%`]);
+    rows.push(['Uptime', formatUptime(d.uptime)]);
+    rows.push(['Ping', `${d.network.ping.toFixed(0)} ms`]);
+    if (d.host) rows.push(['OS', `${d.host.os} · ${d.host.kernel}`]);
+  }
+
+  const topProcesses = node.result.ok
+    ? node.result.data.processes.filter(p => p.cpu > 0 || p.memory > 0).slice(0, 8)
+    : [];
+
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="max-h-[85vh] w-full max-w-lg overflow-auto rounded-lg border border-gray-700 bg-gray-900 p-4"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="t-value font-bold text-gray-100">
+            {node.name} <span className="t-micro font-normal text-gray-500">{node.host}</span>
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded px-2 text-gray-400 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+
+        {!node.result.ok ? (
+          <p className="t-body text-red-400">{node.result.error}</p>
+        ) : (
+          <>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1">
+              {rows.map(([label, value]) => (
+                <div key={label} className="flex justify-between gap-2 border-b border-gray-800 py-1">
+                  <dt className="t-micro text-gray-400">{label}</dt>
+                  <dd className="t-micro truncate font-mono text-gray-200">{value}</dd>
+                </div>
+              ))}
+            </dl>
+            {topProcesses.length > 0 && (
+              <div className="mt-3">
+                <div className="t-micro mb-1 text-gray-400">Top processes</div>
+                <ul className="space-y-0.5">
+                  {topProcesses.map((process, index) => (
+                    <li key={index} className="t-micro flex justify-between gap-2 font-mono text-gray-300">
+                      <span className="truncate">{shortProcessName(process.name)}</span>
+                      <span className="shrink-0 text-gray-500">
+                        {process.cpu.toFixed(0)}% · {process.memory.toFixed(0)}%
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
 
 // --- Top chrome / header ---------------------------------------------------
 
@@ -199,16 +325,17 @@ const EmptyCluster: React.FC = () => (
 interface ServerCardProps {
   node: ClusterNode;
   history: NetworkHistoryEntry[];
+  onSelect: () => void;
 }
 
-const ServerCard: React.FC<ServerCardProps> = ({ node, history }) => {
+const ServerCard: React.FC<ServerCardProps> = ({ node, history, onSelect }) => {
   const { result } = node;
 
   // On a connection failure, show the reason. Like the main dashboard keeping
   // its last value, the frame is always drawn here too.
   if (!result.ok) {
     return (
-      <ServerShell name={node.name} host={node.host} status="offline">
+      <ServerShell name={node.name} host={node.host} status="offline" onSelect={onSelect}>
         <p className="t-body text-red-400">{result.error}</p>
       </ServerShell>
     );
@@ -224,7 +351,7 @@ const ServerCard: React.FC<ServerCardProps> = ({ node, history }) => {
   const topProcess = result.data.processes.find(process => process.cpu > 0 || process.memory > 0);
 
   return (
-    <ServerShell name={node.name} host={node.host} status="online">
+    <ServerShell name={node.name} host={node.host} status="online" onSelect={onSelect}>
       <div className="grid grid-cols-3 gap-2">
         <MiniGauge
           icon={Cpu}
@@ -299,8 +426,16 @@ const ServerShell: React.FC<{
   host: string;
   status: ServerStatus;
   children: React.ReactNode;
-}> = ({ name, host, status, children }) => (
-  <section className="dash-card flex flex-col rounded-lg border border-gray-700 bg-gray-800">
+  onSelect?: () => void;
+}> = ({ name, host, status, children, onSelect }) => (
+  <section
+    className={cn(
+      'dash-card flex flex-col rounded-lg border border-gray-700 bg-gray-800',
+      onSelect && 'cursor-pointer transition-colors hover:border-gray-500'
+    )}
+    onClick={onSelect}
+    title={onSelect ? 'Open node detail' : undefined}
+  >
     <div className="dash-card-head flex items-center justify-between gap-2">
       <div className="flex min-w-0 items-center gap-1.5">
         <Server className="dash-icon shrink-0" color={STATUS_COLOR[status]} strokeWidth={2} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,11 @@
 import React, { useEffect } from 'react';
 
 import { Dashboard } from '@/components/dashboard/Dashboard';
+import { DashboardControls } from '@/components/dashboard/DashboardControls';
 import { useNow } from '@/hooks/useNow';
 import { useSystemData } from '@/hooks/useSystemData';
+import { useAlertNotifications } from '@/hooks/useAlertNotifications';
+import { useKioskRotate } from '@/hooks/useKioskRotate';
 import type { DashboardData } from '@/utils/dashboardData';
 
 // So an alert is visible from the tab alone: when there's a current problem,
@@ -31,6 +34,9 @@ function hasActiveAlert(data: DashboardData): boolean {
 export default function DisplayPage() {
   const { data, error, connected, lastUpdate, networkHistory, diskIoHistory, authRequired } = useSystemData();
   const now = useNow();
+  const notify = useAlertNotifications(data?.alerts ?? []);
+  // Kiosk rotation: with ?rotate=<seconds> the panel cycles to /cluster and back.
+  useKioskRotate('/cluster');
 
   const alerting = data !== null && hasActiveAlert(data);
 
@@ -76,14 +82,17 @@ export default function DisplayPage() {
   }
 
   return (
-    <Dashboard
-      data={data}
-      connected={connected}
-      lastUpdate={lastUpdate}
-      now={now}
-      networkHistory={networkHistory}
-      diskIoHistory={diskIoHistory}
-    />
+    <>
+      <Dashboard
+        data={data}
+        connected={connected}
+        lastUpdate={lastUpdate}
+        now={now}
+        networkHistory={networkHistory}
+        diskIoHistory={diskIoHistory}
+      />
+      <DashboardControls notifyEnabled={notify.enabled} onToggleNotify={notify.toggle} />
+    </>
   );
 }
 

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 // Public status page (#64). Renders the sanitised /api/status summary — an
 // uptime-style page safe to share externally. No reconnaissance data ever
@@ -10,46 +10,80 @@ interface Status {
   status: 'operational' | 'degraded';
   activeAlerts: number;
   uptime: { days: number; hours: number; minutes: number };
-  cpu: number;
-  memory: number;
-  disk: number;
-  load1: number | null;
+  cpu: number | null;
+  memory: number | null;
+  disk: number | null;
   timestamp: string;
 }
 
+type Phase = 'loading' | 'ok' | 'error';
+
 export default function StatusPage() {
   const [status, setStatus] = useState<Status | null>(null);
-  const [error, setError] = useState(false);
+  const [phase, setPhase] = useState<Phase>('loading');
+  const everSucceeded = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
-    const load = () =>
-      fetch('/api/status', { cache: 'no-store' })
-        .then(response => (response.ok ? response.json() : Promise.reject()))
-        .then(data => !cancelled && setStatus(data))
-        .catch(() => !cancelled && setError(true));
-    load();
-    const timer = setInterval(load, 5000);
+    let timer: ReturnType<typeof setTimeout>;
+
+    // Recursive poll: the next request is scheduled only after the current one
+    // settles, so a slow cold-start collection can't pile up overlapping fetches
+    // or let an out-of-order response overwrite a newer one.
+    const poll = async () => {
+      try {
+        const response = await fetch('/api/status', { cache: 'no-store' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = (await response.json()) as Status;
+        if (cancelled) return;
+        everSucceeded.current = true;
+        setStatus(data);
+        setPhase('ok'); // clear any earlier transient error once we recover
+      } catch {
+        // Keep showing the last good value on a transient failure; only surface
+        // an error state if we've never had a successful response.
+        if (!cancelled && !everSucceeded.current) setPhase('error');
+      } finally {
+        if (!cancelled) timer = setTimeout(poll, 5000);
+      }
+    };
+    poll();
+
     return () => {
       cancelled = true;
-      clearInterval(timer);
+      clearTimeout(timer);
     };
   }, []);
 
-  const ok = status?.status === 'operational';
+  const dotColor =
+    phase === 'error'
+      ? '#6b7280'
+      : phase === 'loading'
+        ? '#60a5fa'
+        : status?.status === 'operational'
+          ? '#34d399'
+          : '#f59e0b';
+  const heading =
+    phase === 'error'
+      ? 'Status unavailable'
+      : phase === 'loading'
+        ? 'Checking status…'
+        : status?.status === 'operational'
+          ? 'All systems operational'
+          : 'Degraded performance';
+
+  const fmt = (value: number | null) => (value === null ? '—' : `${value}%`);
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gray-900 p-6 text-gray-100">
       <div className="flex flex-col items-center gap-3">
         <div
-          className="h-4 w-4 rounded-full"
-          style={{ backgroundColor: error ? '#6b7280' : ok ? '#34d399' : '#f59e0b' }}
+          className={phase === 'loading' ? 'h-4 w-4 animate-pulse rounded-full' : 'h-4 w-4 rounded-full'}
+          style={{ backgroundColor: dotColor }}
           aria-hidden
         />
-        <h1 className="text-xl font-semibold">
-          {error ? 'Status unavailable' : ok ? 'All systems operational' : 'Degraded performance'}
-        </h1>
-        {status && !error && (
+        <h1 className="text-xl font-semibold">{heading}</h1>
+        {status && phase === 'ok' && (
           <p className="text-xs text-gray-400">
             up {status.uptime.days}d {status.uptime.hours}h {status.uptime.minutes}m
             {status.activeAlerts > 0 && ` · ${status.activeAlerts} active alert(s)`}
@@ -57,11 +91,11 @@ export default function StatusPage() {
         )}
       </div>
 
-      {status && !error && (
+      {status && phase === 'ok' && (
         <div className="grid w-full max-w-md grid-cols-3 gap-3">
-          <Metric label="CPU" value={`${status.cpu}%`} />
-          <Metric label="Memory" value={`${status.memory}%`} />
-          <Metric label="Disk" value={`${status.disk}%`} />
+          <Metric label="CPU" value={fmt(status.cpu)} />
+          <Metric label="Memory" value={fmt(status.memory)} />
+          <Metric label="Disk" value={fmt(status.disk)} />
         </div>
       )}
     </div>

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+// Public status page (#64). Renders the sanitised /api/status summary — an
+// uptime-style page safe to share externally. No reconnaissance data ever
+// reaches here; see src/app/api/status/route.ts.
+
+interface Status {
+  status: 'operational' | 'degraded';
+  activeAlerts: number;
+  uptime: { days: number; hours: number; minutes: number };
+  cpu: number;
+  memory: number;
+  disk: number;
+  load1: number | null;
+  timestamp: string;
+}
+
+export default function StatusPage() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetch('/api/status', { cache: 'no-store' })
+        .then(response => (response.ok ? response.json() : Promise.reject()))
+        .then(data => !cancelled && setStatus(data))
+        .catch(() => !cancelled && setError(true));
+    load();
+    const timer = setInterval(load, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const ok = status?.status === 'operational';
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gray-900 p-6 text-gray-100">
+      <div className="flex flex-col items-center gap-3">
+        <div
+          className="h-4 w-4 rounded-full"
+          style={{ backgroundColor: error ? '#6b7280' : ok ? '#34d399' : '#f59e0b' }}
+          aria-hidden
+        />
+        <h1 className="text-xl font-semibold">
+          {error ? 'Status unavailable' : ok ? 'All systems operational' : 'Degraded performance'}
+        </h1>
+        {status && !error && (
+          <p className="text-xs text-gray-400">
+            up {status.uptime.days}d {status.uptime.hours}h {status.uptime.minutes}m
+            {status.activeAlerts > 0 && ` · ${status.activeAlerts} active alert(s)`}
+          </p>
+        )}
+      </div>
+
+      {status && !error && (
+        <div className="grid w-full max-w-md grid-cols-3 gap-3">
+          <Metric label="CPU" value={`${status.cpu}%`} />
+          <Metric label="Memory" value={`${status.memory}%`} />
+          <Metric label="Disk" value={`${status.disk}%`} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+const Metric: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="rounded-lg border border-gray-800 bg-gray-950/50 p-3 text-center">
+    <div className="text-lg font-bold">{value}</div>
+    <div className="text-[11px] text-gray-500">{label}</div>
+  </div>
+);

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -308,9 +308,17 @@ const GaugeCard: React.FC<GaugeTileProps> = ({
   detail
 }) => {
   const color = percentage === null ? COLORS.muted : statusColor(percentage);
+  // Emphasise a gauge in the critical band with a pulsing ring. `ring` is a
+  // box-shadow, so it adds no size — the fixed/kiosk layout is unaffected.
+  const alerting = percentage !== null && color === COLORS.critical;
 
   return (
-    <section className="gauge-card dash-card flex min-w-0 flex-col items-center rounded-lg border border-gray-700 bg-gray-800">
+    <section
+      className={cn(
+        'gauge-card dash-card flex min-w-0 flex-col items-center rounded-lg border border-gray-700 bg-gray-800',
+        alerting && 'animate-[alertBlink_1.2s_ease-in-out_infinite] ring-2 ring-red-500/50'
+      )}
+    >
       <div className="flex w-full items-center gap-1">
         <Icon className="dash-icon shrink-0" color={iconColor} strokeWidth={2} />
         <span className="t-micro truncate text-gray-300">{label}</span>

--- a/src/components/dashboard/DashboardControls.tsx
+++ b/src/components/dashboard/DashboardControls.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Bell, BellOff, Camera } from 'lucide-react';
+
+// A small, unobtrusive control cluster pinned to the corner of the dashboard:
+// toggle alert notifications/sound, and export the current snapshot as JSON.
+// Kept out of the fixed card grid so it never affects the kiosk layout budget.
+
+export const DashboardControls: React.FC<{ notifyEnabled: boolean; onToggleNotify: () => void }> = ({
+  notifyEnabled,
+  onToggleNotify
+}) => {
+  const [saving, setSaving] = useState(false);
+
+  const exportSnapshot = async () => {
+    setSaving(true);
+    try {
+      const response = await fetch('/api/system', { cache: 'no-store' });
+      if (!response.ok) return;
+      const data = await response.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `server-snapshot-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      /* ignore — export is best-effort */
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed right-2 bottom-2 z-20 flex gap-1 opacity-40 transition-opacity hover:opacity-100">
+      <button
+        onClick={onToggleNotify}
+        title={notifyEnabled ? 'Alert notifications on' : 'Alert notifications off'}
+        aria-label="Toggle alert notifications"
+        className="rounded border border-gray-700 bg-gray-800/90 p-1.5 text-gray-300 hover:text-white"
+      >
+        {notifyEnabled ? <Bell size={14} /> : <BellOff size={14} />}
+      </button>
+      <button
+        onClick={exportSnapshot}
+        disabled={saving}
+        title="Export current snapshot as JSON"
+        aria-label="Export snapshot"
+        className="rounded border border-gray-700 bg-gray-800/90 p-1.5 text-gray-300 hover:text-white disabled:opacity-50"
+      >
+        <Camera size={14} />
+      </button>
+    </div>
+  );
+};

--- a/src/hooks/useAlertNotifications.ts
+++ b/src/hooks/useAlertNotifications.ts
@@ -57,8 +57,15 @@ export function useAlertNotifications(alerts: AlertEntry[]): AlertNotifications 
   }, [alerts]);
 
   useEffect(() => {
-    if (!enabled || alerts.length === 0) return;
+    if (alerts.length === 0) return;
     const newest = alerts[0];
+    // While disabled, keep the marker current so that turning notifications on
+    // later doesn't replay alerts that arrived meanwhile (opt-in should be silent
+    // until the next genuinely new alert).
+    if (!enabled) {
+      seenId.current = newest.id;
+      return;
+    }
     if (newest.id === seenId.current) return;
 
     // Fire for any new critical alert that arrived since we last looked.

--- a/src/hooks/useAlertNotifications.ts
+++ b/src/hooks/useAlertNotifications.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { AlertEntry } from '@/types/system';
+
+// Desktop notification + audible beep when a NEW critical alert appears, so an
+// unattended wall panel can still get someone's attention. Opt-in: nothing fires
+// until the viewer enables it (which also requests Notification permission). The
+// enabled flag is remembered per-browser in localStorage.
+
+const STORAGE_KEY = 'sm-alert-notify';
+
+function beep() {
+  try {
+    const Ctx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    const ctx = new Ctx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.value = 880;
+    gain.gain.value = 0.05;
+    osc.connect(gain).connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.25);
+    osc.onended = () => ctx.close();
+  } catch {
+    // WebAudio unavailable — silently skip the sound.
+  }
+}
+
+export interface AlertNotifications {
+  enabled: boolean;
+  toggle: () => void;
+}
+
+export function useAlertNotifications(alerts: AlertEntry[]): AlertNotifications {
+  // Restore the saved preference lazily. Safe against hydration: this only drives
+  // the corner toggle icon, which isn't in the initial SSR HTML (the page shows
+  // the startup state until data loads).
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return localStorage.getItem(STORAGE_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+  const seenId = useRef<string | null>(null);
+
+  // Seed the "last seen" marker to the newest alert so enabling doesn't replay
+  // history; only alerts newer than this fire.
+  useEffect(() => {
+    if (seenId.current === null && alerts.length > 0) seenId.current = alerts[0].id;
+  }, [alerts]);
+
+  useEffect(() => {
+    if (!enabled || alerts.length === 0) return;
+    const newest = alerts[0];
+    if (newest.id === seenId.current) return;
+
+    // Fire for any new critical alert that arrived since we last looked.
+    const previousMarker = seenId.current;
+    seenId.current = newest.id;
+    const fresh: AlertEntry[] = [];
+    for (const alert of alerts) {
+      if (alert.id === previousMarker) break;
+      fresh.push(alert);
+    }
+    const critical = fresh.find(alert => alert.level === 'critical');
+    if (!critical) return;
+
+    beep();
+    try {
+      if ('Notification' in window && Notification.permission === 'granted') {
+        new Notification('Server Monitor', { body: critical.message });
+      }
+    } catch {
+      /* notifications unavailable */
+    }
+  }, [enabled, alerts]);
+
+  const toggle = () => {
+    const next = !enabled;
+    setEnabled(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+    if (next && 'Notification' in window && Notification.permission === 'default') {
+      void Notification.requestPermission();
+    }
+  };
+
+  return { enabled, toggle };
+}

--- a/src/hooks/useKioskRotate.ts
+++ b/src/hooks/useKioskRotate.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Kiosk auto-rotation: with `?rotate=<seconds>` in the URL, a wall panel cycles
+// between the dashboard and the cluster view (and back) on that interval,
+// carrying the rotate param along so it keeps going. No param = no rotation, so
+// a normal browser session is unaffected.
+export function useKioskRotate(nextPath: string): void {
+  useEffect(() => {
+    let seconds = 0;
+    try {
+      seconds = Number(new URLSearchParams(window.location.search).get('rotate')) || 0;
+    } catch {
+      seconds = 0;
+    }
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+
+    const timer = setTimeout(
+      () => {
+        const target = new URL(nextPath, window.location.origin);
+        target.searchParams.set('rotate', String(seconds));
+        window.location.href = target.toString();
+      },
+      Math.max(3, seconds) * 1000
+    );
+    return () => clearTimeout(timer);
+  }, [nextPath]);
+}


### PR DESCRIPTION
## Overview

Milestone **M3** (frontend/UX) from the review roadmap. Every addition respects the fixed/kiosk card layout — the new controls live **outside** the card grid and emphasis uses box-shadow rings, so no card changes size.

## Changes

- **Alert notifications + sound (#35)** — opt-in desktop `Notification` and a WebAudio beep on a *new* critical alert; a small corner toggle, remembered per-browser (`useAlertNotifications`).
- **Snapshot export (#38)** — one-click JSON download of the current `/api/system` state.
- **Kiosk auto-rotate (#36)** — `?rotate=<seconds>` cycles a wall panel between the dashboard and cluster views (`useKioskRotate`).
- **Threshold visual emphasis (#13)** — gauge tiles pulse with a red ring in the critical band (box-shadow only, no layout shift).
- **Cluster node detail modal (#15) + deep-link (#65)** — click a node card for a fuller detail modal; `/cluster?node=<name>` opens it directly and the URL stays in sync (shareable/bookmarkable).
- **Public status page (#64)** — new sanitised **`/status`** page + **`/api/status`** endpoint: a status word, rounded CPU/memory/disk, uptime, and an active-alert **count**. It exposes **no** reconnaissance data (no IPs, process names, ports, or alert messages) and stays reachable even when `/api/system` is token-gated.

## Verification

- `npm run format:check`, `npm run lint`, `npm run typecheck` — clean
- `npm test` — **148 passing**
- `npm run build` — succeeds; `/status`, `/api/status` routes present

## Deferred to a follow-up

- **Mobile summary view (#14)** — the layout already folds to a single column on phones; a curated "essentials-only" mode is a separate, self-contained change.
- **Live log tail (#63)** — a `journalctl -f`-over-SSE viewer is security-sensitive (streams raw logs) and deserves its own PR with careful auth/redaction, rather than riding along here.

## Roadmap context

Fourth of five milestones (M0 #51, M1 #52, M2 #53 merged). Next: M4 (bare-metal deploy), then the two deferred UX items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T)_