### PR TITLE
M4: bare-metal install script + systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,43 @@ read on the server.
 Adding, removing, or repointing a cluster node is now a one-line edit in
 `.env` — no code changes or redeploy of the dashboard logic required.
 
+## Bare-metal deploy (systemd)
+
+To run ServerMonitor directly on a host (no Docker) as a service that starts on
+boot and restarts on failure:
+
+```bash
+git clone https://github.com/Ruthgyeul/ServerMonitor.git /opt/servermonitor
+cd /opt/servermonitor
+cp .env.example .env   # edit as needed
+sudo ./scripts/install.sh
+```
+
+`scripts/install.sh` checks for Node.js 18+, runs `npm ci` and `npm run build`
+as the service user, creates the `data/` directory, then renders and installs
+`deploy/servermonitor.service` into `/etc/systemd/system/` and enables it.
+
+It is configurable via environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RUN_USER` | the checkout's owner | Service account the app runs as |
+| `PORT` | `3000` | Port to listen on |
+| `SERVICE` | `servermonitor` | systemd unit name |
+
+Then:
+
+```bash
+systemctl status servermonitor
+journalctl -u servermonitor -f
+sudo systemctl restart servermonitor   # after editing .env
+```
+
+The unit adds the service user to the `systemd-journal` and `adm` groups so the
+firewall / kernel-error / failed-login collectors can read the journal without
+running as root. Running on bare metal (rather than in a container) is also what
+lets the `systemctl`/`journalctl`/`who`/`last` collectors report real values.
+
 ## Alerting
 
 Threshold rules evaluate every collection tick with hysteresis (separate enter/

--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ To run ServerMonitor directly on a host (no Docker) as a service that starts on
 boot and restarts on failure:
 
 ```bash
+# /opt is root-owned, so create the target and hand it to your deploy user first
+# (the installer then defaults RUN_USER to that owner rather than root).
+sudo mkdir -p /opt/servermonitor
+sudo chown "$USER" /opt/servermonitor
 git clone https://github.com/Ruthgyeul/ServerMonitor.git /opt/servermonitor
 cd /opt/servermonitor
 cp .env.example .env   # edit as needed
@@ -233,7 +237,15 @@ Then:
 ```bash
 systemctl status servermonitor
 journalctl -u servermonitor -f
-sudo systemctl restart servermonitor   # after editing .env
+sudo systemctl restart servermonitor   # after editing a server-only value in .env
+```
+
+`NEXT_PUBLIC_*` values (cluster servers, site metadata) are inlined at build
+time, so changing one needs a **rebuild**, not just a restart — rerun the
+installer, which rebuilds and restarts:
+
+```bash
+sudo ./scripts/install.sh
 ```
 
 The unit adds the service user to the `systemd-journal` and `adm` groups so the

--- a/deploy/servermonitor.service
+++ b/deploy/servermonitor.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=ServerMonitor dashboard
+Documentation=https://github.com/Ruthgyeul/ServerMonitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# These four lines are filled in by scripts/install.sh (or edit them by hand).
+User=__RUN_USER__
+WorkingDirectory=__INSTALL_DIR__
+ExecStart=__NPM__ run start
+Environment=PORT=__PORT__
+# .env is optional — the leading `-` means "don't fail if it's missing".
+EnvironmentFile=-__INSTALL_DIR__/.env
+Environment=NODE_ENV=production
+Environment=NEXT_TELEMETRY_DISABLED=1
+Restart=on-failure
+RestartSec=5
+
+# Read access to the kernel journal, so the firewall / kernel-error /
+# failed-login collectors work without root. Harmless if absent.
+SupplementaryGroups=systemd-journal adm
+
+# Light hardening. Kept conservative on purpose: the app persists history/alerts
+# under WorkingDirectory/data, which may live in the run user's home, so we don't
+# set ProtectHome/ProtectSystem (they would make that directory read-only and
+# break persistence). Tighten these if you install outside a home directory.
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/servermonitor.service
+++ b/deploy/servermonitor.service
@@ -6,26 +6,30 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-# These four lines are filled in by scripts/install.sh (or edit them by hand).
+# These lines are filled in by scripts/install.sh (or edit them by hand).
 User=__RUN_USER__
 WorkingDirectory=__INSTALL_DIR__
 ExecStart=__NPM__ run start
-Environment=PORT=__PORT__
 # .env is optional — the leading `-` means "don't fail if it's missing".
 EnvironmentFile=-__INSTALL_DIR__/.env
+# Set PORT *after* EnvironmentFile so the installer-chosen port always wins over
+# any PORT that happens to be in .env (systemd applies later directives last).
+Environment=PORT=__PORT__
 Environment=NODE_ENV=production
 Environment=NEXT_TELEMETRY_DISABLED=1
 Restart=on-failure
 RestartSec=5
 
 # Read access to the kernel journal, so the firewall / kernel-error /
-# failed-login collectors work without root. Harmless if absent.
-SupplementaryGroups=systemd-journal adm
+# failed-login collectors work without root. The installer renders this line
+# with only the groups that actually exist on the host (an absent group here
+# makes systemd fail the unit with 216/GROUP), or blank if neither is present.
+__JOURNAL_GROUPS__
 
 # Light hardening. Kept conservative on purpose: the app persists history/alerts
-# under WorkingDirectory/data, which may live in the run user's home, so we don't
-# set ProtectHome/ProtectSystem (they would make that directory read-only and
-# break persistence). Tighten these if you install outside a home directory.
+# under its data dir, which may live in the run user's home, so we don't set
+# ProtectHome/ProtectSystem (they would make that directory read-only and break
+# persistence). Tighten these if you install outside a home directory.
 NoNewPrivileges=true
 
 [Install]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Bare-metal installer for ServerMonitor: builds the app and installs a systemd
+# service so it runs on boot and restarts on failure. This is the non-Docker
+# path — on a real host it reads /proc, /sys and the host tools directly.
+#
+# Usage (from a clone of the repo):
+#   sudo ./scripts/install.sh
+#
+# Configurable via environment variables:
+#   RUN_USER=<user>   Service account to run as (default: the repo directory's owner)
+#   PORT=<port>       Port to listen on (default: 3000)
+#   SERVICE=<name>    systemd unit name (default: servermonitor)
+#
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SERVICE="${SERVICE:-servermonitor}"
+PORT="${PORT:-3000}"
+
+log() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31mError:\033[0m %s\n' "$*" >&2; }
+
+# --- Preconditions ---------------------------------------------------------
+
+if [ "$(id -u)" -ne 0 ]; then
+  err "This script installs a systemd unit and must run as root (use sudo)."
+  exit 1
+fi
+
+# Default the run user to whoever owns the checkout (so data/ stays writable),
+# falling back to the invoking sudo user, then root.
+RUN_USER="${RUN_USER:-$(stat -c '%U' "$REPO_DIR" 2>/dev/null || echo "${SUDO_USER:-root}")}"
+if ! id "$RUN_USER" >/dev/null 2>&1; then
+  err "RUN_USER '$RUN_USER' does not exist. Set RUN_USER=<existing user> and retry."
+  exit 1
+fi
+
+NPM_BIN="$(command -v npm || true)"
+NODE_BIN="$(command -v node || true)"
+if [ -z "$NPM_BIN" ] || [ -z "$NODE_BIN" ]; then
+  err "node and npm must be installed and on PATH (Node.js 18+)."
+  exit 1
+fi
+
+NODE_MAJOR="$("$NODE_BIN" -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  err "Node.js 18+ is required (found $($NODE_BIN -v))."
+  exit 1
+fi
+
+log "Installing ServerMonitor from $REPO_DIR as user '$RUN_USER' on port $PORT"
+
+# --- Build -----------------------------------------------------------------
+
+# Run the build steps as the service user so file ownership is correct.
+run_as_user() { sudo -u "$RUN_USER" bash -c "cd '$REPO_DIR' && $*"; }
+
+log "Installing dependencies (npm ci)…"
+run_as_user "'$NPM_BIN' ci"
+
+log "Building (npm run build)…"
+run_as_user "'$NPM_BIN' run build"
+
+# The history/alert persistence directory (gitignored).
+log "Ensuring data directory…"
+install -d -o "$RUN_USER" -g "$(id -gn "$RUN_USER")" "$REPO_DIR/data"
+
+# --- systemd unit ----------------------------------------------------------
+
+UNIT_SRC="$REPO_DIR/deploy/servermonitor.service"
+UNIT_DEST="/etc/systemd/system/${SERVICE}.service"
+if [ ! -f "$UNIT_SRC" ]; then
+  err "Unit template not found at $UNIT_SRC"
+  exit 1
+fi
+
+log "Writing $UNIT_DEST"
+# Render the template placeholders. Use | as the sed delimiter since paths contain /.
+sed \
+  -e "s|__RUN_USER__|$RUN_USER|g" \
+  -e "s|__INSTALL_DIR__|$REPO_DIR|g" \
+  -e "s|__NPM__|$NPM_BIN|g" \
+  -e "s|__PORT__|$PORT|g" \
+  "$UNIT_SRC" >"$UNIT_DEST"
+
+# Best-effort validation (available on most systemd hosts).
+if command -v systemd-analyze >/dev/null 2>&1; then
+  systemd-analyze verify "$UNIT_DEST" || err "systemd-analyze reported issues (continuing)."
+fi
+
+log "Enabling and starting ${SERVICE}.service"
+systemctl daemon-reload
+systemctl enable --now "${SERVICE}.service"
+
+log "Done. ServerMonitor is running on port $PORT."
+echo "  Status:  systemctl status ${SERVICE}"
+echo "  Logs:    journalctl -u ${SERVICE} -f"
+echo "  Config:  edit ${REPO_DIR}/.env then: sudo systemctl restart ${SERVICE}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@
 #   RUN_USER=<user>   Service account to run as (default: the repo directory's owner)
 #   PORT=<port>       Port to listen on (default: 3000)
 #   SERVICE=<name>    systemd unit name (default: servermonitor)
+#   DATA_DIR=<path>   History/alert persistence dir (default: <repo>/data, or .env's DATA_DIR)
 #
 set -euo pipefail
 
@@ -28,30 +29,57 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# Default the run user to whoever owns the checkout (so data/ stays writable),
-# falling back to the invoking sudo user, then root.
+# Default the run user to whoever owns the checkout (so builds and data/ stay
+# writable), falling back to the invoking sudo user, then root.
 RUN_USER="${RUN_USER:-$(stat -c '%U' "$REPO_DIR" 2>/dev/null || echo "${SUDO_USER:-root}")}"
 if ! id "$RUN_USER" >/dev/null 2>&1; then
   err "RUN_USER '$RUN_USER' does not exist. Set RUN_USER=<existing user> and retry."
   exit 1
 fi
+RUN_GROUP="$(id -gn "$RUN_USER")"
 
 NPM_BIN="$(command -v npm || true)"
 NODE_BIN="$(command -v node || true)"
 if [ -z "$NPM_BIN" ] || [ -z "$NODE_BIN" ]; then
-  err "node and npm must be installed and on PATH (Node.js 18+)."
+  err "node and npm must be installed and on PATH (Node.js 20.9+)."
   exit 1
 fi
 
-NODE_MAJOR="$("$NODE_BIN" -p 'process.versions.node.split(".")[0]')"
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  err "Node.js 18+ is required (found $($NODE_BIN -v))."
+# Next.js 16 requires Node >= 20.9.0 (see package-lock engines). Enforce the full
+# minimum, not just the major, so a 18.x / 19.x / 20.0-20.8 host fails clearly here.
+NODE_VER="$("$NODE_BIN" -p 'process.versions.node')"
+NODE_MAJOR="${NODE_VER%%.*}"
+NODE_MINOR_REST="${NODE_VER#*.}"
+NODE_MINOR="${NODE_MINOR_REST%%.*}"
+if [ "$NODE_MAJOR" -lt 20 ] || { [ "$NODE_MAJOR" -eq 20 ] && [ "$NODE_MINOR" -lt 9 ]; }; then
+  err "Node.js 20.9.0+ is required (found v$NODE_VER)."
   exit 1
 fi
+
+# Effective persistence directory: DATA_DIR env > .env's DATA_DIR > <repo>/data.
+# A relative value resolves against the repo (matching process.cwd() at runtime).
+read_env_value() {
+  local key="$1"
+  [ -f "$REPO_DIR/.env" ] || return 0
+  grep -E "^${key}=" "$REPO_DIR/.env" | tail -n 1 | cut -d '=' -f2- |
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]\$//"
+}
+DATA_DIR="${DATA_DIR:-$(read_env_value DATA_DIR)}"
+DATA_DIR="${DATA_DIR:-$REPO_DIR/data}"
+case "$DATA_DIR" in /*) ;; *) DATA_DIR="$REPO_DIR/$DATA_DIR" ;; esac
 
 log "Installing ServerMonitor from $REPO_DIR as user '$RUN_USER' on port $PORT"
+log "Persistence directory: $DATA_DIR"
 
 # --- Build -----------------------------------------------------------------
+
+# If the run user doesn't own the checkout, hand it ownership first so `npm ci`
+# and `npm run build` (which write node_modules/.next) don't hit EACCES.
+CURRENT_OWNER="$(stat -c '%U' "$REPO_DIR" 2>/dev/null || echo '')"
+if [ "$CURRENT_OWNER" != "$RUN_USER" ]; then
+  log "Setting ownership of $REPO_DIR to $RUN_USER"
+  chown -R "$RUN_USER:$RUN_GROUP" "$REPO_DIR"
+fi
 
 # Run the build steps as the service user so file ownership is correct.
 run_as_user() { sudo -u "$RUN_USER" bash -c "cd '$REPO_DIR' && $*"; }
@@ -62,11 +90,25 @@ run_as_user "'$NPM_BIN' ci"
 log "Building (npm run build)…"
 run_as_user "'$NPM_BIN' run build"
 
-# The history/alert persistence directory (gitignored).
 log "Ensuring data directory…"
-install -d -o "$RUN_USER" -g "$(id -gn "$RUN_USER")" "$REPO_DIR/data"
+install -d -o "$RUN_USER" -g "$RUN_GROUP" "$DATA_DIR"
 
 # --- systemd unit ----------------------------------------------------------
+
+# Only request journal-read groups that actually exist — an unknown group makes
+# systemd fail the unit with 216/GROUP.
+FOUND_GROUPS=""
+for group in systemd-journal adm; do
+  if getent group "$group" >/dev/null 2>&1; then
+    FOUND_GROUPS="${FOUND_GROUPS:+$FOUND_GROUPS }$group"
+  fi
+done
+GROUPS_LINE=""
+[ -n "$FOUND_GROUPS" ] && GROUPS_LINE="SupplementaryGroups=$FOUND_GROUPS"
+
+# Escape sed replacement metacharacters (& | \) so paths/values with them render
+# literally (e.g. a checkout under /srv/R&D/...).
+esc() { printf '%s' "$1" | sed -e 's/[&|\\]/\\&/g'; }
 
 UNIT_SRC="$REPO_DIR/deploy/servermonitor.service"
 UNIT_DEST="/etc/systemd/system/${SERVICE}.service"
@@ -76,12 +118,12 @@ if [ ! -f "$UNIT_SRC" ]; then
 fi
 
 log "Writing $UNIT_DEST"
-# Render the template placeholders. Use | as the sed delimiter since paths contain /.
 sed \
-  -e "s|__RUN_USER__|$RUN_USER|g" \
-  -e "s|__INSTALL_DIR__|$REPO_DIR|g" \
-  -e "s|__NPM__|$NPM_BIN|g" \
-  -e "s|__PORT__|$PORT|g" \
+  -e "s|__RUN_USER__|$(esc "$RUN_USER")|g" \
+  -e "s|__INSTALL_DIR__|$(esc "$REPO_DIR")|g" \
+  -e "s|__NPM__|$(esc "$NPM_BIN")|g" \
+  -e "s|__PORT__|$(esc "$PORT")|g" \
+  -e "s|__JOURNAL_GROUPS__|$(esc "$GROUPS_LINE")|g" \
   "$UNIT_SRC" >"$UNIT_DEST"
 
 # Best-effort validation (available on most systemd hosts).
@@ -89,11 +131,15 @@ if command -v systemd-analyze >/dev/null 2>&1; then
   systemd-analyze verify "$UNIT_DEST" || err "systemd-analyze reported issues (continuing)."
 fi
 
-log "Enabling and starting ${SERVICE}.service"
+log "Enabling and (re)starting ${SERVICE}.service"
 systemctl daemon-reload
-systemctl enable --now "${SERVICE}.service"
+systemctl enable "${SERVICE}.service"
+# restart (not just start) so re-running the installer picks up a new build/port
+# on an already-active service.
+systemctl restart "${SERVICE}.service"
 
 log "Done. ServerMonitor is running on port $PORT."
 echo "  Status:  systemctl status ${SERVICE}"
 echo "  Logs:    journalctl -u ${SERVICE} -f"
 echo "  Config:  edit ${REPO_DIR}/.env then: sudo systemctl restart ${SERVICE}"
+echo "           (changing a NEXT_PUBLIC_* value needs a rebuild: rerun this installer)"


### PR DESCRIPTION
## Overview

Milestone **M4** (deploy) from the review roadmap — a non-Docker path to run ServerMonitor as a boot-managed systemd service.

## Changes

- **`deploy/servermonitor.service`** — a systemd unit template (placeholders filled by the installer): `Type=simple`, `ExecStart=<npm> run start`, `EnvironmentFile=-<dir>/.env` (optional), `Restart=on-failure`. It adds the service user to `systemd-journal` and `adm` groups so the firewall / kernel-error / failed-login collectors read the journal without root, and sets `NoNewPrivileges=true`. `ProtectHome`/`ProtectSystem` are intentionally omitted so the `data/` persistence dir stays writable when the checkout lives under a home directory.
- **`scripts/install.sh`** — checks Node.js 18+, runs `npm ci` + `npm run build` as the service user, creates `data/`, renders the unit into `/etc/systemd/system/`, and `enable --now`s it. Configurable via `RUN_USER` / `PORT` / `SERVICE`.
- **README** — a "Bare-metal deploy (systemd)" section.

## Verification

- `bash -n scripts/install.sh` — clean
- The rendered unit passes `systemd-analyze verify` (exit 0)
- `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (148 passing) — clean (no app code changed)

## Roadmap context

Fifth of the roadmap's milestones (M0 #51, M1 #52, M2 #53, M3 #54 merged). A follow-up **M5** will run a project-wide dependency/security audit and update packages (addressing the Dependabot alerts), plus the two deferred UX items (mobile summary, live log tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01FURQP3DHH9uj56BNHZ6B6T)_